### PR TITLE
feat: FIPS compliance in karpenter via the 2004 ImageFamily of community images. 

### DIFF
--- a/examples/v1beta1/general-purpose.yaml
+++ b/examples/v1beta1/general-purpose.yaml
@@ -34,4 +34,5 @@ metadata:
   annotations:
     kubernetes.io/description: "General purpose AKSNodeClass for running Ubuntu2204 nodes"
 spec:
+  # Supported Values: AzureLinux, Ubuntu2204, Ubuntu2004
   imageFamily: Ubuntu2204

--- a/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
@@ -51,6 +51,7 @@ spec:
                 description: ImageFamily is the image family that instances use.
                 enum:
                 - Ubuntu2204
+                - Ubuntu2004
                 - AzureLinux
                 type: string
               imageVersion:

--- a/pkg/apis/v1alpha2/aksnodeclass.go
+++ b/pkg/apis/v1alpha2/aksnodeclass.go
@@ -36,7 +36,7 @@ type AKSNodeClassSpec struct {
 	ImageID *string `json:"-"`
 	// ImageFamily is the image family that instances use.
 	// +kubebuilder:default=Ubuntu2204
-	// +kubebuilder:validation:Enum:={Ubuntu2204,AzureLinux}
+	// +kubebuilder:validation:Enum:={Ubuntu2204,Ubuntu2004,AzureLinux}
 	ImageFamily *string `json:"imageFamily,omitempty"`
 	// ImageVersion is the image version that instances use.
 	// +optional

--- a/pkg/apis/v1alpha2/labels.go
+++ b/pkg/apis/v1alpha2/labels.go
@@ -125,5 +125,6 @@ var (
 
 const (
 	Ubuntu2204ImageFamily = "Ubuntu2204"
+	Ubuntu2004ImageFamily = "Ubuntu2004"
 	AzureLinuxImageFamily = "AzureLinux"
 )

--- a/pkg/providers/imagefamily/resolver.go
+++ b/pkg/providers/imagefamily/resolver.go
@@ -115,6 +115,8 @@ func getImageFamily(familyName *string, parameters *template.StaticParameters) I
 	switch lo.FromPtr(familyName) {
 	case v1alpha2.Ubuntu2204ImageFamily:
 		return &Ubuntu2204{Options: parameters}
+	case v1alpha2.Ubuntu2004ImageFamily:
+		return &Ubuntu2004{Options: parameters}
 	case v1alpha2.AzureLinuxImageFamily:
 		return &AzureLinux{Options: parameters}
 	default:

--- a/pkg/providers/imagefamily/ubuntu_2004.go
+++ b/pkg/providers/imagefamily/ubuntu_2004.go
@@ -1,0 +1,83 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagefamily
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/bootstrap"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/launchtemplate/parameters"
+
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-core/pkg/cloudprovider"
+	"github.com/aws/karpenter-core/pkg/scheduling"
+)
+
+const (
+	Ubuntu2004Gen1FipsCommunityImage = "2004fipscontainerd"
+)
+
+type Ubuntu2004 struct {
+	Options *parameters.StaticParameters
+}
+
+func (u Ubuntu2004) Name() string {
+	return v1alpha2.Ubuntu2004ImageFamily
+}
+
+func (u Ubuntu2004) DefaultImages() []DefaultImageOutput {
+	return []DefaultImageOutput{
+		{
+			CommunityImage:   Ubuntu2004Gen1FipsCommunityImage,
+			PublicGalleryURL: AKSUbuntuPublicGalleryURL,
+			Requirements: scheduling.NewRequirements(
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureAmd64),
+				scheduling.NewRequirement(v1alpha2.LabelSKUHyperVGeneration, v1.NodeSelectorOpIn, v1alpha2.HyperVGenerationV1),
+			),
+		},
+	}
+}
+
+// UserData returns the default userdata script for the image Family
+func (u Ubuntu2004) UserData(kubeletConfig *corev1beta1.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ *cloudprovider.InstanceType) bootstrap.Bootstrapper {
+	return bootstrap.AKS{
+		Options: bootstrap.Options{
+			ClusterName:      u.Options.ClusterName,
+			ClusterEndpoint:  u.Options.ClusterEndpoint,
+			KubeletConfig:    kubeletConfig,
+			Taints:           taints,
+			Labels:           labels,
+			CABundle:         caBundle,
+			GPUNode:          u.Options.GPUNode,
+			GPUDriverVersion: u.Options.GPUDriverVersion,
+			GPUImageSHA:      u.Options.GPUImageSHA,
+		},
+		Arch:                           u.Options.Arch,
+		TenantID:                       u.Options.TenantID,
+		SubscriptionID:                 u.Options.SubscriptionID,
+		Location:                       u.Options.Location,
+		UserAssignedIdentityID:         u.Options.UserAssignedIdentityID,
+		ResourceGroup:                  u.Options.ResourceGroup,
+		ClusterID:                      u.Options.ClusterID,
+		APIServerName:                  u.Options.APIServerName,
+		KubeletClientTLSBootstrapToken: u.Options.KubeletClientTLSBootstrapToken,
+		NetworkPlugin:                  u.Options.NetworkPlugin,
+		NetworkPolicy:                  u.Options.NetworkPolicy,
+		KubernetesVersion:              u.Options.KubernetesVersion,
+	}
+}

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -903,6 +903,7 @@ var _ = Describe("InstanceType Provider", func() {
 				"Standard_D2_v3", v1alpha2.AzureLinuxImageFamily, imagefamily.AzureLinuxGen1CommunityImage, imagefamily.AKSAzureLinuxPublicGalleryURL),
 			Entry("ARM instance type with AzureLinux image family",
 				"Standard_D16plds_v5", v1alpha2.AzureLinuxImageFamily, imagefamily.AzureLinuxGen2ArmCommunityImage, imagefamily.AKSAzureLinuxPublicGalleryURL),
+			Entry("Gen 1 Fips Compliant instance type with AKSUbuntu2004", "Standard_D2_v3", v1alpha2.Ubuntu2004ImageFamily, imagefamily.Ubuntu2004Gen1FipsCommunityImage, imagefamily.AKSUbuntuPublicGalleryURL),
 		)
 	})
 	Context("Instance Types", func() {


### PR DESCRIPTION
ci

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
This PR adds the 2204 ImageFamily which contains the fips images. For now starting with just the fips image and no filtering or CR changes. 

Note that fips is only compatible with Gen1 HyperVGeneration. 

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
