### PR TITLE
chore: az-mkrg fix

### DIFF
--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -22,7 +22,7 @@ az-login: ## Login into Azure
 	az account set --subscription $(AZURE_SUBSCRIPTION_ID)
 
 az-mkrg: ## Create resource group
-	if ! az group exists --name $(AZURE_RESOURCE_GROUP) -o none; then \
+	if az group exists --name $(AZURE_RESOURCE_GROUP) | grep -q "false"; then \
 		az group create --name $(AZURE_RESOURCE_GROUP) --location $(AZURE_LOCATION) -o none; \
 	fi
 


### PR DESCRIPTION
**Description**
Follow-up to #131. Currently the e2e test suite + local dev via `make az-all` is blocked by this. The if condition was always evaluating as true, because non-empty strings in bash are truthy.

**How was this change tested?**
* `make az-mkrg`, e2e suite (passed, except for utilization, not due to this issue)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No
