### PR TITLE
test(e2e): change to eastus

### DIFF
--- a/.github/actions/e2e/create-acr/action.yaml
+++ b/.github/actions/e2e/create-acr/action.yaml
@@ -22,7 +22,7 @@ inputs:
   location:
     type: string
     description: "the azure location to run the e2e test in"
-    default: "westus2"
+    default: "eastus"
 runs:
   using: "composite"
   steps:

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -29,7 +29,7 @@ inputs:
   location:
     type: string
     description: "the azure location to run the e2e test in"
-    default: "westus2"
+    default: "eastus"
 runs:
   using: "composite"
   steps:

--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -28,7 +28,7 @@ inputs:
   location:
     type: string
     description: "the azure location to run the e2e test in"
-    default: "westus2"
+    default: "eastus"
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -5,7 +5,7 @@ on:
       location:
         type: string
         description: "the azure location to run the e2e test in"
-        default: "westus2"
+        default: "eastus"
   push:
     branches: [main]
   workflow_run:
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/e2e-matrix.yaml
     with:
       git_ref: ${{ needs.resolve.outputs.GIT_REF }}
-      location: ${{ inputs.location || 'westus2' }}
+      location: ${{ inputs.location || 'eastus' }}
     secrets:
       E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}
       E2E_TENANT_ID: ${{ secrets.E2E_TENANT_ID }}

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -7,7 +7,7 @@ on:
       location:
         type: string
         description: "the azure location to run the e2e test in"
-        default: "westus2"
+        default: "eastus"
   #     k8s_version:
   #       type: string
   #       default: "1.27"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,7 @@ on:
       location:
         type: string
         description: "the azure location to run the e2e test in"
-        default: "westus2"
+        default: "eastus"
     #   k8s_version:
     #     type: string
     #     default: "1.27"


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
`eastus` should be a better region for our testing, so changing over our defaults.

**How was this change tested?**
Did this test with manual input of `eastus`:
- https://github.com/Azure/karpenter-provider-azure/actions/runs/7659927013

Additionally, running the `/test` as normal.
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
