### PR TITLE
chore: karpenter-global-settings migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/Azure/skewer v0.0.19
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
-	github.com/aws/karpenter-core v0.32.2-0.20231109191441-e32aafc81fb5
+	github.com/aws/karpenter-core v0.32.3
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/go-playground/validator/v10 v10.17.0

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8V
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
-github.com/aws/karpenter-core v0.32.2-0.20231109191441-e32aafc81fb5 h1:za0geRskcT+Og9W/sRg+BiqJVLPNep8rTTB02aHR5oM=
-github.com/aws/karpenter-core v0.32.2-0.20231109191441-e32aafc81fb5/go.mod h1:x3pk+ePuEsKXchZqzv71SOzyWdAQLUNn1s0IcsS+o2I=
+github.com/aws/karpenter-core v0.32.3 h1:BS5jCl0OV31Lm+QMCaCWMk+utdZN17doV6xlhu2dlug=
+github.com/aws/karpenter-core v0.32.3/go.mod h1:RNih2g6qCiah8rFaZ7HkmClIK66Hjj38z3DbWnWGM2w=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -186,9 +186,9 @@ spec:
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
                         x-kubernetes-validations:
                           - message: label domain "kubernetes.io" is restricted
-                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.startsWith("node.kubernetes.io/") || self.startsWith("node-restriction.kubernetes.io/") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
                           - message: label domain "k8s.io" is restricted
-                            rule: self.startsWith("kops.k8s.io/") || !self.find("^([^/]+)").endsWith("k8s.io")
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
                           - message: label domain "karpenter.sh" is restricted
                             rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
                           - message: label "kubernetes.io/hostname" is restricted

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -97,9 +97,9 @@ spec:
                           maxProperties: 100
                           x-kubernetes-validations:
                             - message: label domain "kubernetes.io" is restricted
-                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.startsWith("node.kubernetes.io") || x.startsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
                             - message: label domain "k8s.io" is restricted
-                              rule: self.all(x, x.startsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
                             - message: label domain "karpenter.sh" is restricted
                               rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
                             - message: label "karpenter.sh/nodepool" is restricted
@@ -236,9 +236,9 @@ spec:
                                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
                                 x-kubernetes-validations:
                                   - message: label domain "kubernetes.io" is restricted
-                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.startsWith("node.kubernetes.io/") || self.startsWith("node-restriction.kubernetes.io/") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
                                   - message: label domain "k8s.io" is restricted
-                                    rule: self.startsWith("kops.k8s.io/") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
                                   - message: label domain "karpenter.sh" is restricted
                                     rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
                                   - message: label "karpenter.sh/nodepool" is restricted

--- a/pkg/apis/settings/settings.go
+++ b/pkg/apis/settings/settings.go
@@ -28,8 +28,6 @@ import (
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/configmap"
-
-	coresettings "github.com/aws/karpenter-core/pkg/apis/settings"
 )
 
 type settingsKeyType struct{}
@@ -145,10 +143,6 @@ func (s Settings) validateEndpoint() error {
 func (s Settings) GetAPIServerName() string {
 	endpoint, _ := url.Parse(s.ClusterEndpoint) // already validated
 	return endpoint.Hostname()
-}
-
-func (*Settings) FromContext(ctx context.Context) coresettings.Injectable {
-	return FromContext(ctx)
 }
 
 func ToContext(ctx context.Context, s *Settings) context.Context {

--- a/pkg/apis/settings/suite_test.go
+++ b/pkg/apis/settings/suite_test.go
@@ -37,6 +37,10 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = Describe("Validation", func() {
+	It("should not fail when ConfigMap is nil", func() {
+		_, err := (&settings.Settings{}).Inject(ctx, nil)
+		Expect(err).ToNot(HaveOccurred())
+	})
 	It("should succeed to set defaults", func() {
 		cm := &v1.ConfigMap{
 			Data: map[string]string{

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -30,7 +30,6 @@ import (
 	clock "k8s.io/utils/clock/testing"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
-	coresettings "github.com/aws/karpenter-core/pkg/apis/settings"
 	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	corecloudprovider "github.com/aws/karpenter-core/pkg/cloudprovider"
 
@@ -44,8 +43,8 @@ import (
 	. "knative.dev/pkg/logging/testing"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
-	"github.com/Azure/karpenter-provider-azure/pkg/apis/settings"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
@@ -70,10 +69,14 @@ func TestCloudProvider(t *testing.T) {
 	RunSpecs(t, "CloudProvider")
 }
 
+func toBoolPtr(b bool) *bool {
+	return &b
+}
+
 var _ = BeforeSuite(func() {
 	env = coretest.NewEnvironment(scheme.Scheme, coretest.WithCRDs(apis.CRDs...))
-	ctx = coresettings.ToContext(ctx, coretest.Settings(coresettings.Settings{DriftEnabled: true}))
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = coreoptions.ToContext(ctx, coretest.Options(coretest.OptionsFields{FeatureGates: coretest.FeatureGates{Drift: toBoolPtr(true)}}))
+	ctx = options.ToContext(ctx, test.Options())
 	ctx, stop = context.WithCancel(ctx)
 	azureEnv = test.NewEnvironment(ctx, env)
 
@@ -92,7 +95,7 @@ var _ = BeforeEach(func() {
 	ctx = coreoptions.ToContext(ctx, coretest.Options())
 	// TODO v1beta1 options
 	// ctx = options.ToContext(ctx, test.Options())
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 	nodeClass = test.AKSNodeClass()
 	nodePool = coretest.NodePool(corev1beta1.NodePool{
 		Spec: corev1beta1.NodePoolSpec{

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -69,13 +70,9 @@ func TestCloudProvider(t *testing.T) {
 	RunSpecs(t, "CloudProvider")
 }
 
-func toBoolPtr(b bool) *bool {
-	return &b
-}
-
 var _ = BeforeSuite(func() {
 	env = coretest.NewEnvironment(scheme.Scheme, coretest.WithCRDs(apis.CRDs...))
-	ctx = coreoptions.ToContext(ctx, coretest.Options(coretest.OptionsFields{FeatureGates: coretest.FeatureGates{Drift: toBoolPtr(true)}}))
+	ctx = coreoptions.ToContext(ctx, coretest.Options(coretest.OptionsFields{FeatureGates: coretest.FeatureGates{Drift: lo.ToPtr(true)}}))
 	ctx = options.ToContext(ctx, test.Options())
 	ctx, stop = context.WithCancel(ctx)
 	azureEnv = test.NewEnvironment(ctx, env)

--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
-	"github.com/Azure/karpenter-provider-azure/pkg/apis/settings"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
 	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclaim/garbagecollection"
 	"github.com/Azure/karpenter-provider-azure/pkg/fake"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 
@@ -74,9 +74,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	ctx = coreoptions.ToContext(ctx, coretest.Options())
-	// TODO v1beta1 we dont have options yet
-	// ctx = options.ToContext(ctx, test.Options())
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 
 	env = coretest.NewEnvironment(scheme.Scheme, coretest.WithCRDs(apis.CRDs...))
 	ctx, stop = context.WithCancel(ctx)

--- a/pkg/controllers/nodeclaim/inplaceupdate/utils.go
+++ b/pkg/controllers/nodeclaim/inplaceupdate/utils.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
-	"github.com/Azure/karpenter-provider-azure/pkg/apis/settings"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 )
 
 // According to https://pkg.go.dev/encoding/json#Marshal, it's safe to use map-types (and encoding/json in general) to produce
@@ -63,10 +63,10 @@ func HashFromVM(vm *armcompute.VirtualMachine) (string, error) {
 	return hashStruct.CalculateHash()
 }
 
-// HashFromNodeClaim calculates an inplace update hash from the specified machine and settings
-func HashFromNodeClaim(settings *settings.Settings, _ *v1beta1.NodeClaim) (string, error) {
+// HashFromNodeClaim calculates an inplace update hash from the specified machine and options
+func HashFromNodeClaim(options *options.Options, _ *v1beta1.NodeClaim) (string, error) {
 	hashStruct := &inPlaceUpdateFields{
-		Identities: sets.New(settings.NodeIdentities...),
+		Identities: sets.New(options.NodeIdentities...),
 	}
 
 	return hashStruct.CalculateHash()

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/client-go/transport"
 	"knative.dev/pkg/ptr"
 
-	"github.com/Azure/karpenter-provider-azure/pkg/apis/settings"
 	"github.com/Azure/karpenter-provider-azure/pkg/auth"
 	azurecache "github.com/Azure/karpenter-provider-azure/pkg/cache"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instancetype"
@@ -80,7 +80,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		imageResolver,
 		imageProvider,
 		lo.Must(getCABundle(operator.GetConfig())),
-		settings.FromContext(ctx).ClusterEndpoint,
+		options.FromContext(ctx).ClusterEndpoint,
 		azConfig.TenantID,
 		azConfig.SubscriptionID,
 		azConfig.UserAssignedIdentityID,

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -1,0 +1,177 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"hash/fnv"
+	"math/rand"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/apis/settings"
+	coreoptions "github.com/aws/karpenter-core/pkg/operator/options"
+	"github.com/aws/karpenter-core/pkg/utils/env"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func init() {
+	coreoptions.Injectables = append(coreoptions.Injectables, &Options{})
+}
+
+type nodeIdentitiesValue []string
+
+func newNodeIdentitiesValue(val string, p *[]string) *nodeIdentitiesValue {
+	*p = strings.Split(val, ",")
+	return (*nodeIdentitiesValue)(p)
+}
+
+func (s *nodeIdentitiesValue) Set(val string) error {
+	*s = nodeIdentitiesValue(strings.Split(val, ","))
+	return nil
+}
+
+func (s *nodeIdentitiesValue) Get() any { return []string(*s) }
+
+func (s *nodeIdentitiesValue) String() string { return strings.Join(*s, ",") }
+
+type optionsKey struct{}
+
+type Options struct {
+	ClusterName                    string
+	ClusterEndpoint                string // => APIServerName in bootstrap, except needs to be w/o https/port
+	VMMemoryOverheadPercent        float64
+	ClusterID                      string
+	KubeletClientTLSBootstrapToken string   // => TLSBootstrapToken in bootstrap (may need to be per node/nodepool)
+	SSHPublicKey                   string   // ssh.publicKeys.keyData => VM SSH public key // TODO: move to node template?
+	NetworkPlugin                  string   // => NetworkPlugin in bootstrap
+	NetworkPolicy                  string   // => NetworkPolicy in bootstrap
+	NodeIdentities                 []string // => Applied onto each VM
+
+	setFlags map[string]bool
+}
+
+func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
+	fs.StringVar(&o.ClusterName, "cluster-name", env.WithDefaultString("CLUSTER_NAME", ""), "[REQUIRED] The kubernetes cluster name for resource discovery.")
+	fs.StringVar(&o.ClusterEndpoint, "cluster-endpoint", env.WithDefaultString("CLUSTER_ENDPOINT", ""), "[REQUIRED] The external kubernetes cluster endpoint for new nodes to connect with. If not specified, will discover the cluster endpoint using DescribeCluster API.")
+	fs.Float64Var(&o.VMMemoryOverheadPercent, "vm-memory-overhead-percent", env.WithDefaultFloat64("VM_MEMORY_OVERHEAD_PERCENT", 0.075), "The VM memory overhead as a percent that will be subtracted from the total memory for all instance types.")
+	fs.StringVar(&o.ClusterID, "cluster-id", env.WithDefaultString("CLUSTER_ID", ""), "The kubernetes cluster ID. If not specified, will generated based on cluster endpoint.")
+	fs.StringVar(&o.KubeletClientTLSBootstrapToken, "kubelet-client-tls-bootstrap-token", env.WithDefaultString("KUBELET_CLIENT_TLS_BOOTSTRAP_TOKEN", ""), "[REQUIRED] The bootstrap token for new nodes to join the cluster.")
+	fs.StringVar(&o.SSHPublicKey, "ssh-public-key", env.WithDefaultString("SSH_PUBLIC_KEY", ""), "[REQUIRED] VM SSH public key.")
+	fs.StringVar(&o.NetworkPlugin, "network-plugin", env.WithDefaultString("NETWORK_PLUGIN", "azure"), "AKS cluster networking plugin.")
+	fs.StringVar(&o.NetworkPolicy, "network-policy", env.WithDefaultString("NETWORK_POLICY", ""), "AKS cluster network policy.")
+	fs.Var(newNodeIdentitiesValue(env.WithDefaultString("NODE_IDENTITIES", ""), &o.NodeIdentities), "node-identities", "User assigned identities for nodes.")
+}
+
+func (o Options) GetAPIServerName() string {
+	endpoint, _ := url.Parse(o.ClusterEndpoint) // assume to already validated
+	return endpoint.Hostname()
+}
+
+func (o *Options) Parse(fs *coreoptions.FlagSet, args ...string) error {
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		return fmt.Errorf("parsing flags, %w", err)
+	}
+
+	// Check if each option has been set. This is a little brute force and better options might exist,
+	// but this only needs to be here for one version
+	o.setFlags = map[string]bool{}
+	cliFlags := sets.New[string]()
+	fs.Visit(func(f *flag.Flag) {
+		cliFlags.Insert(f.Name)
+	})
+	fs.VisitAll(func(f *flag.Flag) {
+		envName := strings.ReplaceAll(strings.ToUpper(f.Name), "-", "_")
+		_, ok := os.LookupEnv(envName)
+		o.setFlags[f.Name] = ok || cliFlags.Has(f.Name)
+	})
+
+	if err := o.Validate(); err != nil {
+		return fmt.Errorf("validating options, %w", err)
+	}
+
+	// if ClusterID is not set, generate it from cluster endpoint
+	// if clusterEndpoint is empty, it might awaiting merge from MergeSettings(), do not run GetAPIServerName() or it could panic
+	// TODO: chore: remove clusterEndpoint validation logic here when karpenter-global-settings (and merge logic) are completely removed
+	if o.ClusterID == "" && o.ClusterEndpoint != "" {
+		o.ClusterID = getAKSClusterID(o.GetAPIServerName())
+	}
+
+	return nil
+}
+
+func (o *Options) ToContext(ctx context.Context) context.Context {
+	return ToContext(ctx, o)
+}
+
+func (o *Options) MergeSettings(ctx context.Context) {
+	s := settings.FromContext(ctx)
+	mergeField(&o.ClusterName, s.ClusterName, o.setFlags["cluster-name"])
+	mergeField(&o.ClusterEndpoint, s.ClusterEndpoint, o.setFlags["cluster-endpoint"])
+	mergeField(&o.VMMemoryOverheadPercent, s.VMMemoryOverheadPercent, o.setFlags["vm-memory-overhead-percent"])
+	mergeField(&o.ClusterID, s.ClusterID, o.setFlags["cluster-id"])
+	mergeField(&o.KubeletClientTLSBootstrapToken, s.KubeletClientTLSBootstrapToken, o.setFlags["kubelet-client-tls-bootstrap-token"])
+	mergeField(&o.SSHPublicKey, s.SSHPublicKey, o.setFlags["ssh-public-key"])
+	mergeField(&o.NetworkPlugin, s.NetworkPlugin, o.setFlags["network-plugin"])
+	mergeField(&o.NetworkPolicy, s.NetworkPolicy, o.setFlags["network-policy"])
+	mergeField(&o.NodeIdentities, s.NodeIdentities, o.setFlags["node-identities"])
+
+	if err := o.validateRequiredFields(); err != nil {
+		panic(fmt.Errorf("checking required fields, %w", err))
+	}
+
+	// if ClusterID is not set, generate it from cluster endpoint
+	if o.ClusterID == "" {
+		o.ClusterID = getAKSClusterID(o.GetAPIServerName())
+	}
+}
+
+func ToContext(ctx context.Context, opts *Options) context.Context {
+	return context.WithValue(ctx, optionsKey{}, opts)
+}
+
+func FromContext(ctx context.Context) *Options {
+	retval := ctx.Value(optionsKey{})
+	if retval == nil {
+		return nil
+	}
+	return retval.(*Options)
+}
+
+func mergeField[T any](dest *T, src T, isDestSet bool) {
+	if !isDestSet {
+		*dest = src
+	}
+}
+
+// getAKSClusterID returns cluster ID based on the DNS prefix of the cluster.
+// The logic comes from AgentBaker and other places, originally from aks-engine
+// with the additional assumption of DNS prefix being the first 33 chars of FQDN
+func getAKSClusterID(apiServerFQDN string) string {
+	dnsPrefix := apiServerFQDN[:33]
+	h := fnv.New64a()
+	h.Write([]byte(dnsPrefix))
+	r := rand.New(rand.NewSource(int64(h.Sum64()))) //nolint:gosec
+	return fmt.Sprintf("%08d", r.Uint32())[:8]
+}

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -70,14 +70,14 @@ type Options struct {
 }
 
 func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
-	fs.StringVar(&o.ClusterName, "cluster-name", env.WithDefaultString("CLUSTER_NAME", ""), "[REQUIRED] The kubernetes cluster name for resource discovery.")
-	fs.StringVar(&o.ClusterEndpoint, "cluster-endpoint", env.WithDefaultString("CLUSTER_ENDPOINT", ""), "[REQUIRED] The external kubernetes cluster endpoint for new nodes to connect with. If not specified, will discover the cluster endpoint using DescribeCluster API.")
+	fs.StringVar(&o.ClusterName, "cluster-name", env.WithDefaultString("CLUSTER_NAME", ""), "[REQUIRED] The kubernetes cluster name for resource tags.")
+	fs.StringVar(&o.ClusterEndpoint, "cluster-endpoint", env.WithDefaultString("CLUSTER_ENDPOINT", ""), "[REQUIRED] The external kubernetes cluster endpoint for new nodes to connect with.")
 	fs.Float64Var(&o.VMMemoryOverheadPercent, "vm-memory-overhead-percent", env.WithDefaultFloat64("VM_MEMORY_OVERHEAD_PERCENT", 0.075), "The VM memory overhead as a percent that will be subtracted from the total memory for all instance types.")
-	fs.StringVar(&o.ClusterID, "cluster-id", env.WithDefaultString("CLUSTER_ID", ""), "The kubernetes cluster ID. If not specified, will generated based on cluster endpoint.")
-	fs.StringVar(&o.KubeletClientTLSBootstrapToken, "kubelet-client-tls-bootstrap-token", env.WithDefaultString("KUBELET_CLIENT_TLS_BOOTSTRAP_TOKEN", ""), "[REQUIRED] The bootstrap token for new nodes to join the cluster.")
+	fs.StringVar(&o.ClusterID, "cluster-id", env.WithDefaultString("CLUSTER_ID", ""), "The kubernetes cluster ID. If not specified, will be generated based on cluster endpoint.")
+	fs.StringVar(&o.KubeletClientTLSBootstrapToken, "kubelet-bootstrap-token", env.WithDefaultString("KUBELET_BOOTSTRAP_TOKEN", ""), "[REQUIRED] The bootstrap token for new nodes to join the cluster.")
 	fs.StringVar(&o.SSHPublicKey, "ssh-public-key", env.WithDefaultString("SSH_PUBLIC_KEY", ""), "[REQUIRED] VM SSH public key.")
-	fs.StringVar(&o.NetworkPlugin, "network-plugin", env.WithDefaultString("NETWORK_PLUGIN", "azure"), "AKS cluster networking plugin.")
-	fs.StringVar(&o.NetworkPolicy, "network-policy", env.WithDefaultString("NETWORK_POLICY", ""), "AKS cluster network policy.")
+	fs.StringVar(&o.NetworkPlugin, "network-plugin", env.WithDefaultString("NETWORK_PLUGIN", "azure"), "The network plugin used by the cluster.")
+	fs.StringVar(&o.NetworkPolicy, "network-policy", env.WithDefaultString("NETWORK_POLICY", ""), "The network policy used by the cluster.")
 	fs.Var(newNodeIdentitiesValue(env.WithDefaultString("NODE_IDENTITIES", ""), &o.NodeIdentities), "node-identities", "User assigned identities for nodes.")
 }
 
@@ -131,7 +131,7 @@ func (o *Options) MergeSettings(ctx context.Context) {
 	mergeField(&o.ClusterEndpoint, s.ClusterEndpoint, o.setFlags["cluster-endpoint"])
 	mergeField(&o.VMMemoryOverheadPercent, s.VMMemoryOverheadPercent, o.setFlags["vm-memory-overhead-percent"])
 	mergeField(&o.ClusterID, s.ClusterID, o.setFlags["cluster-id"])
-	mergeField(&o.KubeletClientTLSBootstrapToken, s.KubeletClientTLSBootstrapToken, o.setFlags["kubelet-client-tls-bootstrap-token"])
+	mergeField(&o.KubeletClientTLSBootstrapToken, s.KubeletClientTLSBootstrapToken, o.setFlags["kubelet-bootstrap-token"])
 	mergeField(&o.SSHPublicKey, s.SSHPublicKey, o.setFlags["ssh-public-key"])
 	mergeField(&o.NetworkPlugin, s.NetworkPlugin, o.setFlags["network-plugin"])
 	mergeField(&o.NetworkPolicy, s.NetworkPolicy, o.setFlags["network-policy"])

--- a/pkg/operator/options/options_validation.go
+++ b/pkg/operator/options/options_validation.go
@@ -1,0 +1,65 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/go-playground/validator/v10"
+	"go.uber.org/multierr"
+)
+
+func (o Options) Validate() error {
+	validate := validator.New()
+	return multierr.Combine(
+		//o.validateRequiredFields(),	// TODO: add back to Validate when karpenter-global-settings (and merge logic) are completely removed
+		o.validateEndpoint(),
+		o.validateVMMemoryOverheadPercent(),
+		validate.Struct(o),
+	)
+}
+
+func (o Options) validateEndpoint() error {
+	if o.ClusterEndpoint == "" {
+		return nil
+	}
+	endpoint, err := url.Parse(o.ClusterEndpoint)
+	// url.Parse() will accept a lot of input without error; make
+	// sure it's a real URL
+	if err != nil || !endpoint.IsAbs() || endpoint.Hostname() == "" {
+		return fmt.Errorf("\"%s\" not a valid clusterEndpoint URL", o.ClusterEndpoint)
+	}
+	return nil
+}
+
+func (o Options) validateVMMemoryOverheadPercent() error {
+	if o.VMMemoryOverheadPercent < 0 {
+		return fmt.Errorf("vm-memory-overhead-percent cannot be negative")
+	}
+	return nil
+}
+
+func (o Options) validateRequiredFields() error {
+	if o.ClusterEndpoint == "" {
+		return fmt.Errorf("missing field, cluster-endpoint")
+	}
+	if o.ClusterName == "" {
+		return fmt.Errorf("missing field, cluster-name")
+	}
+	return nil
+}

--- a/pkg/operator/options/options_validation.go
+++ b/pkg/operator/options/options_validation.go
@@ -61,5 +61,11 @@ func (o Options) validateRequiredFields() error {
 	if o.ClusterName == "" {
 		return fmt.Errorf("missing field, cluster-name")
 	}
+	if o.KubeletClientTLSBootstrapToken == "" {
+		return fmt.Errorf("missing field, kubelet-bootstrap-token")
+	}
+	if o.SSHPublicKey == "" {
+		return fmt.Errorf("missing field, ssh-public-key")
+	}
 	return nil
 }

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -1,0 +1,274 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	. "knative.dev/pkg/logging/testing"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/apis/settings"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
+	"github.com/Azure/karpenter-provider-azure/pkg/test"
+	coreoptions "github.com/aws/karpenter-core/pkg/operator/options"
+)
+
+var ctx context.Context
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Options")
+}
+
+var _ = Describe("Options", func() {
+	var envState map[string]string
+	var environmentVariables = []string{
+		"CLUSTER_NAME",
+		"CLUSTER_ENDPOINT",
+		"VM_MEMORY_OVERHEAD_PERCENT",
+		"CLUSTER_ID",
+		"KUBELET_CLIENT_TLS_BOOTSTRAP_TOKEN",
+		"SSH_PUBLIC_KEY",
+		"NETWORK_PLUGIN",
+		"NETWORK_POLICY",
+		"NODE_IDENTITIES",
+	}
+
+	var fs *coreoptions.FlagSet
+	var opts *options.Options
+
+	BeforeEach(func() {
+		envState = map[string]string{}
+		for _, ev := range environmentVariables {
+			val, ok := os.LookupEnv(ev)
+			if ok {
+				envState[ev] = val
+			}
+			os.Unsetenv(ev)
+		}
+		fs = &coreoptions.FlagSet{
+			FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
+		}
+		opts = &options.Options{}
+		opts.AddFlags(fs)
+
+		// Inject default settings
+		var err error
+		ctx, err = (&settings.Settings{}).Inject(ctx, nil)
+		Expect(err).To(BeNil())
+	})
+
+	AfterEach(func() {
+		for _, ev := range environmentVariables {
+			os.Unsetenv(ev)
+		}
+		for ev, val := range envState {
+			os.Setenv(ev, val)
+		}
+	})
+
+	Context("Merging", func() {
+		It("shouldn't overwrite options when all are set", func() {
+			err := opts.Parse(
+				fs,
+				"--cluster-name", "options-cluster",
+				"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+				"--vm-memory-overhead-percent", "0.1",
+				"--cluster-id", "options-cluster-id",
+				"--kubelet-client-tls-bootstrap-token", "options-bootstrap-token",
+				"--ssh-public-key", "options-ssh-public-key",
+				"--network-plugin", "azure",
+				"--network-policy", "",
+				"--node-identities", "/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/optionsid1,/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/optionsid2",
+			)
+			Expect(err).ToNot(HaveOccurred())
+			ctx = settings.ToContext(ctx, &settings.Settings{
+				ClusterName:                    "settings-cluster",
+				ClusterEndpoint:                "https://karpenter-000000000001.hcp.westus2.staging.azmk8s.io",
+				VMMemoryOverheadPercent:        0.1,
+				ClusterID:                      "settings-cluster-id",
+				KubeletClientTLSBootstrapToken: "settings-bootstrap-token",
+				SSHPublicKey:                   "settings-ssh-public-key",
+				NetworkPlugin:                  "kubenet",
+				NetworkPolicy:                  "azure",
+				NodeIdentities:                 []string{"/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/settingsid1", "/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/settingsid2"},
+			})
+			opts.MergeSettings(ctx)
+			expectOptionsEqual(opts, test.Options(test.OptionsFields{
+				ClusterName:                    lo.ToPtr("options-cluster"),
+				ClusterEndpoint:                lo.ToPtr("https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io"),
+				VMMemoryOverheadPercent:        lo.ToPtr(0.1),
+				ClusterID:                      lo.ToPtr("options-cluster-id"),
+				KubeletClientTLSBootstrapToken: lo.ToPtr("options-bootstrap-token"),
+				SSHPublicKey:                   lo.ToPtr("options-ssh-public-key"),
+				NetworkPlugin:                  lo.ToPtr("azure"),
+				NetworkPolicy:                  lo.ToPtr(""),
+				NodeIdentities:                 []string{"/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/optionsid1", "/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/optionsid2"},
+			}))
+		})
+		It("should overwrite options when none are set", func() {
+			err := opts.Parse(fs)
+			Expect(err).ToNot(HaveOccurred())
+			ctx = settings.ToContext(ctx, &settings.Settings{
+				ClusterName:                    "settings-cluster",
+				ClusterEndpoint:                "https://karpenter-000000000001.hcp.westus2.staging.azmk8s.io",
+				VMMemoryOverheadPercent:        0.1,
+				ClusterID:                      "settings-cluster-id",
+				KubeletClientTLSBootstrapToken: "settings-bootstrap-token",
+				SSHPublicKey:                   "settings-ssh-public-key",
+				NetworkPlugin:                  "kubenet",
+				NetworkPolicy:                  "azure",
+				NodeIdentities:                 []string{"/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/settingsid1", "/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/settingsid2"},
+			})
+			opts.MergeSettings(ctx)
+			expectOptionsEqual(opts, test.Options(test.OptionsFields{
+				ClusterName:                    lo.ToPtr("settings-cluster"),
+				ClusterEndpoint:                lo.ToPtr("https://karpenter-000000000001.hcp.westus2.staging.azmk8s.io"),
+				VMMemoryOverheadPercent:        lo.ToPtr(0.1),
+				ClusterID:                      lo.ToPtr("settings-cluster-id"),
+				KubeletClientTLSBootstrapToken: lo.ToPtr("settings-bootstrap-token"),
+				SSHPublicKey:                   lo.ToPtr("settings-ssh-public-key"),
+				NetworkPlugin:                  lo.ToPtr("kubenet"),
+				NetworkPolicy:                  lo.ToPtr("azure"),
+				NodeIdentities:                 []string{"/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/settingsid1", "/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/settingsid2"},
+			}))
+
+		})
+		It("should correctly merge options and settings when mixed", func() {
+			err := opts.Parse(
+				fs,
+				"--cluster-name", "options-cluster",
+				"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+				"--vm-memory-overhead-percent", "0.1",
+				"--cluster-id", "options-cluster-id",
+				"--kubelet-client-tls-bootstrap-token", "options-bootstrap-token",
+			)
+			Expect(err).ToNot(HaveOccurred())
+			ctx = settings.ToContext(ctx, &settings.Settings{
+				ClusterName:                    "settings-cluster",
+				ClusterEndpoint:                "https://karpenter-000000000001.hcp.westus2.staging.azmk8s.io",
+				VMMemoryOverheadPercent:        0.1,
+				ClusterID:                      "settings-cluster-id",
+				KubeletClientTLSBootstrapToken: "settings-bootstrap-token",
+				SSHPublicKey:                   "settings-ssh-public-key",
+				NetworkPlugin:                  "kubenet",
+				NetworkPolicy:                  "azure",
+				NodeIdentities:                 []string{"/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/settingsid1", "/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/settingsid2"},
+			})
+			opts.MergeSettings(ctx)
+			expectOptionsEqual(opts, test.Options(test.OptionsFields{
+				ClusterName:                    lo.ToPtr("options-cluster"),
+				ClusterEndpoint:                lo.ToPtr("https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io"),
+				VMMemoryOverheadPercent:        lo.ToPtr(0.1),
+				ClusterID:                      lo.ToPtr("options-cluster-id"),
+				KubeletClientTLSBootstrapToken: lo.ToPtr("options-bootstrap-token"),
+				SSHPublicKey:                   lo.ToPtr("settings-ssh-public-key"),
+				NetworkPlugin:                  lo.ToPtr("kubenet"),
+				NetworkPolicy:                  lo.ToPtr("azure"),
+				NodeIdentities:                 []string{"/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/settingsid1", "/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/settingsid2"},
+			}))
+		})
+
+		It("should correctly fallback to env vars when CLI flags aren't set", func() {
+			os.Setenv("CLUSTER_NAME", "env-cluster")
+			os.Setenv("CLUSTER_ENDPOINT", "https://env-cluster")
+			os.Setenv("VM_MEMORY_OVERHEAD_PERCENT", "0.3")
+			os.Setenv("CLUSTER_ID", "env-cluster-id")
+			os.Setenv("KUBELET_CLIENT_TLS_BOOTSTRAP_TOKEN", "env-bootstrap-token")
+			os.Setenv("SSH_PUBLIC_KEY", "env-ssh-public-key")
+			os.Setenv("NETWORK_PLUGIN", "env-network-plugin")
+			os.Setenv("NETWORK_POLICY", "env-network-policy")
+			os.Setenv("NODE_IDENTITIES", "/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/envid1,/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/envid2")
+			fs = &coreoptions.FlagSet{
+				FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
+			}
+			opts.AddFlags(fs)
+			err := opts.Parse(fs)
+			Expect(err).ToNot(HaveOccurred())
+			expectOptionsEqual(opts, test.Options(test.OptionsFields{
+				ClusterName:                    lo.ToPtr("env-cluster"),
+				ClusterEndpoint:                lo.ToPtr("https://env-cluster"),
+				VMMemoryOverheadPercent:        lo.ToPtr(0.3),
+				ClusterID:                      lo.ToPtr("env-cluster-id"),
+				KubeletClientTLSBootstrapToken: lo.ToPtr("env-bootstrap-token"),
+				SSHPublicKey:                   lo.ToPtr("env-ssh-public-key"),
+				NetworkPlugin:                  lo.ToPtr("env-network-plugin"),
+				NetworkPolicy:                  lo.ToPtr("env-network-policy"),
+				NodeIdentities:                 []string{"/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/envid1", "/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/envid2"},
+			}))
+		})
+	})
+
+	Context("Validation", func() {
+		It("should fail validation with panic when clusterName not included", func() {
+			err := opts.Parse(fs, "--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io")
+			//Expect(err).To(HaveOccurred()) // TODO: Add back when karpenter-global-settings (and merge logic) are completely removed
+
+			// TODO: Remove below when karpenter-global-settings (and merge logic) are completely removed
+			Expect(err).ToNot(HaveOccurred())
+			ctx = settings.ToContext(ctx, &settings.Settings{})
+			Expect(func() { opts.MergeSettings(ctx) }).To(Panic())
+
+		})
+		It("should fail validation with panic when clusterEndpoint not included", func() {
+			err := opts.Parse(fs, "--cluster-name", "my-name")
+			//Expect(err).To(HaveOccurred()) // TODO: Add back when karpenter-global-settings (and merge logic) are completely removed
+
+			// TODO: Remove below when karpenter-global-settings (and merge logic) are completely removed
+			Expect(err).ToNot(HaveOccurred())
+			ctx = settings.ToContext(ctx, &settings.Settings{})
+			Expect(func() { opts.MergeSettings(ctx) }).To(Panic())
+		})
+		It("should fail when clusterEndpoint is invalid (not absolute)", func() {
+			err := opts.Parse(
+				fs,
+				"--cluster-name", "my-name",
+				"--cluster-endpoint", "karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+			)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should fail when vmMemoryOverheadPercent is negative", func() {
+			err := opts.Parse(
+				fs,
+				"--cluster-name", "my-name",
+				"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+				"--vm-memory-overhead-percent", "-0.01",
+			)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+func expectOptionsEqual(optsA *options.Options, optsB *options.Options) {
+	GinkgoHelper()
+	Expect(optsA.ClusterName).To(Equal(optsB.ClusterName))
+	Expect(optsA.ClusterEndpoint).To(Equal(optsB.ClusterEndpoint))
+	Expect(optsA.VMMemoryOverheadPercent).To(Equal(optsB.VMMemoryOverheadPercent))
+	Expect(optsA.ClusterID).To(Equal(optsB.ClusterID))
+	Expect(optsA.KubeletClientTLSBootstrapToken).To(Equal(optsB.KubeletClientTLSBootstrapToken))
+	Expect(optsA.SSHPublicKey).To(Equal(optsB.SSHPublicKey))
+	Expect(optsA.NetworkPlugin).To(Equal(optsB.NetworkPlugin))
+	Expect(optsA.NetworkPolicy).To(Equal(optsB.NetworkPolicy))
+	Expect(optsA.NodeIdentities).To(Equal(optsB.NodeIdentities))
+}

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Options", func() {
 		"CLUSTER_ENDPOINT",
 		"VM_MEMORY_OVERHEAD_PERCENT",
 		"CLUSTER_ID",
-		"KUBELET_CLIENT_TLS_BOOTSTRAP_TOKEN",
+		"KUBELET_BOOTSTRAP_TOKEN",
 		"SSH_PUBLIC_KEY",
 		"NETWORK_PLUGIN",
 		"NETWORK_POLICY",
@@ -96,7 +96,7 @@ var _ = Describe("Options", func() {
 				"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
 				"--vm-memory-overhead-percent", "0.1",
 				"--cluster-id", "options-cluster-id",
-				"--kubelet-client-tls-bootstrap-token", "options-bootstrap-token",
+				"--kubelet-bootstrap-token", "options-bootstrap-token",
 				"--ssh-public-key", "options-ssh-public-key",
 				"--network-plugin", "azure",
 				"--network-policy", "",
@@ -162,7 +162,7 @@ var _ = Describe("Options", func() {
 				"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
 				"--vm-memory-overhead-percent", "0.1",
 				"--cluster-id", "options-cluster-id",
-				"--kubelet-client-tls-bootstrap-token", "options-bootstrap-token",
+				"--kubelet-bootstrap-token", "options-bootstrap-token",
 			)
 			Expect(err).ToNot(HaveOccurred())
 			ctx = settings.ToContext(ctx, &settings.Settings{
@@ -195,7 +195,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("CLUSTER_ENDPOINT", "https://env-cluster")
 			os.Setenv("VM_MEMORY_OVERHEAD_PERCENT", "0.3")
 			os.Setenv("CLUSTER_ID", "env-cluster-id")
-			os.Setenv("KUBELET_CLIENT_TLS_BOOTSTRAP_TOKEN", "env-bootstrap-token")
+			os.Setenv("KUBELET_BOOTSTRAP_TOKEN", "env-bootstrap-token")
 			os.Setenv("SSH_PUBLIC_KEY", "env-ssh-public-key")
 			os.Setenv("NETWORK_PLUGIN", "env-network-plugin")
 			os.Setenv("NETWORK_POLICY", "env-network-policy")

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -222,7 +222,12 @@ var _ = Describe("Options", func() {
 
 	Context("Validation", func() {
 		It("should fail validation with panic when clusterName not included", func() {
-			err := opts.Parse(fs, "--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io")
+			err := opts.Parse(
+				fs,
+				"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+				"--kubelet-bootstrap-token", "flag-bootstrap-token",
+				"--ssh-public-key", "flag-ssh-public-key",
+			)
 			//Expect(err).To(HaveOccurred()) // TODO: Add back when karpenter-global-settings (and merge logic) are completely removed
 
 			// TODO: Remove below when karpenter-global-settings (and merge logic) are completely removed
@@ -232,7 +237,40 @@ var _ = Describe("Options", func() {
 
 		})
 		It("should fail validation with panic when clusterEndpoint not included", func() {
-			err := opts.Parse(fs, "--cluster-name", "my-name")
+			err := opts.Parse(
+				fs,
+				"--cluster-name", "my-name",
+				"--kubelet-bootstrap-token", "flag-bootstrap-token",
+				"--ssh-public-key", "flag-ssh-public-key",
+			)
+			//Expect(err).To(HaveOccurred()) // TODO: Add back when karpenter-global-settings (and merge logic) are completely removed
+
+			// TODO: Remove below when karpenter-global-settings (and merge logic) are completely removed
+			Expect(err).ToNot(HaveOccurred())
+			ctx = settings.ToContext(ctx, &settings.Settings{})
+			Expect(func() { opts.MergeSettings(ctx) }).To(Panic())
+		})
+		It("should fail validation with panic when kubeletClientTLSBootstrapToken not included", func() {
+			err := opts.Parse(
+				fs,
+				"--cluster-name", "my-name",
+				"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+				"--ssh-public-key", "flag-ssh-public-key",
+			)
+			//Expect(err).To(HaveOccurred()) // TODO: Add back when karpenter-global-settings (and merge logic) are completely removed
+
+			// TODO: Remove below when karpenter-global-settings (and merge logic) are completely removed
+			Expect(err).ToNot(HaveOccurred())
+			ctx = settings.ToContext(ctx, &settings.Settings{})
+			Expect(func() { opts.MergeSettings(ctx) }).To(Panic())
+		})
+		It("should fail validation with panic when SSHPublicKey not included", func() {
+			err := opts.Parse(
+				fs,
+				"--cluster-name", "my-name",
+				"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+				"--kubelet-bootstrap-token", "flag-bootstrap-token",
+			)
 			//Expect(err).To(HaveOccurred()) // TODO: Add back when karpenter-global-settings (and merge logic) are completely removed
 
 			// TODO: Remove below when karpenter-global-settings (and merge logic) are completely removed
@@ -245,6 +283,8 @@ var _ = Describe("Options", func() {
 				fs,
 				"--cluster-name", "my-name",
 				"--cluster-endpoint", "karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+				"--kubelet-bootstrap-token", "flag-bootstrap-token",
+				"--ssh-public-key", "flag-ssh-public-key",
 			)
 			Expect(err).To(HaveOccurred())
 		})
@@ -253,6 +293,8 @@ var _ = Describe("Options", func() {
 				fs,
 				"--cluster-name", "my-name",
 				"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+				"--kubelet-bootstrap-token", "flag-bootstrap-token",
+				"--ssh-public-key", "flag-ssh-public-key",
 				"--vm-memory-overhead-percent", "-0.01",
 			)
 			Expect(err).To(HaveOccurred())

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -72,7 +72,7 @@ func (a AKS) Script() (string, error) {
 // a : known argument/parameter, passed in (usually from environment)
 // x : unique per cluster,  extracted or specified. (Candidates for exposure/accessibility via API)
 // X : unique per nodepool, extracted or specified. (Candidates for exposure/accessibility via API)
-// c : user input, global Karpenter config (provider-specific)
+// o : user input, Options (provider-specific), e.g., could be from environment variables
 // p : user input, part of standard Provisioner (NodePool) CR spec. Example: custom labels, kubelet config
 // t : user input, NodeTemplate (potentially per node)
 // k : computed (at runtime) by Karpenter (e.g. based on VM SKU, extra labels, etc.)
@@ -84,13 +84,13 @@ func (a AKS) Script() (string, error) {
 
 // Config sources for types:
 //
-// Hardcoded (this file)                         : unused (-), static (s) and unsupported (n), as well as selected defaults (s)
-// Computed at runtime                           : computed (k)
-// Karpenter global ConfigMap (provider-specific): cluster-level user input (c) - ALL DEFAULTED FOR NOW
-//                                               : as well as unique per cluster (x) - until we have a better place for these
-// (TBD)                                         : unique per nodepool. extracted or specified (X)
-// NodeTemplate                                  : user input that could be per-node (t) - ALL DEFAULTED FOR NOW
-// Provisioner spec                              : selected nodepool-level user input (p)
+// Hardcoded (this file)       : unused (-), static (s) and unsupported (n), as well as selected defaults (s)
+// Computed at runtime         : computed (k)
+// Options (provider-specific) : cluster-level user input (o) - ALL DEFAULTED FOR NOW
+//                             : as well as unique per cluster (x) - until we have a better place for these
+// (TBD)                       : unique per nodepool. extracted or specified (X)
+// NodeTemplate                : user input that could be per-node (t) - ALL DEFAULTED FOR NOW
+// Provisioner spec            : selected nodepool-level user input (p)
 
 // NodeBootstrapVariables carries all variables needed to bootstrap a node
 // It is used as input rendering the bootstrap script Go template (customDataTemplate)
@@ -143,7 +143,7 @@ type NodeBootstrapVariables struct {
 	ContainerRuntime                  string   // s   always containerd
 	CLITool                           string   // s   static/unnecessary
 	ContainerdDownloadURLBase         string   // -   unnecessary
-	NetworkMode                       string   // c   user input
+	NetworkMode                       string   // o   user input
 	UserAssignedIdentityID            string   // a   user input
 	APIServerName                     string   // x   unique per cluster
 	IsVHD                             bool     // s   static-ish
@@ -161,17 +161,17 @@ type NodeBootstrapVariables struct {
 	DisableSSH                        bool     // t   user input
 	NeedsContainerd                   bool     // s   static true
 	TeleportEnabled                   bool     // t   user input
-	ShouldConfigureHTTPProxy          bool     // c   user input
-	ShouldConfigureHTTPProxyCA        bool     // c   user input [secret]
-	HTTPProxyTrustedCA                string   // c   user input [secret]
-	ShouldConfigureCustomCATrust      bool     // c   user input
-	CustomCATrustConfigCerts          []string // c   user input [secret]
+	ShouldConfigureHTTPProxy          bool     // o   user input
+	ShouldConfigureHTTPProxyCA        bool     // o   user input [secret]
+	HTTPProxyTrustedCA                string   // o   user input [secret]
+	ShouldConfigureCustomCATrust      bool     // o   user input
+	CustomCATrustConfigCerts          []string // o   user input [secret]
 	IsKrustlet                        bool     // t   user input
 	GPUNeedsFabricManager             bool     // v   determined by GPU hardware type
 	NeedsDockerLogin                  bool     // t   user input [still needed?]
 	IPv6DualStackEnabled              bool     // t   user input
 	OutboundCommand                   string   // s   mostly static/can be
-	EnableUnattendedUpgrades          bool     // c   user input [presumably cluster level, correct?]
+	EnableUnattendedUpgrades          bool     // o   user input [presumably cluster level, correct?]
 	EnsureNoDupePromiscuousBridge     bool     // k   derived {{ and NeedsContainerd IsKubenet (not HasCalicoNetworkPolicy) }} [could be computed by template ...]
 	ShouldConfigSwapFile              bool     // t   user input
 	ShouldConfigTransparentHugePage   bool     // t   user input
@@ -184,18 +184,18 @@ type NodeBootstrapVariables struct {
 	CSEInstallFilepath                string   // s   static
 	CSEDistroInstallFilepath          string   // s   static
 	CSEConfigFilepath                 string   // s   static
-	AzurePrivateRegistryServer        string   // c   user input
-	HasCustomSearchDomain             bool     // c   user input
+	AzurePrivateRegistryServer        string   // o   user input
+	HasCustomSearchDomain             bool     // o   user input
 	CustomSearchDomainFilepath        string   // s   static
-	HTTPProxyURLs                     string   // c   user input [presumably cluster-level]
-	HTTPSProxyURLs                    string   // c   user input [presumably cluster-level]
-	NoProxyURLs                       string   // c   user input [presumably cluster-level]
+	HTTPProxyURLs                     string   // o   user input [presumably cluster-level]
+	HTTPSProxyURLs                    string   // o   user input [presumably cluster-level]
+	NoProxyURLs                       string   // o   user input [presumably cluster-level]
 	TLSBootstrappingEnabled           bool     // s   static true
 	SecureTLSBootstrappingEnabled     bool     // s   static false
 	DHCPv6ServiceFilepath             string   // k   derived from user input [how?]
 	DHCPv6ConfigFilepath              string   // k   derived from user input [how?]
-	THPEnabled                        string   // c   user input [presumably cluster-level][should be bool?]
-	THPDefrag                         string   // c   user input [presumably cluster-level][should be bool?]
+	THPEnabled                        string   // o   user input [presumably cluster-level][should be bool?]
+	THPDefrag                         string   // o   user input [presumably cluster-level][should be bool?]
 	ServicePrincipalFileContent       string   // s   only required for RP cluster [static: msi?]
 	KubeletClientContent              string   // -   unnecessary [if using TLS bootstrapping]
 	KubeletClientCertContent          string   // -   unnecessary
@@ -205,9 +205,9 @@ type NodeBootstrapVariables struct {
 	GPUImageSHA                       string   // s	  static sha rarely updated
 	GPUDriverVersion                  string   // k   determine by OS + GPU hardware requirements; can be determined automatically, but hard. suggest using GPU operator.
 	GPUInstanceProfile                string   // t   user-specified
-	CustomSearchDomainName            string   // c   user-specified [presumably cluster-level]
-	CustomSearchRealmUser             string   // c   user-specified [presumably cluster-level]
-	CustomSearchRealmPassword         string   // c   user-specified [presumably cluster-level]
+	CustomSearchDomainName            string   // o   user-specified [presumably cluster-level]
+	CustomSearchRealmUser             string   // o   user-specified [presumably cluster-level]
+	CustomSearchRealmPassword         string   // o   user-specified [presumably cluster-level]
 	MessageOfTheDay                   string   // t   user-specified [presumably node-level]
 	HasKubeletDiskType                bool     // t   user-specified [presumably node-level]
 	NeedsCgroupV2                     bool     // k   can be automatically determined

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -72,7 +72,7 @@ func (a AKS) Script() (string, error) {
 // a : known argument/parameter, passed in (usually from environment)
 // x : unique per cluster,  extracted or specified. (Candidates for exposure/accessibility via API)
 // X : unique per nodepool, extracted or specified. (Candidates for exposure/accessibility via API)
-// o : user input, Options (provider-specific), e.g., could be from environment variables
+// c : user input, Options (provider-specific), e.g., could be from environment variables
 // p : user input, part of standard Provisioner (NodePool) CR spec. Example: custom labels, kubelet config
 // t : user input, NodeTemplate (potentially per node)
 // k : computed (at runtime) by Karpenter (e.g. based on VM SKU, extra labels, etc.)
@@ -86,7 +86,7 @@ func (a AKS) Script() (string, error) {
 //
 // Hardcoded (this file)       : unused (-), static (s) and unsupported (n), as well as selected defaults (s)
 // Computed at runtime         : computed (k)
-// Options (provider-specific) : cluster-level user input (o) - ALL DEFAULTED FOR NOW
+// cptions (provider-specific) : cluster-level user input (c) - ALL DEFAULTED FOR NOW
 //                             : as well as unique per cluster (x) - until we have a better place for these
 // (TBD)                       : unique per nodepool. extracted or specified (X)
 // NodeTemplate                : user input that could be per-node (t) - ALL DEFAULTED FOR NOW
@@ -143,7 +143,7 @@ type NodeBootstrapVariables struct {
 	ContainerRuntime                  string   // s   always containerd
 	CLITool                           string   // s   static/unnecessary
 	ContainerdDownloadURLBase         string   // -   unnecessary
-	NetworkMode                       string   // o   user input
+	NetworkMode                       string   // c   user input
 	UserAssignedIdentityID            string   // a   user input
 	APIServerName                     string   // x   unique per cluster
 	IsVHD                             bool     // s   static-ish
@@ -161,17 +161,17 @@ type NodeBootstrapVariables struct {
 	DisableSSH                        bool     // t   user input
 	NeedsContainerd                   bool     // s   static true
 	TeleportEnabled                   bool     // t   user input
-	ShouldConfigureHTTPProxy          bool     // o   user input
-	ShouldConfigureHTTPProxyCA        bool     // o   user input [secret]
-	HTTPProxyTrustedCA                string   // o   user input [secret]
-	ShouldConfigureCustomCATrust      bool     // o   user input
-	CustomCATrustConfigCerts          []string // o   user input [secret]
+	ShouldConfigureHTTPProxy          bool     // c   user input
+	ShouldConfigureHTTPProxyCA        bool     // c   user input [secret]
+	HTTPProxyTrustedCA                string   // c   user input [secret]
+	ShouldConfigureCustomCATrust      bool     // c   user input
+	CustomCATrustConfigCerts          []string // c   user input [secret]
 	IsKrustlet                        bool     // t   user input
 	GPUNeedsFabricManager             bool     // v   determined by GPU hardware type
 	NeedsDockerLogin                  bool     // t   user input [still needed?]
 	IPv6DualStackEnabled              bool     // t   user input
 	OutboundCommand                   string   // s   mostly static/can be
-	EnableUnattendedUpgrades          bool     // o   user input [presumably cluster level, correct?]
+	EnableUnattendedUpgrades          bool     // c   user input [presumably cluster level, correct?]
 	EnsureNoDupePromiscuousBridge     bool     // k   derived {{ and NeedsContainerd IsKubenet (not HasCalicoNetworkPolicy) }} [could be computed by template ...]
 	ShouldConfigSwapFile              bool     // t   user input
 	ShouldConfigTransparentHugePage   bool     // t   user input
@@ -184,18 +184,18 @@ type NodeBootstrapVariables struct {
 	CSEInstallFilepath                string   // s   static
 	CSEDistroInstallFilepath          string   // s   static
 	CSEConfigFilepath                 string   // s   static
-	AzurePrivateRegistryServer        string   // o   user input
-	HasCustomSearchDomain             bool     // o   user input
+	AzurePrivateRegistryServer        string   // c   user input
+	HasCustomSearchDomain             bool     // c   user input
 	CustomSearchDomainFilepath        string   // s   static
-	HTTPProxyURLs                     string   // o   user input [presumably cluster-level]
-	HTTPSProxyURLs                    string   // o   user input [presumably cluster-level]
-	NoProxyURLs                       string   // o   user input [presumably cluster-level]
+	HTTPProxyURLs                     string   // c   user input [presumably cluster-level]
+	HTTPSProxyURLs                    string   // c   user input [presumably cluster-level]
+	NoProxyURLs                       string   // c   user input [presumably cluster-level]
 	TLSBootstrappingEnabled           bool     // s   static true
 	SecureTLSBootstrappingEnabled     bool     // s   static false
 	DHCPv6ServiceFilepath             string   // k   derived from user input [how?]
 	DHCPv6ConfigFilepath              string   // k   derived from user input [how?]
-	THPEnabled                        string   // o   user input [presumably cluster-level][should be bool?]
-	THPDefrag                         string   // o   user input [presumably cluster-level][should be bool?]
+	THPEnabled                        string   // c   user input [presumably cluster-level][should be bool?]
+	THPDefrag                         string   // c   user input [presumably cluster-level][should be bool?]
 	ServicePrincipalFileContent       string   // s   only required for RP cluster [static: msi?]
 	KubeletClientContent              string   // -   unnecessary [if using TLS bootstrapping]
 	KubeletClientCertContent          string   // -   unnecessary
@@ -205,9 +205,9 @@ type NodeBootstrapVariables struct {
 	GPUImageSHA                       string   // s	  static sha rarely updated
 	GPUDriverVersion                  string   // k   determine by OS + GPU hardware requirements; can be determined automatically, but hard. suggest using GPU operator.
 	GPUInstanceProfile                string   // t   user-specified
-	CustomSearchDomainName            string   // o   user-specified [presumably cluster-level]
-	CustomSearchRealmUser             string   // o   user-specified [presumably cluster-level]
-	CustomSearchRealmPassword         string   // o   user-specified [presumably cluster-level]
+	CustomSearchDomainName            string   // c   user-specified [presumably cluster-level]
+	CustomSearchRealmUser             string   // c   user-specified [presumably cluster-level]
+	CustomSearchRealmPassword         string   // c   user-specified [presumably cluster-level]
 	MessageOfTheDay                   string   // t   user-specified [presumably node-level]
 	HasKubeletDiskType                bool     // t   user-specified [presumably node-level]
 	NeedsCgroupV2                     bool     // k   can be automatically determined

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -86,7 +86,7 @@ func (a AKS) Script() (string, error) {
 //
 // Hardcoded (this file)       : unused (-), static (s) and unsupported (n), as well as selected defaults (s)
 // Computed at runtime         : computed (k)
-// cptions (provider-specific) : cluster-level user input (c) - ALL DEFAULTED FOR NOW
+// Options (provider-specific) : cluster-level user input (c) - ALL DEFAULTED FOR NOW
 //                             : as well as unique per cluster (x) - until we have a better place for these
 // (TBD)                       : unique per nodepool. extracted or specified (X)
 // NodeTemplate                : user input that could be per-node (t) - ALL DEFAULTED FOR NOW

--- a/pkg/providers/imagefamily/resolver.go
+++ b/pkg/providers/imagefamily/resolver.go
@@ -34,11 +34,11 @@ import (
 )
 
 const (
-	networkPluginAzureCNIOverlay = "overlay"
-	networkPluginKubenet         = "kubenet"
+	networkPluginAzure   = "azure"
+	networkPluginKubenet = "kubenet"
 
-	// defaultKubernetesMaxPodsAzureCNIOverlay is the maximum number of pods to run on a node for Azure CNI Overlay.
-	defaultKubernetesMaxPodsAzureCNIOverlay = 250
+	// defaultKubernetesMaxPodsAzure is the maximum number of pods to run on a node for Azure CNI Overlay.
+	defaultKubernetesMaxPodsAzure = 250
 	// defaultKubernetesMaxPodsKubenet is the maximum number of pods to run on a node for Kubenet.
 	defaultKubernetesMaxPodsKubenet = 100
 	// defaultKubernetesMaxPods is the maximum number of pods on a node.
@@ -123,8 +123,8 @@ func getImageFamily(familyName *string, parameters *template.StaticParameters) I
 }
 
 func getMaxPods(networkPlugin string) int32 {
-	if networkPlugin == networkPluginAzureCNIOverlay {
-		return defaultKubernetesMaxPodsAzureCNIOverlay
+	if networkPlugin == networkPluginAzure {
+		return defaultKubernetesMaxPodsAzure
 	} else if networkPlugin == networkPluginKubenet {
 		return defaultKubernetesMaxPodsKubenet
 	}

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -42,8 +42,8 @@ import (
 	corecloudprovider "github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 
-	"github.com/Azure/karpenter-provider-azure/pkg/apis/settings"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 
@@ -396,8 +396,8 @@ func (p *Provider) launchInstance(
 		return nil, nil, err
 	}
 
-	sshPublicKey := settings.FromContext(ctx).SSHPublicKey
-	nodeIdentityIDs := settings.FromContext(ctx).NodeIdentities
+	sshPublicKey := options.FromContext(ctx).SSHPublicKey
+	nodeIdentityIDs := options.FromContext(ctx).NodeIdentities
 	vm := newVMObject(resourceName, nicReference, zone, capacityType, p.location, sshPublicKey, nodeIdentityIDs, nodeClass, nodeClaim, launchTemplate, instanceType)
 
 	logging.FromContext(ctx).Debugf("Creating virtual machine %s (%s)", resourceName, instanceType.Name)

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -30,9 +30,9 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
-	"github.com/Azure/karpenter-provider-azure/pkg/apis/settings"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
 	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
@@ -67,9 +67,7 @@ func TestAzure(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	ctx = coreoptions.ToContext(ctx, coretest.Options())
-	// TODO v1beta1 options
-	// ctx = options.ToContext(ctx, test.Options())
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 	env = coretest.NewEnvironment(scheme.Scheme, coretest.WithCRDs(apis.CRDs...))
 
 	ctx, stop = context.WithCancel(ctx)

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -33,7 +33,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 
-	"github.com/Azure/karpenter-provider-azure/pkg/apis/settings"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 
 	"github.com/aws/karpenter-core/pkg/utils/resources"
 )
@@ -316,7 +316,7 @@ func memory(ctx context.Context, sku *skewer.SKU) *resource.Quantity {
 	memory := resources.Quantity(fmt.Sprintf("%dGi", int64(memoryGiB(sku))))
 	// Account for VM overhead in calculation
 	memory.Sub(resource.MustParse(fmt.Sprintf("%dMi", int64(math.Ceil(
-		float64(memory.Value())*settings.FromContext(ctx).VMMemoryOverheadPercent/1024/1024)))))
+		float64(memory.Value())*options.FromContext(ctx).VMMemoryOverheadPercent/1024/1024)))))
 	return memory
 }
 

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -53,14 +53,14 @@ import (
 
 	sdkerrors "github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
-	"github.com/Azure/karpenter-provider-azure/pkg/apis/settings"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
 	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
 	"github.com/Azure/karpenter-provider-azure/pkg/fake"
-	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instancetype"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
@@ -82,7 +82,7 @@ func TestAzure(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	ctx = coreoptions.ToContext(ctx, coretest.Options())
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 
 	env = coretest.NewEnvironment(scheme.Scheme, coretest.WithCRDs(apis.CRDs...))
 
@@ -715,7 +715,7 @@ var _ = Describe("InstanceType Provider", func() {
 
 		BeforeEach(func() {
 			// disable VM memory overhead for simpler capacity testing
-			ctx = settings.ToContext(ctx, test.Settings(test.SettingOptions{
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{
 				VMMemoryOverheadPercent: lo.ToPtr[float64](0),
 			}))
 			instanceTypes, err = azureEnv.InstanceTypesProvider.List(ctx, &corev1beta1.KubeletConfiguration{}, nodeClass)
@@ -849,9 +849,9 @@ var _ = Describe("InstanceType Provider", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 		})
 		It("should have VM identity set", func() {
-			ctx = settings.ToContext(
+			ctx = options.ToContext(
 				ctx,
-				test.Settings(test.SettingOptions{
+				test.Options(test.OptionsFields{
 					NodeIdentities: []string{
 						"/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myid1",
 						"/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myid2",

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -462,7 +462,7 @@ var _ = Describe("InstanceType Provider", func() {
 			Expect(kubeletFlags).To(ContainSubstring("--eviction-hard=memory.available<750Mi")) // AKS default
 			Expect(kubeletFlags).To(ContainSubstring("--eviction-soft=memory.available<1Gi"))
 			Expect(kubeletFlags).To(ContainSubstring("--eviction-soft-grace-period=memory.available=10s"))
-			Expect(kubeletFlags).To(ContainSubstring("--max-pods=100")) // kubenet
+			Expect(kubeletFlags).To(ContainSubstring("--max-pods=250")) // networkPlugin=azure
 			Expect(kubeletFlags).To(ContainSubstring("--pods-per-core=110"))
 			Expect(kubeletFlags).To(ContainSubstring("--image-gc-low-threshold=20"))
 			Expect(kubeletFlags).To(ContainSubstring("--image-gc-high-threshold=30"))
@@ -521,7 +521,7 @@ var _ = Describe("InstanceType Provider", func() {
 			Expect(kubeletFlags).To(ContainSubstring("--eviction-hard=memory.available<750Mi")) // AKS default
 			Expect(kubeletFlags).To(ContainSubstring("--eviction-soft=memory.available<1Gi"))
 			Expect(kubeletFlags).To(ContainSubstring("--eviction-soft-grace-period=memory.available=10s"))
-			Expect(kubeletFlags).To(ContainSubstring("--max-pods=100")) // kubenet
+			Expect(kubeletFlags).To(ContainSubstring("--max-pods=250")) // networkPlugin=azure
 			Expect(kubeletFlags).To(ContainSubstring("--pods-per-core=110"))
 			Expect(kubeletFlags).To(ContainSubstring("--image-gc-low-threshold=20"))
 			Expect(kubeletFlags).To(ContainSubstring("--image-gc-high-threshold=30"))

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -471,13 +471,20 @@ var _ = Describe("InstanceType Provider", func() {
 	})
 
 	Context("Provisioner with KubeletConfig on a kubenet Cluster", func() {
+		var originalOptions *options.Options
+
 		BeforeEach(func() {
+			originalOptions = options.FromContext(ctx)
 			var kubenet = "kubenet"
 			ctx = options.ToContext(
 				ctx,
 				test.Options(test.OptionsFields{
 					NetworkPlugin: &kubenet,
 				}))
+		})
+
+		AfterEach(func() {
+			ctx = options.ToContext(ctx, originalOptions)
 		})
 
 		It("should support provisioning with kubeletConfig, computeResources and maxPods not specified", func() {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -468,65 +468,6 @@ var _ = Describe("InstanceType Provider", func() {
 			Expect(kubeletFlags).To(ContainSubstring("--image-gc-high-threshold=30"))
 			Expect(kubeletFlags).To(ContainSubstring("--cpu-cfs-quota=true"))
 		})
-		It("should support provisioning with kubeletConfig, computeResources and maxPods specified", func() {
-			nodePool.Spec.Template.Spec.Kubelet = &corev1beta1.KubeletConfiguration{
-				PodsPerCore: lo.ToPtr(int32(110)),
-				EvictionSoft: map[string]string{
-					instancetype.MemoryAvailable: "1Gi",
-				},
-				EvictionSoftGracePeriod: map[string]metav1.Duration{
-					instancetype.MemoryAvailable: {Duration: 10 * time.Second},
-				},
-				EvictionMaxPodGracePeriod:   lo.ToPtr(int32(15)),
-				ImageGCHighThresholdPercent: lo.ToPtr(int32(30)),
-				ImageGCLowThresholdPercent:  lo.ToPtr(int32(20)),
-				CPUCFSQuota:                 lo.ToPtr(true),
-
-				SystemReserved: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("200m"),
-					v1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-				KubeReserved: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("100m"),
-					v1.ResourceMemory: resource.MustParse("500Mi"),
-				},
-				EvictionHard: map[string]string{
-					instancetype.MemoryAvailable: "10Mi",
-				},
-				MaxPods: lo.ToPtr(int32(15)),
-			}
-
-			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-			pod := coretest.UnschedulablePod()
-			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
-			ExpectScheduled(ctx, env.Client, pod)
-
-			Expect(azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
-			vm := azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Pop().VM
-			customData := *vm.Properties.OSProfile.CustomData
-			Expect(customData).ToNot(BeNil())
-			decodedBytes, err := base64.StdEncoding.DecodeString(customData)
-			Expect(err).To(Succeed())
-			decodedString := string(decodedBytes[:])
-			kubeletFlags := decodedString[strings.Index(decodedString, "KUBELET_FLAGS=")+len("KUBELET_FLAGS="):]
-
-			Expect(kubeletFlags).To(SatisfyAny( // AKS default
-				ContainSubstring("--system-reserved=cpu=0,memory=0"),
-				ContainSubstring("--system-reserved=memory=0,cpu=0"),
-			))
-			Expect(kubeletFlags).To(SatisfyAny( // AKS calculation based on cpu and memory
-				ContainSubstring("--kube-reserved=cpu=100m,memory=1843Mi"),
-				ContainSubstring("--kube-reserved=memory=1843Mi,cpu=100m"),
-			))
-			Expect(kubeletFlags).To(ContainSubstring("--eviction-hard=memory.available<750Mi")) // AKS default
-			Expect(kubeletFlags).To(ContainSubstring("--eviction-soft=memory.available<1Gi"))
-			Expect(kubeletFlags).To(ContainSubstring("--eviction-soft-grace-period=memory.available=10s"))
-			Expect(kubeletFlags).To(ContainSubstring("--max-pods=250")) // networkPlugin=azure
-			Expect(kubeletFlags).To(ContainSubstring("--pods-per-core=110"))
-			Expect(kubeletFlags).To(ContainSubstring("--image-gc-low-threshold=20"))
-			Expect(kubeletFlags).To(ContainSubstring("--image-gc-high-threshold=30"))
-			Expect(kubeletFlags).To(ContainSubstring("--cpu-cfs-quota=true"))
-		})
 	})
 
 	Context("Provisioner with KubeletConfig on a kubenet Cluster", func() {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -475,11 +475,10 @@ var _ = Describe("InstanceType Provider", func() {
 
 		BeforeEach(func() {
 			originalOptions = options.FromContext(ctx)
-			var kubenet = "kubenet"
 			ctx = options.ToContext(
 				ctx,
 				test.Options(test.OptionsFields{
-					NetworkPlugin: &kubenet,
+					NetworkPlugin: lo.ToPtr("kubenet"),
 				}))
 		})
 

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -27,8 +27,8 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/Azure/karpenter-provider-azure/pkg/apis/settings"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/scheduling"
@@ -101,9 +101,9 @@ func (p *Provider) getStaticParameters(ctx context.Context, instanceType *cloudp
 	}
 
 	return &parameters.StaticParameters{
-		ClusterName:                    settings.FromContext(ctx).ClusterName,
+		ClusterName:                    options.FromContext(ctx).ClusterName,
 		ClusterEndpoint:                p.clusterEndpoint,
-		Tags:                           lo.Assign(settings.FromContext(ctx).Tags, nodeClass.Spec.Tags),
+		Tags:                           nodeClass.Spec.Tags,
 		Labels:                         labels,
 		CABundle:                       p.caBundle,
 		Arch:                           arch,
@@ -115,11 +115,11 @@ func (p *Provider) getStaticParameters(ctx context.Context, instanceType *cloudp
 		UserAssignedIdentityID:         p.userAssignedIdentityID,
 		ResourceGroup:                  p.resourceGroup,
 		Location:                       p.location,
-		ClusterID:                      settings.FromContext(ctx).ClusterID,
-		APIServerName:                  settings.FromContext(ctx).GetAPIServerName(),
-		KubeletClientTLSBootstrapToken: settings.FromContext(ctx).KubeletClientTLSBootstrapToken,
-		NetworkPlugin:                  settings.FromContext(ctx).NetworkPlugin,
-		NetworkPolicy:                  settings.FromContext(ctx).NetworkPolicy,
+		ClusterID:                      options.FromContext(ctx).ClusterID,
+		APIServerName:                  options.FromContext(ctx).GetAPIServerName(),
+		KubeletClientTLSBootstrapToken: options.FromContext(ctx).KubeletClientTLSBootstrapToken,
+		NetworkPlugin:                  options.FromContext(ctx).NetworkPlugin,
+		NetworkPolicy:                  options.FromContext(ctx).NetworkPolicy,
 	}
 }
 

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -50,7 +50,7 @@ func Options(overrides ...OptionsFields) *azoptions.Options {
 		ClusterID:                      lo.FromPtrOr(options.ClusterID, "00000000"),
 		KubeletClientTLSBootstrapToken: lo.FromPtrOr(options.KubeletClientTLSBootstrapToken, "test-token"),
 		SSHPublicKey:                   lo.FromPtrOr(options.SSHPublicKey, "test-ssh-public-key"),
-		NetworkPlugin:                  lo.FromPtrOr(options.NetworkPlugin, "kubenet"),
+		NetworkPlugin:                  lo.FromPtrOr(options.NetworkPlugin, "azure"),
 		NetworkPolicy:                  lo.FromPtrOr(options.NetworkPolicy, ""),
 		VMMemoryOverheadPercent:        lo.FromPtrOr(options.VMMemoryOverheadPercent, 0.075),
 		NodeIdentities:                 options.NodeIdentities,

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -22,10 +22,10 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/samber/lo"
 
-	azsettings "github.com/Azure/karpenter-provider-azure/pkg/apis/settings"
+	azoptions "github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 )
 
-type SettingsFields struct {
+type OptionsFields struct {
 	ClusterName                    *string
 	ClusterEndpoint                *string
 	ClusterID                      *string
@@ -35,17 +35,16 @@ type SettingsFields struct {
 	NetworkPolicy                  *string
 	VMMemoryOverheadPercent        *float64
 	NodeIdentities                 []string
-	Tags                           map[string]string
 }
 
-func Settings(overrides ...SettingsFields) *azsettings.Settings {
-	options := SettingsFields{}
+func Options(overrides ...OptionsFields) *azoptions.Options {
+	options := OptionsFields{}
 	for _, override := range overrides {
 		if err := mergo.Merge(&options, override, mergo.WithOverride); err != nil {
 			panic(fmt.Sprintf("Failed to merge settings: %s", err))
 		}
 	}
-	return &azsettings.Settings{
+	return &azoptions.Options{
 		ClusterName:                    lo.FromPtrOr(options.ClusterName, "test-cluster"),
 		ClusterEndpoint:                lo.FromPtrOr(options.ClusterEndpoint, "https://test-cluster"),
 		ClusterID:                      lo.FromPtrOr(options.ClusterID, "00000000"),
@@ -55,6 +54,5 @@ func Settings(overrides ...SettingsFields) *azsettings.Settings {
 		NetworkPolicy:                  lo.FromPtrOr(options.NetworkPolicy, ""),
 		VMMemoryOverheadPercent:        lo.FromPtrOr(options.VMMemoryOverheadPercent, 0.075),
 		NodeIdentities:                 options.NodeIdentities,
-		Tags:                           options.Tags,
 	}
 }

--- a/pkg/test/settings.go
+++ b/pkg/test/settings.go
@@ -51,7 +51,7 @@ func Settings(overrides ...SettingsFields) *azsettings.Settings {
 		ClusterID:                      lo.FromPtrOr(options.ClusterID, "00000000"),
 		KubeletClientTLSBootstrapToken: lo.FromPtrOr(options.KubeletClientTLSBootstrapToken, "test-token"),
 		SSHPublicKey:                   lo.FromPtrOr(options.SSHPublicKey, "test-ssh-public-key"),
-		NetworkPlugin:                  lo.FromPtrOr(options.NetworkPlugin, "kubenet"),
+		NetworkPlugin:                  lo.FromPtrOr(options.NetworkPlugin, "azure"),
 		NetworkPolicy:                  lo.FromPtrOr(options.NetworkPolicy, ""),
 		VMMemoryOverheadPercent:        lo.FromPtrOr(options.VMMemoryOverheadPercent, 0.075),
 		NodeIdentities:                 options.NodeIdentities,

--- a/test/pkg/environment/azure/setup.go
+++ b/test/pkg/environment/azure/setup.go
@@ -27,7 +27,6 @@ import (
 )
 
 var persistedSettings []v1.EnvVar
-var persistedSettingsLegacy = &v1.ConfigMap{}
 
 var (
 	CleanableObjects = []client.Object{
@@ -37,7 +36,6 @@ var (
 
 func (env *Environment) BeforeEach() {
 	persistedSettings = env.ExpectSettings()
-	persistedSettingsLegacy = env.ExpectSettingsLegacy()
 	env.Environment.BeforeEach()
 }
 
@@ -52,5 +50,4 @@ func (env *Environment) AfterEach() {
 	env.Environment.AfterEach()
 	// Ensure we reset settings after collecting the controller logs
 	env.ExpectSettingsReplaced(persistedSettings...)
-	env.ExpectSettingsReplacedLegacy(persistedSettingsLegacy.Data)
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number --> N/A

**Description**

**Context:**
- Following karpenter-core's effort, we are migrating away from `Settings` to `Options`
  - `Settings`, from pkg/api/settings = karpenter-global-settings ConfigMap
  - `Options`, from pkg/operator/options = flags OR environment variables
- At the time between "introducing `Options`", which is this PR, and the breaking API change in v0.33(?), which removed ConfigMap support entirely, we will support either options, with `Options` taking precedence

**Expected impact from this change:**
- `Options`: flags and environment variables is now supported as an alternative for all values currently utilizing the ConfigMap
  - ConfigMap can be safely removed once we create the container using flags or environment variables

**Non-impact:**
- ConfigMap is still supported, but `Options` taking precedence if both exists
- E2Es and charts are still using ConfigMap until the API update that removes `Settings` entirely

**Additional changes**
- A `networkPlugin` constant in `imagefamily` package was incorrectly set to "overlay" rather than "azure"
  - Its primary use is to determine the maximum number of pods, since Azure CNI allow more number of pods than `kubenet`
  - The change to use `Options` also reworked the default values in unit test, thus this gap/bug was exposed
  - This PR also include the fix for that constant, as well as additional cases in that unit test


**How was this change tested?**

* Manually test basic scale up-down for Karpenter deployed using environment variables
* E2E for both Karpenter deployed using ConfigMap and environment variables

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
- `Options`: flags and environment variables is now supported as an alternative for all values currently utilizing the ConfigMap
  - ConfigMap can be safely removed once we create the container using flags or environment variables
```
