### PR TITLE
fix: mark spot as unavailable on LowPriorityQuota

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/Azure/azure-kusto-go v0.14.0
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
-	github.com/Azure/azure-sdk-for-go-extensions v0.1.5
+	github.com/Azure/azure-sdk-for-go-extensions v0.1.6
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/Azure/azure-kusto-go v0.14.0 h1:5XVmjh5kVgsm2scpsWisJ6Q1ZgWHJcIOPCZC1
 github.com/Azure/azure-kusto-go v0.14.0/go.mod h1:wSmXIsQwBVPHDNsSQsX98nuc12VyvxoNHQa2q9t1Ce0=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go-extensions v0.1.5 h1:iGNv4we/Mst2hPcaZOynmCJJGNsPyN4YNV1YTzaGCb8=
-github.com/Azure/azure-sdk-for-go-extensions v0.1.5/go.mod h1:27StPiXJp6Xzkq2AQL7gPK7VC0hgmCnUKlco1dO1jaM=
+github.com/Azure/azure-sdk-for-go-extensions v0.1.6 h1:EXGvDcj54u98XfaI/Cy65Ds6vNsIJeGKYf0eNLB1y4Q=
+github.com/Azure/azure-sdk-for-go-extensions v0.1.6/go.mod h1:27StPiXJp6Xzkq2AQL7gPK7VC0hgmCnUKlco1dO1jaM=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.1 h1:lGlwhPtrX6EVml1hO0ivjkUxsSyl4dsiw9qcA1k/3IQ=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.1/go.mod h1:RKUqNu35KJYcVG/fqTRqmuXJZYNhYkBrnC/hX7yGbTA=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.1 h1:LNHhpdK7hzUcx/k1LIcuh5k7k1LGIWLQfCjaneSj7Fc=

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -69,15 +69,6 @@ func (u *UnavailableOfferings) MarkUnavailable(ctx context.Context, unavailableR
 	u.MarkUnavailableWithTTL(ctx, unavailableReason, instanceType, zone, capacityType, UnavailableOfferingsTTL)
 }
 
-func (u *UnavailableOfferings) Put(key string, value struct{}, ttl time.Duration) {
-	u.cache.Set(key, value, ttl)
-}
-
-func (u *UnavailableOfferings) Has(key string) bool {
-	_, found := u.cache.Get(key)
-	return found
-}
-
 func (u *UnavailableOfferings) Flush() {
 	u.cache.Flush()
 }

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -57,7 +57,7 @@ func (u *UnavailableOfferings) IsUnavailable(instanceType, zone, capacityType st
 }
 
 // MarkSpotUnavailable communicates recently observed temporary capacity shortages for spot
-func (u *UnavailableOfferings) MarkSpotUnavailable(ctx context.Context) {
+func (u *UnavailableOfferings) MarkSpotUnavailableWithTTL(ctx context.Context, ttl time.Duration) {
 	u.MarkUnavailableWithTTL(ctx, "SpotUnavailable", "", "", v1beta1.CapacityTypeSpot, UnavailableOfferingsTTL)
 }
 

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -69,6 +69,15 @@ func (u *UnavailableOfferings) MarkUnavailable(ctx context.Context, unavailableR
 	u.MarkUnavailableWithTTL(ctx, unavailableReason, instanceType, zone, capacityType, UnavailableOfferingsTTL)
 }
 
+func (u *UnavailableOfferings) Put(key string, value struct{}, ttl time.Duration) {
+	u.cache.Set(key, value, ttl)
+}
+
+func (u *UnavailableOfferings) Has(key string) bool {
+	_, found := u.cache.Get(key)
+	return found
+}
+
 func (u *UnavailableOfferings) Flush() {
 	u.cache.Flush()
 }

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -26,35 +26,34 @@ import (
 	"knative.dev/pkg/logging"
 )
 
+var (
+	spotKey = key("", "", v1beta1.CapacityTypeSpot)
+)
+
 // UnavailableOfferings stores any offerings that return ICE (insufficient capacity errors) when
 // attempting to launch the capacity. These offerings are ignored as long as they are in the cache on
 // GetInstanceTypes responses
 type UnavailableOfferings struct {
 	// key: <capacityType>:<instanceType>:<zone>, value: struct{}{}
 	cache *cache.Cache
-	// pre-computed key for spot since we will be computing this key many times and it
-	// will always be the same.
-	spotKey string
 }
 
 func NewUnavailableOfferingsWithCache(c *cache.Cache) *UnavailableOfferings {
 	return &UnavailableOfferings{
-		cache:   c,
-		spotKey: key("", "", v1beta1.CapacityTypeSpot),
+		cache: c,
 	}
 }
 
 func NewUnavailableOfferings() *UnavailableOfferings {
 	return &UnavailableOfferings{
-		cache:   cache.New(UnavailableOfferingsTTL, DefaultCleanupInterval),
-		spotKey: key("", "", v1beta1.CapacityTypeSpot),
+		cache: cache.New(UnavailableOfferingsTTL, DefaultCleanupInterval),
 	}
 }
 
 // IsUnavailable returns true if the offering appears in the cache
 func (u *UnavailableOfferings) IsUnavailable(instanceType, zone, capacityType string) bool {
 	if capacityType == v1beta1.CapacityTypeSpot {
-		if _, ok := u.cache.Get(u.spotKey); ok {
+		if _, ok := u.cache.Get(spotKey); ok {
 			return true
 		}
 	}

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -53,7 +53,7 @@ func NewUnavailableOfferings() *UnavailableOfferings {
 // IsUnavailable returns true if the offering appears in the cache
 func (u *UnavailableOfferings) IsUnavailable(instanceType, zone, capacityType string) bool {
 	if capacityType == v1beta1.CapacityTypeSpot {
-		if _, ok := u.cache.Get(spotKey); ok {
+		if _, found := u.cache.Get(spotKey); found {
 			return true
 		}
 	}

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -38,19 +38,17 @@ type UnavailableOfferings struct {
 }
 
 func NewUnavailableOfferingsWithCache(c *cache.Cache) *UnavailableOfferings {
-	u := &UnavailableOfferings{
-		cache: cache.New(UnavailableOfferingsTTL, DefaultCleanupInterval),
+	return &UnavailableOfferings{
+		cache:   c,
+		spotKey: key("", "", v1beta1.CapacityTypeSpot),
 	}
-	u.spotKey = u.key("", "", v1beta1.CapacityTypeSpot)
-	return u
 }
 
 func NewUnavailableOfferings() *UnavailableOfferings {
-	u := &UnavailableOfferings{
-		cache: cache.New(UnavailableOfferingsTTL, DefaultCleanupInterval),
+	return &UnavailableOfferings{
+		cache:   cache.New(UnavailableOfferingsTTL, DefaultCleanupInterval),
+		spotKey: key("", "", v1beta1.CapacityTypeSpot),
 	}
-	u.spotKey = u.key("", "", v1beta1.CapacityTypeSpot)
-	return u
 }
 
 // IsUnavailable returns true if the offering appears in the cache
@@ -60,7 +58,7 @@ func (u *UnavailableOfferings) IsUnavailable(instanceType, zone, capacityType st
 			return true
 		}
 	}
-	_, found := u.cache.Get(u.key(instanceType, zone, capacityType))
+	_, found := u.cache.Get(key(instanceType, zone, capacityType))
 	return found
 }
 
@@ -78,7 +76,7 @@ func (u *UnavailableOfferings) MarkUnavailableWithTTL(ctx context.Context, unava
 		"zone", zone,
 		"capacity-type", capacityType,
 		"ttl", ttl).Debugf("removing offering from offerings")
-	u.cache.Set(u.key(instanceType, zone, capacityType), struct{}{}, ttl)
+	u.cache.Set(key(instanceType, zone, capacityType), struct{}{}, ttl)
 }
 
 // MarkUnavailable communicates recently observed temporary capacity shortages in the provided offerings
@@ -91,6 +89,6 @@ func (u *UnavailableOfferings) Flush() {
 }
 
 // key returns the cache key for all offerings in the cache
-func (u *UnavailableOfferings) key(instanceType string, zone string, capacityType string) string {
+func key(instanceType string, zone string, capacityType string) string {
 	return fmt.Sprintf("%s:%s:%s", capacityType, instanceType, zone)
 }

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -46,8 +46,8 @@ func NewUnavailableOfferingsWithCache(c *cache.Cache) *UnavailableOfferings {
 }
 
 func NewUnavailableOfferings() *UnavailableOfferings {
-	u := &UnavailableOfferings{ 
-		cache: cache.New(UnavailableOfferingsTTL, DefaultCleanupInterval), 
+	u := &UnavailableOfferings{
+		cache: cache.New(UnavailableOfferingsTTL, DefaultCleanupInterval),
 	}
 	u.spotKey = u.key("", "", v1beta1.CapacityTypeSpot)
 	return u

--- a/pkg/cache/unavailableofferings_test.go
+++ b/pkg/cache/unavailableofferings_test.go
@@ -52,12 +52,8 @@ func TestUnavailableOfferings(t *testing.T) {
 }
 
 func TestUnavailableOfferings_KeyGeneration(t *testing.T) {
-	c := cache.New(time.Second, time.Second)
-	u := NewUnavailableOfferingsWithCache(c)
-
-	// test that the key is generated correctly
 	expectedKey := "spot:NV16as_v4:westus"
-	key := u.key("NV16as_v4", "westus", "spot")
+	key := key("NV16as_v4", "westus", "spot")
 	if key != expectedKey {
 		t.Errorf("Expected key to be %s, but got %s", expectedKey, key)
 	}

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -415,7 +415,14 @@ func (p *Provider) launchInstance(
 	return resp, instanceType, nil
 }
 
+// nolint:gocyclo
 func (p *Provider) handleResponseErrors(ctx context.Context, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
+	if sdkerrors.LowPriorityQuotaHasBeenReached(err) {
+		// Mark all SPOT offerings as unavailable for all instance types in all zones
+		// This will also update the TTL for an existing offering in the cache that is already unavailable
+		p.unavailableOfferings.Put(sdkerrors.LowPriorityQuotaExceededTerm, struct{}{}, SubscriptionQuotaReachedTTL)
+		logging.FromContext(ctx).Error(err)
+	}
 	if sdkerrors.SKUFamilyQuotaHasBeenReached(err) {
 		// Subscription quota has been reached for this VM SKU, mark the instance type as unavailable in all zones available to the offering
 		// This will also update the TTL for an existing offering in the cache that is already unavailable

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -418,10 +418,10 @@ func (p *Provider) launchInstance(
 // nolint:gocyclo
 func (p *Provider) handleResponseErrors(ctx context.Context, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
 	if sdkerrors.LowPriorityQuotaHasBeenReached(err) {
-		// Mark all SPOT offerings as unavailable for all instance types in all zones
-		// This will also update the TTL for an existing offering in the cache that is already unavailable
+		// Mark in cache that spot quota has been reached for this subscription 
 		p.unavailableOfferings.Put(sdkerrors.LowPriorityQuotaExceededTerm, struct{}{}, SubscriptionQuotaReachedTTL)
 		logging.FromContext(ctx).Error(err)
+		return fmt.Errorf("LowPriorityQuota Has been reached and this subscription has hit the regional vCPU quota for spot. To scale beyond this limit, please review the quota increase process here: https://docs.microsoft.com/en-us/azure/azure-portal/supportability/low-priority-quota")
 	}
 	if sdkerrors.SKUFamilyQuotaHasBeenReached(err) {
 		// Subscription quota has been reached for this VM SKU, mark the instance type as unavailable in all zones available to the offering

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -419,7 +419,8 @@ func (p *Provider) launchInstance(
 func (p *Provider) handleResponseErrors(ctx context.Context, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
 	if sdkerrors.LowPriorityQuotaHasBeenReached(err) {
 		// Mark in cache that spot quota has been reached for this subscription
-		p.unavailableOfferings.Put(sdkerrors.LowPriorityQuotaExceededTerm, struct{}{}, SubscriptionQuotaReachedTTL)
+		p.unavailableOfferings.MarkUnavailable(ctx, "", "", "", corev1beta1.CapacityTypeSpot)
+
 		logging.FromContext(ctx).Error(err)
 		return fmt.Errorf("LowPriorityQuota Has been reached and this subscription has hit the regional vCPU quota for spot. To scale beyond this limit, please review the quota increase process here: https://docs.microsoft.com/en-us/azure/azure-portal/supportability/low-priority-quota")
 	}

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -419,7 +419,7 @@ func (p *Provider) launchInstance(
 func (p *Provider) handleResponseErrors(ctx context.Context, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
 	if sdkerrors.LowPriorityQuotaHasBeenReached(err) {
 		// Mark in cache that spot quota has been reached for this subscription
-		p.unavailableOfferings.MarkUnavailable(ctx, "", "", "", corev1beta1.CapacityTypeSpot)
+		p.unavailableOfferings.MarkSpotUnavailable(ctx)
 
 		logging.FromContext(ctx).Error(err)
 		return fmt.Errorf("this subscription has reached the regional vCPU quota for spot (LowPriorityQuota). To scale beyond this limit, please review the quota increase process here: https://docs.microsoft.com/en-us/azure/azure-portal/supportability/low-priority-quota")

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -422,7 +422,7 @@ func (p *Provider) handleResponseErrors(ctx context.Context, instanceType *corec
 		p.unavailableOfferings.MarkUnavailable(ctx, "", "", "", corev1beta1.CapacityTypeSpot)
 
 		logging.FromContext(ctx).Error(err)
-		return fmt.Errorf("LowPriorityQuota Has been reached and this subscription has hit the regional vCPU quota for spot. To scale beyond this limit, please review the quota increase process here: https://docs.microsoft.com/en-us/azure/azure-portal/supportability/low-priority-quota")
+		return fmt.Errorf("this subscription has reached the regional vCPU quota for spot (LowPriorityQuota). To scale beyond this limit, please review the quota increase process here: https://docs.microsoft.com/en-us/azure/azure-portal/supportability/low-priority-quota")
 	}
 	if sdkerrors.SKUFamilyQuotaHasBeenReached(err) {
 		// Subscription quota has been reached for this VM SKU, mark the instance type as unavailable in all zones available to the offering

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -419,7 +419,7 @@ func (p *Provider) launchInstance(
 func (p *Provider) handleResponseErrors(ctx context.Context, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
 	if sdkerrors.LowPriorityQuotaHasBeenReached(err) {
 		// Mark in cache that spot quota has been reached for this subscription
-		p.unavailableOfferings.MarkSpotUnavailable(ctx)
+		p.unavailableOfferings.MarkSpotUnavailableWithTTL(ctx, SubscriptionQuotaReachedTTL)
 
 		logging.FromContext(ctx).Error(err)
 		return fmt.Errorf("this subscription has reached the regional vCPU quota for spot (LowPriorityQuota). To scale beyond this limit, please review the quota increase process here: https://docs.microsoft.com/en-us/azure/azure-portal/supportability/low-priority-quota")

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -418,7 +418,7 @@ func (p *Provider) launchInstance(
 // nolint:gocyclo
 func (p *Provider) handleResponseErrors(ctx context.Context, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
 	if sdkerrors.LowPriorityQuotaHasBeenReached(err) {
-		// Mark in cache that spot quota has been reached for this subscription 
+		// Mark in cache that spot quota has been reached for this subscription
 		p.unavailableOfferings.Put(sdkerrors.LowPriorityQuotaExceededTerm, struct{}{}, SubscriptionQuotaReachedTTL)
 		logging.FromContext(ctx).Error(err)
 		return fmt.Errorf("LowPriorityQuota Has been reached and this subscription has hit the regional vCPU quota for spot. To scale beyond this limit, please review the quota increase process here: https://docs.microsoft.com/en-us/azure/azure-portal/supportability/low-priority-quota")

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/logging"
 
-	sdkerrors "github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
 	"github.com/Azure/karpenter/pkg/providers/instance/skuclient"
 	"github.com/Azure/karpenter/pkg/providers/pricing"
 	"github.com/Azure/skewer"
@@ -136,7 +135,7 @@ func (p *Provider) createOfferings(sku *skewer.SKU, zones sets.Set[string]) []cl
 		onDemandPrice, onDemandOk := p.pricingProvider.OnDemandPrice(*sku.Name)
 		spotPrice, spotOk := p.pricingProvider.SpotPrice(*sku.Name)
 		availableOnDemand := onDemandOk && !p.unavailableOfferings.IsUnavailable(*sku.Name, zone, corev1beta1.CapacityTypeOnDemand)
-		availableSpot := spotOk && !p.unavailableOfferings.IsUnavailable(*sku.Name, zone, corev1beta1.CapacityTypeSpot) && !p.unavailableOfferings.Has(sdkerrors.LowPriorityQuotaExceededTerm)
+		availableSpot := spotOk && !p.unavailableOfferings.IsUnavailable(*sku.Name, zone, corev1beta1.CapacityTypeSpot) && !p.unavailableOfferings.IsUnavailable("", "", corev1beta1.CapacityTypeSpot)
 		offerings = append(offerings, cloudprovider.Offering{Zone: zone, CapacityType: corev1beta1.CapacityTypeSpot, Price: spotPrice, Available: availableSpot})
 		offerings = append(offerings, cloudprovider.Offering{Zone: zone, CapacityType: corev1beta1.CapacityTypeOnDemand, Price: onDemandPrice, Available: availableOnDemand})
 	}

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -135,7 +135,7 @@ func (p *Provider) createOfferings(sku *skewer.SKU, zones sets.Set[string]) []cl
 		onDemandPrice, onDemandOk := p.pricingProvider.OnDemandPrice(*sku.Name)
 		spotPrice, spotOk := p.pricingProvider.SpotPrice(*sku.Name)
 		availableOnDemand := onDemandOk && !p.unavailableOfferings.IsUnavailable(*sku.Name, zone, corev1beta1.CapacityTypeOnDemand)
-		availableSpot := spotOk && !p.unavailableOfferings.IsUnavailable(*sku.Name, zone, corev1beta1.CapacityTypeSpot) && !p.unavailableOfferings.IsUnavailable("", "", corev1beta1.CapacityTypeSpot)
+		availableSpot := spotOk && !p.unavailableOfferings.IsUnavailable(*sku.Name, zone, corev1beta1.CapacityTypeSpot)
 		offerings = append(offerings, cloudprovider.Offering{Zone: zone, CapacityType: corev1beta1.CapacityTypeSpot, Price: spotPrice, Available: availableSpot})
 		offerings = append(offerings, cloudprovider.Offering{Zone: zone, CapacityType: corev1beta1.CapacityTypeOnDemand, Price: onDemandPrice, Available: availableOnDemand})
 	}

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -195,7 +195,6 @@ var _ = Describe("InstanceType Provider", func() {
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
 			ExpectNotScheduled(ctx, env.Client, pod)
 			azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(nil)
-			pod = coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
 			ExpectScheduled(ctx, env.Client, pod)
 			// Check the capacity type is on-demand

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -172,6 +172,44 @@ var _ = Describe("InstanceType Provider", func() {
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
 			ExpectScheduled(ctx, env.Client, pod)
 		})
+		It("should fail to provision when LowPriorityCoresQuota errors are hit, then switch capacity type and succeed", func() { 
+			LowPriorityCoresQuotaErrorMessage := "Operation could not be completed as it results in exceeding approved Low Priority Cores quota. Additional details - Deployment Model: Resource Manager, Location: westus2, Current Limit: 0, Current Usage: 0, Additional Required: 32, (Minimum) New Limit Required: 32. Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%(redacted)%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22westus2%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22LowPriorityCores%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:32,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22LowPriorityCores%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests"
+			// Create nodepool that has both ondemand and spot capacity types enabled 
+			coretest.ReplaceRequirements(nodePool, v1.NodeSelectorRequirement{
+				Key:     corev1beta1.CapacityTypeLabelKey,
+				Operator: v1.NodeSelectorOpIn,
+				Values:   []string{corev1beta1.CapacityTypeOnDemand, corev1beta1.CapacityTypeSpot},
+			})
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass) 
+			// Set the LowPriorityCoresQuota error to be returned when creating the vm	 
+			azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.Error.Set( 
+				&azcore.ResponseError{
+					ErrorCode: sdkerrors.OperationNotAllowed,
+					RawResponse: &http.Response{
+						Body: createSDKErrorBody(sdkerrors.OperationNotAllowed, LowPriorityCoresQuotaErrorMessage),
+					},
+				},
+			)
+			// Create a pod that should fail to schedule 
+			pod := coretest.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+			azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(nil) 
+			pod = coretest.UnschedulablePod() 
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod) 
+			ExpectScheduled(ctx, env.Client, pod) 
+			// Check the capacity type is on-demand
+			Expect(pod.Spec.NodeName).ToNot(BeNil())
+
+			// List all nodes in the nodepool and check the capacity type is on-demand
+			nodes, err := env.KubernetesInterface.CoreV1().Nodes().List(ctx, metav1.ListOptions{}) 
+			Expect(err).ToNot(HaveOccurred()) 
+			Expect(len(nodes.Items)).To(Equal(1)) 
+			Expect(nodes.Items[0].Labels[corev1beta1.CapacityTypeLabelKey]).To(Equal(corev1beta1.CapacityTypeOnDemand)) 
+		})
+		
+
+
 		It("should fail to provision when VM SKU family vCPU quota exceeded error is returned, and succeed when it is gone", func() {
 			familyVCPUQuotaExceededErrorMessage := "Operation could not be completed as it results in exceeding approved standardDLSv5Family Cores quota. Additional details - Deployment Model: Resource Manager, Location: westus2, Current Limit: 100, Current Usage: 96, Additional Required: 32, (Minimum) New Limit Required: 128. Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%(redacted)%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22westus2%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22standardDLSv5Family%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:128,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22standardDLSv5Family%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests"
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -172,17 +172,17 @@ var _ = Describe("InstanceType Provider", func() {
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
 			ExpectScheduled(ctx, env.Client, pod)
 		})
-		It("should fail to provision when LowPriorityCoresQuota errors are hit, then switch capacity type and succeed", func() { 
+		It("should fail to provision when LowPriorityCoresQuota errors are hit, then switch capacity type and succeed", func() {
 			LowPriorityCoresQuotaErrorMessage := "Operation could not be completed as it results in exceeding approved Low Priority Cores quota. Additional details - Deployment Model: Resource Manager, Location: westus2, Current Limit: 0, Current Usage: 0, Additional Required: 32, (Minimum) New Limit Required: 32. Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%(redacted)%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22westus2%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22LowPriorityCores%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:32,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22LowPriorityCores%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests"
-			// Create nodepool that has both ondemand and spot capacity types enabled 
+			// Create nodepool that has both ondemand and spot capacity types enabled
 			coretest.ReplaceRequirements(nodePool, v1.NodeSelectorRequirement{
-				Key:     corev1beta1.CapacityTypeLabelKey,
+				Key:      corev1beta1.CapacityTypeLabelKey,
 				Operator: v1.NodeSelectorOpIn,
 				Values:   []string{corev1beta1.CapacityTypeOnDemand, corev1beta1.CapacityTypeSpot},
 			})
-			ExpectApplied(ctx, env.Client, nodePool, nodeClass) 
-			// Set the LowPriorityCoresQuota error to be returned when creating the vm	 
-			azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.Error.Set( 
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+			// Set the LowPriorityCoresQuota error to be returned when creating the vm
+			azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.Error.Set(
 				&azcore.ResponseError{
 					ErrorCode: sdkerrors.OperationNotAllowed,
 					RawResponse: &http.Response{
@@ -190,25 +190,23 @@ var _ = Describe("InstanceType Provider", func() {
 					},
 				},
 			)
-			// Create a pod that should fail to schedule 
+			// Create a pod that should fail to schedule
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
 			ExpectNotScheduled(ctx, env.Client, pod)
-			azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(nil) 
-			pod = coretest.UnschedulablePod() 
-			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod) 
-			ExpectScheduled(ctx, env.Client, pod) 
+			azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(nil)
+			pod = coretest.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
+			ExpectScheduled(ctx, env.Client, pod)
 			// Check the capacity type is on-demand
 			Expect(pod.Spec.NodeName).ToNot(BeNil())
 
 			// List all nodes in the nodepool and check the capacity type is on-demand
-			nodes, err := env.KubernetesInterface.CoreV1().Nodes().List(ctx, metav1.ListOptions{}) 
-			Expect(err).ToNot(HaveOccurred()) 
-			Expect(len(nodes.Items)).To(Equal(1)) 
-			Expect(nodes.Items[0].Labels[corev1beta1.CapacityTypeLabelKey]).To(Equal(corev1beta1.CapacityTypeOnDemand)) 
+			nodes, err := env.KubernetesInterface.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(nodes.Items)).To(Equal(1))
+			Expect(nodes.Items[0].Labels[corev1beta1.CapacityTypeLabelKey]).To(Equal(corev1beta1.CapacityTypeOnDemand))
 		})
-		
-
 
 		It("should fail to provision when VM SKU family vCPU quota exceeded error is returned, and succeed when it is gone", func() {
 			familyVCPUQuotaExceededErrorMessage := "Operation could not be completed as it results in exceeding approved standardDLSv5Family Cores quota. Additional details - Deployment Model: Resource Manager, Location: westus2, Current Limit: 100, Current Usage: 96, Additional Required: 32, (Minimum) New Limit Required: 128. Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%(redacted)%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22westus2%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22standardDLSv5Family%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:128,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22standardDLSv5Family%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests"

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -198,7 +198,7 @@ var _ = Describe("InstanceType Provider", func() {
 			azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(nil)
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
 			ExpectScheduled(ctx, env.Client, pod)
-		
+
 			// Expect that on-demand nodes are selected if spot capacity is unavailable, and the nodepool uses both spot + on-demand
 			nodes, err := env.KubernetesInterface.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -198,10 +198,8 @@ var _ = Describe("InstanceType Provider", func() {
 			azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(nil)
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
 			ExpectScheduled(ctx, env.Client, pod)
-			// Check the capacity type is on-demand
-			Expect(pod.Spec.NodeName).ToNot(BeNil())
-
-			// List all nodes in the nodepool and check the capacity type is on-demand
+		
+			// Expect that on-demand nodes are selected if spot capacity is unavailable, and the nodepool uses both spot + on-demand
 			nodes, err := env.KubernetesInterface.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(nodes.Items)).To(Equal(1))


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #91 

**Description**
If spot capacity hits the spot regional cores count, karpenter should fall back onto on-demand. This PR adds that functionality

**How was this change tested?**
- make presubmt 
- Manual repro where i first reproed the issue presented in #91 , then proceeded to build a new image with this code and validate it will successfully choose on demand instances if spot capacity is fully used up. 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
feat: fail-over to on-demand if spot capacity is unavailable
```
