### PR TITLE
fix: add topology.disk.csi.azure.com/zone to normalized labels

### DIFF
--- a/pkg/apis/v1alpha2/labels.go
+++ b/pkg/apis/v1alpha2/labels.go
@@ -33,9 +33,6 @@ func init() {
 		LabelSKUMemory,
 		LabelSKUAccelerator,
 
-		LabelSKUConfidential,
-		LabelSKUIsolatedSize,
-
 		LabelSKUAcceleratedNetworking,
 
 		LabelSKUStoragePremiumCapable,
@@ -88,10 +85,6 @@ var (
 	LabelSKUAccelerator = Group + "/sku-accelerator"
 
 	// selected capabilities (from additive features in VM size name, or from SKU capabilities)
-	// https://learn.microsoft.com/en-us/azure/virtual-machines/vm-naming-conventions
-	LabelSKUConfidential = Group + "/sku-confidential"  // c
-	LabelSKUIsolatedSize = Group + "/sku-isolated-size" // i
-
 	LabelSKUAcceleratedNetworking = Group + "/sku-networking-accelerated" // sku.AcceleratedNetworkingEnabled
 
 	LabelSKUStoragePremiumCapable     = Group + "/sku-storage-premium-capable"     // sku.IsPremiumIO
@@ -113,11 +106,6 @@ var (
 	AKSLabelDomain = "kubernetes.azure.com"
 
 	AKSLabelCluster = AKSLabelDomain + "/cluster"
-
-	SkuFeatureToLabel = map[rune]string{
-		'c': LabelSKUConfidential,
-		'i': LabelSKUIsolatedSize,
-	}
 )
 
 const (

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -23,9 +23,11 @@ import (
 
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 	"knative.dev/pkg/ptr"
+	corev1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	"sigs.k8s.io/karpenter/pkg/operator/scheme"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
@@ -43,6 +45,7 @@ import (
 
 func init() {
 	lo.Must0(apis.AddToScheme(scheme.Scheme))
+	corev1beta1.NormalizedLabels = lo.Assign(corev1beta1.NormalizedLabels, map[string]string{"topology.disk.csi.azure.com/zone": corev1.LabelTopologyZone})
 }
 
 type Operator struct {

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -135,7 +135,7 @@ func NewInstanceType(ctx context.Context, sku *skewer.SKU, vmsize *skewer.VMSize
 
 func computeRequirements(sku *skewer.SKU, vmsize *skewer.VMSizeType, architecture string,
 	offerings cloudprovider.Offerings, region string) scheduling.Requirements {
-	requirements := scheduling.NewRequirements(
+		requirements := scheduling.NewRequirements(
 		// Well Known Upstream
 		scheduling.NewRequirement(v1.LabelInstanceTypeStable, v1.NodeSelectorOpIn, sku.GetName()),
 		scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, getArchitecture(architecture)),
@@ -183,12 +183,6 @@ func computeRequirements(sku *skewer.SKU, vmsize *skewer.VMSizeType, architectur
 	// size parts
 	requirements[v1alpha2.LabelSKUFamily].Insert(vmsize.Family)
 
-	// everything from additive features
-	for _, featureLabel := range v1alpha2.SkuFeatureToLabel {
-		requirements.Add(scheduling.NewRequirement(featureLabel, v1.NodeSelectorOpDoesNotExist))
-	}
-
-	setRequirementsAdditiveFeatures(requirements, vmsize)
 	setRequirementsStoragePremiumCapable(requirements, sku)
 	setRequirementsEncryptionAtHostSupported(requirements, sku)
 	setRequirementsEphemeralOSDiskSupported(requirements, sku, vmsize)
@@ -201,13 +195,7 @@ func computeRequirements(sku *skewer.SKU, vmsize *skewer.VMSizeType, architectur
 	return requirements
 }
 
-func setRequirementsAdditiveFeatures(requirements scheduling.Requirements, vmsize *skewer.VMSizeType) {
-	for _, feature := range vmsize.AdditiveFeatures {
-		if featureLabel, ok := v1alpha2.SkuFeatureToLabel[feature]; ok {
-			requirements[featureLabel].Insert("true")
-		}
-	}
-}
+
 
 func setRequirementsStoragePremiumCapable(requirements scheduling.Requirements, sku *skewer.SKU) {
 	if sku.IsPremiumIO() {

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -135,7 +135,7 @@ func NewInstanceType(ctx context.Context, sku *skewer.SKU, vmsize *skewer.VMSize
 
 func computeRequirements(sku *skewer.SKU, vmsize *skewer.VMSizeType, architecture string,
 	offerings cloudprovider.Offerings, region string) scheduling.Requirements {
-		requirements := scheduling.NewRequirements(
+	requirements := scheduling.NewRequirements(
 		// Well Known Upstream
 		scheduling.NewRequirement(v1.LabelInstanceTypeStable, v1.NodeSelectorOpIn, sku.GetName()),
 		scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, getArchitecture(architecture)),
@@ -194,8 +194,6 @@ func computeRequirements(sku *skewer.SKU, vmsize *skewer.VMSizeType, architectur
 
 	return requirements
 }
-
-
 
 func setRequirementsStoragePremiumCapable(requirements scheduling.Requirements, sku *skewer.SKU) {
 	if sku.IsPremiumIO() {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -835,14 +835,12 @@ var _ = Describe("InstanceType Provider", func() {
 				v1alpha2.LabelSKUAcceleratedNetworking:     "true",
 				v1alpha2.LabelSKUEncryptionAtHostSupported: "true",
 				v1alpha2.LabelSKUStoragePremiumCapable:     "true",
-				v1alpha2.AKSLabelCluster:                   "test-cluster",
 				v1alpha2.LabelSKUGPUName:                   "A100",
 				v1alpha2.LabelSKUGPUManufacturer:           "nvidia",
 				v1alpha2.LabelSKUGPUCount:                  "1",
 				v1alpha2.LabelSKUCPU:                       "24",
 				v1alpha2.LabelSKUMemory:                    "8192",
 				v1alpha2.LabelSKUAccelerator:               "A100",
-
 				// Deprecated Labels
 				v1.LabelFailureDomainBetaRegion:    fake.Region,
 				v1.LabelFailureDomainBetaZone:      fmt.Sprintf("%s-1", fake.Region),
@@ -851,6 +849,8 @@ var _ = Describe("InstanceType Provider", func() {
 				v1.LabelInstanceType:               "Standard_NC24ads_A100_v4",
 				"topology.disk.csi.azure.com/zone": fmt.Sprintf("%s-1", fake.Region),
 				v1.LabelWindowsBuild:               "window",
+				// Cluster Label
+				v1alpha2.AKSLabelCluster: "test-cluster",
 			}
 
 			// Ensure that we're exercising all well known labels

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -818,9 +818,9 @@ var _ = Describe("InstanceType Provider", func() {
 
 			nodeSelector := map[string]string{
 				// Well known
-				v1.LabelTopologyRegion:           "test-region-1",
+				v1.LabelTopologyRegion:           fake.Region,
 				corev1beta1.NodePoolLabelKey:     nodePool.Name,
-				v1.LabelTopologyZone:             "test-zone-1a",
+				v1.LabelTopologyZone:             fmt.Sprintf("%s-1", fake.Region),
 				v1.LabelInstanceTypeStable:       "Standard_NC24ads_A100_v4",
 				v1.LabelOSStable:                 "linux",
 				v1.LabelArchStable:               "amd64",
@@ -829,29 +829,27 @@ var _ = Describe("InstanceType Provider", func() {
 				v1alpha2.LabelSKUName:                      "Standard_NC24ads_A100_v4",
 				v1alpha2.LabelSKUFamily:                    "N",
 				v1alpha2.LabelSKUVersion:                   "4",
-				v1alpha2.LabelSKUConfidential:              "false",
-				v1alpha2.LabelSKUStorageCacheSize:          "0",
+				v1alpha2.LabelSKUStorageCacheSize:          "0", // Either Temp disk or cache disk can be empty :)
 				v1alpha2.LabelSKUStorageTempMaxSize:        "0",
-				v1alpha2.LabelSKUStorageEphemeralOSMaxSize: "0",
+				v1alpha2.LabelSKUStorageEphemeralOSMaxSize: "53.6870912",
 				v1alpha2.LabelSKUAcceleratedNetworking:     "true",
 				v1alpha2.LabelSKUEncryptionAtHostSupported: "true",
 				v1alpha2.LabelSKUStoragePremiumCapable:     "true",
-				v1alpha2.LabelSKUIsolatedSize:              "false",
 				v1alpha2.AKSLabelCluster:                   "test-cluster",
 				v1alpha2.LabelSKUGPUName:                   "A100",
-				v1alpha2.LabelSKUGPUManufacturer:           "NVIDIA",
-				v1alpha2.LabelSKUGPUCount:                  "4",
-				v1alpha2.LabelSKUCPU:                       "96",
-				v1alpha2.LabelSKUMemory:                    "384",
+				v1alpha2.LabelSKUGPUManufacturer:           "nvidia",
+				v1alpha2.LabelSKUGPUCount:                  "1",
+				v1alpha2.LabelSKUCPU:                       "24",
+				v1alpha2.LabelSKUMemory:                    "8192",
 				v1alpha2.LabelSKUAccelerator:               "A100",
 
 				// Deprecated Labels
-				v1.LabelFailureDomainBetaRegion:    "westus",
-				v1.LabelFailureDomainBetaZone:      "test-zone-1a",
+				v1.LabelFailureDomainBetaRegion:    fake.Region,
+				v1.LabelFailureDomainBetaZone:      fmt.Sprintf("%s-1", fake.Region),
 				"beta.kubernetes.io/arch":          "amd64",
 				"beta.kubernetes.io/os":            "linux",
 				v1.LabelInstanceType:               "Standard_NC24ads_A100_v4",
-				"topology.disk.csi.azure.com/zone": "test-zone-1a",
+				"topology.disk.csi.azure.com/zone": fmt.Sprintf("%s-1", fake.Region),
 				v1.LabelWindowsBuild:               "window",
 			}
 

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -19,6 +19,9 @@ package test
 import (
 	"context"
 
+	"github.com/samber/lo"
+	
+	corev1 "k8s.io/api/core/v1"
 	azurecache "github.com/Azure/karpenter-provider-azure/pkg/cache"
 	"github.com/Azure/karpenter-provider-azure/pkg/fake"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
@@ -30,11 +33,16 @@ import (
 	"github.com/patrickmn/go-cache"
 	"knative.dev/pkg/ptr"
 
+	corev1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
 )
 
-var resourceGroup = "test-resourceGroup"
 
+func init() { 
+		corev1beta1.NormalizedLabels = lo.Assign(corev1beta1.NormalizedLabels, map[string]string{"topology.disk.csi.azure.com/zone": corev1.LabelTopologyZone})
+}
+
+var resourceGroup = "test-resourceGroup"
 type Environment struct {
 	// API
 	VirtualMachinesAPI          *fake.VirtualMachinesAPI

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -20,8 +20,7 @@ import (
 	"context"
 
 	"github.com/samber/lo"
-	
-	corev1 "k8s.io/api/core/v1"
+
 	azurecache "github.com/Azure/karpenter-provider-azure/pkg/cache"
 	"github.com/Azure/karpenter-provider-azure/pkg/fake"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
@@ -31,18 +30,19 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing"
 	"github.com/patrickmn/go-cache"
+	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/ptr"
 
 	corev1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
 )
 
-
-func init() { 
-		corev1beta1.NormalizedLabels = lo.Assign(corev1beta1.NormalizedLabels, map[string]string{"topology.disk.csi.azure.com/zone": corev1.LabelTopologyZone})
+func init() {
+	corev1beta1.NormalizedLabels = lo.Assign(corev1beta1.NormalizedLabels, map[string]string{"topology.disk.csi.azure.com/zone": corev1.LabelTopologyZone})
 }
 
 var resourceGroup = "test-resourceGroup"
+
 type Environment struct {
 	// API
 	VirtualMachinesAPI          *fake.VirtualMachinesAPI


### PR DESCRIPTION
fix: adding topology label to normalized labels

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
workload using topology.disk-csi-azure.com/zone in node affinity would fail to schedule. Karpenter has a concept for translating these labels in its scheduling code to normalize the values. This PR Changes topology.disk.csi.azure.com to map to the standard topology label. 

This PR also adds additional testing around well known labels and pod node selector requests. This discovered the unimplemented Isolated size and Confidential well known labels we expose. Removing them until we have more concrete usecases for them. They are not in the docs so no docs update required. 

**How was this change tested?**
Scale up, workload with `topology.disk.csi.azure.com/zone1 schedules fine. 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
