### PR TITLE
fix(ci): tighten GHA permissions

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -10,8 +10,7 @@ on:
         type: string
 
 permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
+  contents: read
 
 env:
   REGISTRY_REPO: unlisted/aks/karpenter
@@ -41,6 +40,8 @@ jobs:
           echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
 
   publish-images:
+    permissions:
+      id-token: write # This is required for requesting the JWT
     runs-on: ubuntu-latest
     needs: prepare-variables
     steps:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -4,8 +4,12 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   ci-test:
+    permissions:
+      statuses: write
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read    
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -3,9 +3,14 @@ on:
   schedule:
     - cron: '0 12 * * *'
   workflow_dispatch:
+
+permissions:
+  contents: read
 jobs:
   deflake:
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1

--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -11,15 +11,18 @@ on:
   workflow_run:
     workflows: [ApprovalComment]
     types: [completed]
+
 permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
-  statuses: write # ./.github/actions/commit-status/*
+  contents: read
+
 jobs:
   resolve:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/resolve-args.yaml
   e2e-matrix:
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      statuses: write # ./.github/actions/commit-status/*          
     needs: [resolve]
     uses: ./.github/workflows/e2e-matrix.yaml
     with:

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -18,6 +18,10 @@ on:
         required: true
       E2E_SUBSCRIPTION_ID:
         required: true
+
+permissions:
+  contents: read
+        
 jobs:
   initialize-generative-params:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,14 +24,17 @@ on:
         required: true
       E2E_SUBSCRIPTION_ID:
         required: true
+
 permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
-  statuses: write # ./.github/actions/commit-status/*
+  contents: read
+
 jobs:
   run-suite:
     name: suite-${{ inputs.suite }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      statuses: write # ./.github/actions/commit-status/*      
     env:
       AZURE_SUBSCRIPTION_ID: ${{ secrets.E2E_SUBSCRIPTION_ID }}
     steps:

--- a/.github/workflows/resolve-args.yaml
+++ b/.github/workflows/resolve-args.yaml
@@ -4,6 +4,10 @@ on:
     outputs:
       GIT_REF:
         value: ${{ jobs.resolve.outputs.GIT_REF }}
+
+permissions:
+  contents: read
+  
 jobs:
   resolve:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

This tightens the permissions on GitHub Actions, prepping for expected changes to GITHUB_TOKEN. Should resolve all high Token-Permissions security code scanning alerts (https://github.com/Azure/karpenter-provider-azure/security/code-scanning?query=Token-Permissions+is%3Aopen+branch%3Amain+severity%3Ahigh)

**How was this change tested?**

* To be tested in CI

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
