### PR TITLE
test(e2e): disable known GPU Quota failing E2E test for now

### DIFF
--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -22,7 +22,7 @@ az-login: ## Login into Azure
 	az account set --subscription $(AZURE_SUBSCRIPTION_ID)
 
 az-mkrg: ## Create resource group
-	if ! az group exists --name $(AZURE_RESOURCE_GROUP) -o none; then \
+	if ! az group exists --name $(AZURE_RESOURCE_GROUP); then \
 		az group create --name $(AZURE_RESOURCE_GROUP) --location $(AZURE_LOCATION) -o none; \
 	fi
 

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -22,7 +22,7 @@ az-login: ## Login into Azure
 	az account set --subscription $(AZURE_SUBSCRIPTION_ID)
 
 az-mkrg: ## Create resource group
-	if [ "$(az group exists --name $(AZURE_RESOURCE_GROUP))" = "false" ]; then \
+	if [ $(az group exists --name $(AZURE_RESOURCE_GROUP)) = "false" ]; then \
 		az group create --name $(AZURE_RESOURCE_GROUP) --location $(AZURE_LOCATION); \
 	fi
 

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -22,7 +22,7 @@ az-login: ## Login into Azure
 	az account set --subscription $(AZURE_SUBSCRIPTION_ID)
 
 az-mkrg: ## Create resource group
-	if [ az group exists --name $(AZURE_RESOURCE_GROUP) = "false" ]; then \
+	if [ "$(az group exists --name $(AZURE_RESOURCE_GROUP))" = "false" ]; then \
 		az group create --name $(AZURE_RESOURCE_GROUP) --location $(AZURE_LOCATION); \
 	fi
 

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -22,7 +22,7 @@ az-login: ## Login into Azure
 	az account set --subscription $(AZURE_SUBSCRIPTION_ID)
 
 az-mkrg: ## Create resource group
-	if [ az group exists --name $(AZURE_RESOURCE_GROUP) -eq "false" ]; then \
+	if [ az group exists --name $(AZURE_RESOURCE_GROUP) = "false" ]; then \
 		az group create --name $(AZURE_RESOURCE_GROUP) --location $(AZURE_LOCATION); \
 	fi
 

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -22,8 +22,8 @@ az-login: ## Login into Azure
 	az account set --subscription $(AZURE_SUBSCRIPTION_ID)
 
 az-mkrg: ## Create resource group
-	if ! az group exists --name $(AZURE_RESOURCE_GROUP); then \
-		az group create --name $(AZURE_RESOURCE_GROUP) --location $(AZURE_LOCATION) -o none; \
+	if [ az group exists --name $(AZURE_RESOURCE_GROUP) -eq "false" ]; then \
+		az group create --name $(AZURE_RESOURCE_GROUP) --location $(AZURE_LOCATION); \
 	fi
 
 az-mkacr: az-mkrg ## Create test ACR

--- a/test/suites/gpu/suite_test.go
+++ b/test/suites/gpu/suite_test.go
@@ -93,7 +93,9 @@ var _ = Describe("GPU", func() {
 			env.EventuallyExpectHealthyPodCountWithTimeout(time.Minute*15, labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), int(*deployment.Spec.Replicas))
 			env.ExpectCreatedNodeCount("==", int(*deployment.Spec.Replicas))
 		},
-		Entry("should provision one GPU Node and one GPU Pod (AzureLinux)", env.AZLinuxNodeClass()),
+		// DISABLED by charliedmcb.
+		// TODO: This test is experiencing known Quota issues, which @Bryce-Soghigian is working to resolve (re-enable after quota issues are solved)
+		XEntry("should provision one GPU Node and one GPU Pod (AzureLinux)", env.AZLinuxNodeClass()),
 		Entry("should provision one GPU Node and one GPU Pod (Ubuntu2204)", env.DefaultAKSNodeClass()),
 	)
 })


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
This test case is consistently failing due to a quota related issue.

@Bryce-Soghigian is working on unblocking the quota issue. However, in the meantime it makes sense to disable this test rather than pollute our runs with known failures.

**How was this change tested?**
Nothing additional
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
