### PR TITLE
perf: migrate knative logger to controller-runtime injected logger

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ We have three types of testing:
 ### What should be used for logging?
 * [klog](https://github.com/search?q=repo%3AAzure%2Fkarpenter%20klog&type=code) is only invoked when creating clients or authorizers.
 * [zapr](https://github.com/search?q=repo%3AAzure%2Fkarpenter%20zap&type=code) is only invoked in our debug package.
-* [knative.dev/pkg/logging](https://pkg.go.dev/knative.dev/pkg/logging) _should_ be used everywhere else.
+* [sigs.k8s.io/controller-runtime/pkg/log](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/log) _should_ be used everywhere else.
 
 ### What is `skaffold.yaml`?
 [skaffold.yaml](https://github.com/Azure/karpenter/blob/main/skaffold.yaml) is the configuration file for deploying Karpenter locally via [skaffold](https://skaffold.dev/docs/).

--- a/pkg/apis/v1alpha2/suite_test.go
+++ b/pkg/apis/v1alpha2/suite_test.go
@@ -22,7 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "knative.dev/pkg/logging/testing"
 
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 
@@ -31,6 +30,7 @@ import (
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
+	. "github.com/Azure/karpenter-provider-azure/pkg/utils"
 )
 
 var ctx context.Context

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/patrickmn/go-cache"
-	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 )
 
@@ -69,12 +69,12 @@ func (u *UnavailableOfferings) MarkSpotUnavailableWithTTL(ctx context.Context, t
 // MarkUnavailableWithTTL allows us to mark an offering unavailable with a custom TTL
 func (u *UnavailableOfferings) MarkUnavailableWithTTL(ctx context.Context, unavailableReason, instanceType, zone, capacityType string, ttl time.Duration) {
 	// even if the key is already in the cache, we still need to call Set to extend the cached entry's TTL
-	logging.FromContext(ctx).With(
+	log.FromContext(ctx).V(1).WithValues(
 		"unavailable", unavailableReason,
 		"instance-type", instanceType,
 		"zone", zone,
 		"capacity-type", capacityType,
-		"ttl", ttl).Debugf("removing offering from offerings")
+		"ttl", ttl).Info("removing offering from offerings")
 	u.cache.Set(key(instanceType, zone, capacityType), struct{}{}, ttl)
 }
 

--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
@@ -41,7 +41,7 @@ const (
 )
 
 func (c *CloudProvider) isK8sVersionDrifted(ctx context.Context, nodeClaim *corev1beta1.NodeClaim) (cloudprovider.DriftReason, error) {
-	logger := logging.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	nodeName := nodeClaim.Status.NodeName
 
@@ -62,7 +62,7 @@ func (c *CloudProvider) isK8sVersionDrifted(ctx context.Context, nodeClaim *core
 
 	nodeK8sVersion := strings.TrimPrefix(n.Status.NodeInfo.KubeletVersion, "v")
 	if nodeK8sVersion != k8sVersion {
-		logger.Debugf("drift triggered for %s, with expected k8s version %s, and actual k8s version %s", K8sVersionDrift, k8sVersion, nodeK8sVersion)
+		logger.V(1).Info("drift triggered for %s, with expected k8s version %s, and actual k8s version %s", K8sVersionDrift, k8sVersion, nodeK8sVersion)
 		return K8sVersionDrift, nil
 	}
 	return "", nil
@@ -74,7 +74,7 @@ func (c *CloudProvider) isK8sVersionDrifted(ctx context.Context, nodeClaim *core
 // nolint: gocyclo
 func (c *CloudProvider) isImageVersionDrifted(
 	ctx context.Context, nodeClaim *corev1beta1.NodeClaim, nodeClass *v1alpha2.AKSNodeClass) (cloudprovider.DriftReason, error) {
-	logger := logging.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	id, err := utils.GetVMName(nodeClaim.Status.ProviderID)
 	if err != nil {
@@ -97,7 +97,7 @@ func (c *CloudProvider) isImageVersionDrifted(
 		vm.Properties.StorageProfile.ImageReference == nil ||
 		vm.Properties.StorageProfile.ImageReference.CommunityGalleryImageID == nil ||
 		*vm.Properties.StorageProfile.ImageReference.CommunityGalleryImageID == "" {
-		logger.Debug("not using a CommunityGalleryImageID for nodeClaim %s", nodeClaim.Name)
+		logger.V(1).Info("not using a CommunityGalleryImageID for nodeClaim %s", nodeClaim.Name)
 		return "", nil
 	}
 
@@ -114,7 +114,7 @@ func (c *CloudProvider) isImageVersionDrifted(
 	}
 
 	if vmImageID != expectedImageID {
-		logger.Debugf("drift triggered for %s, with expected image id %s, and actual image id %s", ImageVersionDrift, expectedImageID, vmImageID)
+		logger.V(1).Info("drift triggered for %s, with expected image id %s, and actual image id %s", ImageVersionDrift, expectedImageID, vmImageID)
 		return ImageVersionDrift, nil
 	}
 	return "", nil

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -41,7 +41,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/operator/scheme"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
 
-	. "knative.dev/pkg/logging/testing"
+	. "github.com/Azure/karpenter-provider-azure/pkg/utils"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -19,8 +19,8 @@ package controllers
 import (
 	"context"
 
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/karpenter/pkg/operator/controller"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
@@ -31,7 +31,7 @@ import (
 )
 
 func NewControllers(ctx context.Context, kubeClient client.Client, cloudProvider *cloudprovider.CloudProvider, instanceProvider *instance.Provider) []controller.Controller {
-	logging.FromContext(ctx).With("version", project.Version).Debugf("discovered version")
+	log.FromContext(ctx).V(1).WithValues("version", project.Version).Info("discovered version")
 	controllers := []controller.Controller{
 		nodeclaimgarbagecollection.NewController(kubeClient, cloudProvider),
 		inplaceupdate.NewController(kubeClient, instanceProvider),

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -27,8 +27,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -91,11 +91,11 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 }
 
 func (c *Controller) garbageCollect(ctx context.Context, nodeClaim *corev1beta1.NodeClaim, nodeList *v1.NodeList) error {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("provider-id", nodeClaim.Status.ProviderID))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("provider-id", nodeClaim.Status.ProviderID))
 	if err := c.cloudProvider.Delete(ctx, nodeClaim); err != nil {
 		return corecloudprovider.IgnoreNodeClaimNotFoundError(err)
 	}
-	logging.FromContext(ctx).Debugf("garbage collected cloudprovider instance")
+	log.FromContext(ctx).V(1).Info("garbage collected cloudprovider instance")
 
 	// Go ahead and cleanup the node if we know that it exists to make scheduling go quicker
 	if node, ok := lo.Find(nodeList.Items, func(n v1.Node) bool {
@@ -104,7 +104,7 @@ func (c *Controller) garbageCollect(ctx context.Context, nodeClaim *corev1beta1.
 		if err := c.kubeClient.Delete(ctx, &node); err != nil {
 			return client.IgnoreNotFound(err)
 		}
-		logging.FromContext(ctx).With("node", node.Name).Debugf("garbage collected node")
+		log.FromContext(ctx).V(1).WithValues("node", node.Name).Info("garbage collected node")
 	}
 	return nil
 }

--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -32,12 +32,12 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 
+	. "github.com/Azure/karpenter-provider-azure/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
-	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/test"

--- a/pkg/controllers/nodeclaim/inplaceupdate/controller.go
+++ b/pkg/controllers/nodeclaim/inplaceupdate/controller.go
@@ -23,11 +23,11 @@ import (
 
 	"github.com/samber/lo"
 	"go.uber.org/zap/zapcore"
-	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -88,7 +88,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim
 	}
 	actualHash := nodeClaim.Annotations[v1alpha2.AnnotationInPlaceUpdateHash]
 
-	logging.FromContext(ctx).Debugf("goal hash is: %q, actual hash is: %q", goalHash, actualHash)
+	log.FromContext(ctx).V(1).Info("goal hash is: %q, actual hash is: %q", goalHash, actualHash)
 
 	// If there's no difference from goal state, no need to do anything else
 	if goalHash == actualHash {
@@ -175,12 +175,13 @@ func (c *Controller) Builder(_ context.Context, m manager.Manager) corecontrolle
 }
 
 func logVMPatch(ctx context.Context, update *armcompute.VirtualMachineUpdate) {
-	if logging.FromContext(ctx).Level().Enabled(zapcore.DebugLevel) {
+	if zapcore.Level(log.FromContext(ctx).GetV()).Enabled(zapcore.DebugLevel) {
+
 		rawStr := "<nil>"
 		if update != nil {
 			raw, _ := json.Marshal(update)
 			rawStr = string(raw)
 		}
-		logging.FromContext(ctx).Debugf("applying patch to Azure VM: %s", rawStr)
+		log.FromContext(ctx).V(1).Info("applying patch to Azure VM: %s", rawStr)
 	}
 }

--- a/pkg/controllers/nodeclaim/inplaceupdate/suite_test.go
+++ b/pkg/controllers/nodeclaim/inplaceupdate/suite_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
+	. "github.com/Azure/karpenter-provider-azure/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	corev1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 	corecontroller "sigs.k8s.io/karpenter/pkg/operator/controller"

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -22,10 +22,10 @@ import (
 	"os"
 	"testing"
 
+	. "github.com/Azure/karpenter-provider-azure/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	. "knative.dev/pkg/logging/testing"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"

--- a/pkg/providers/imagefamily/image.go
+++ b/pkg/providers/imagefamily/image.go
@@ -28,7 +28,7 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
 	"k8s.io/client-go/kubernetes"
-	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 )
@@ -86,7 +86,7 @@ func (p *Provider) KubeServerVersion(ctx context.Context) (string, error) {
 	version := strings.TrimPrefix(serverVersion.GitVersion, "v") // v1.24.9 -> 1.24.9
 	p.kubernetesVersionCache.SetDefault(kubernetesVersionCacheKey, version)
 	if p.cm.HasChanged("kubernetes-version", version) {
-		logging.FromContext(ctx).With("kubernetes-version", version).Debugf("discovered kubernetes version")
+		log.FromContext(ctx).V(1).WithValues("kubernetes-version", version).Info("discovered kubernetes version")
 	}
 	return version, nil
 }
@@ -118,7 +118,7 @@ func (p *Provider) GetImageID(communityImageName, publicGalleryURL, versionName 
 
 	selectedImageID := BuildImageID(publicGalleryURL, communityImageName, versionName)
 	if p.cm.HasChanged(key, selectedImageID) {
-		logging.FromContext(context.Background()).With("image-id", selectedImageID).Info("discovered new image id")
+		log.FromContext(context.Background()).WithValues("image-id", selectedImageID).Info("discovered new image id")
 	}
 	p.imageCache.Set(key, selectedImageID, imageExpirationInterval)
 	return selectedImageID, nil

--- a/pkg/providers/imagefamily/resolver.go
+++ b/pkg/providers/imagefamily/resolver.go
@@ -20,8 +20,8 @@ import (
 	"context"
 
 	core "k8s.io/api/core/v1"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
 	"github.com/Azure/karpenter-provider-azure/pkg/metrics"
@@ -95,7 +95,7 @@ func (r Resolver) Resolve(ctx context.Context, nodeClass *v1alpha2.AKSNodeClass,
 		instancetype.MemoryAvailable: instanceType.Overhead.EvictionThreshold.Memory().String()}
 	kubeletConfig.MaxPods = lo.ToPtr(getMaxPods(staticParameters.NetworkPlugin))
 
-	logging.FromContext(ctx).Infof("Resolved image %s for instance type %s", imageID, instanceType.Name)
+	log.FromContext(ctx).Info("Resolved image %s for instance type %s", imageID, instanceType.Name)
 	template := &template.Parameters{
 		StaticParameters: staticParameters,
 		UserData: imageFamily.UserData(

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -43,7 +43,7 @@ import (
 	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/operator/scheme"
 
-	. "knative.dev/pkg/logging/testing"
+	. "github.com/Azure/karpenter-provider-azure/pkg/utils"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/Azure/karpenter-provider-azure/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
@@ -37,8 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
-	. "knative.dev/pkg/logging/testing"
-
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
 
 	corev1beta1 "sigs.k8s.io/karpenter/pkg/apis/v1beta1"

--- a/pkg/providers/loadbalancer/loadbalancer.go
+++ b/pkg/providers/loadbalancer/loadbalancer.go
@@ -23,10 +23,11 @@ import (
 	"sync"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
-	"knative.dev/pkg/logging"
 )
 
 const (
@@ -95,7 +96,7 @@ func (p *Provider) LoadBalancerBackendPools(ctx context.Context) (*BackendAddres
 		return lo.FromPtr(backendPool.ID), true
 	})
 
-	logging.FromContext(ctx).Debugf("Returning %d IPv4 backend pools: %s", len(ipv4PoolIDs), ipv4PoolIDs)
+	log.FromContext(ctx).V(1).Info("Returning %d IPv4 backend pools: %s", len(ipv4PoolIDs), ipv4PoolIDs)
 
 	// RP only actually assigns the LB backend pools to VMs if OutboundType is LoadBalancer,
 	// but that's also the only OutboundType which creates the LoadBalancer, so as long as we're not allowing
@@ -127,7 +128,7 @@ func (p *Provider) getLoadBalancers(ctx context.Context) ([]*armnetwork.LoadBala
 }
 
 func (p *Provider) loadFromAzure(ctx context.Context) ([]*armnetwork.LoadBalancer, error) {
-	logging.FromContext(ctx).Infof("Querying load balancers in resource group %s", p.resourceGroup)
+	log.FromContext(ctx).Info("Querying load balancers in resource group %s", p.resourceGroup)
 
 	pager := p.loadBalancersAPI.NewListPager(p.resourceGroup, nil)
 
@@ -142,7 +143,7 @@ func (p *Provider) loadFromAzure(ctx context.Context) ([]*armnetwork.LoadBalance
 
 	// Only return the LBs we actually care about
 	result := lo.Filter(lbs, isClusterLoadBalancer)
-	logging.FromContext(ctx).Infof("Found %d load balancers of interest", len(result))
+	log.FromContext(ctx).Info("Found %d load balancers of interest", len(result))
 	return result, nil
 }
 

--- a/pkg/providers/loadbalancer/suite_test.go
+++ b/pkg/providers/loadbalancer/suite_test.go
@@ -21,16 +21,15 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/patrickmn/go-cache"
-	"github.com/samber/lo"
-	. "knative.dev/pkg/logging/testing"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/karpenter-provider-azure/pkg/fake"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
+	. "github.com/Azure/karpenter-provider-azure/pkg/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/patrickmn/go-cache"
+	"github.com/samber/lo"
 )
 
 var ctx context.Context

--- a/pkg/providers/pricing/pricing.go
+++ b/pkg/providers/pricing/pricing.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing/client"
 	"github.com/samber/lo"
-	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 )
 
@@ -82,7 +82,7 @@ func NewProvider(ctx context.Context, pricing client.PricingAPI, region string, 
 		pricing:    pricing,
 		cm:         pretty.NewChangeMonitor(),
 	}
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("pricing"))
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("pricing"))
 
 	go func() {
 		// perform an initial price update at startup
@@ -162,7 +162,7 @@ func (p *Provider) updatePricing(ctx context.Context) {
 	prices := map[client.Item]bool{}
 	err := p.fetchPricing(ctx, processPage(prices))
 	if err != nil {
-		logging.FromContext(ctx).Errorf("error fetching updated pricing for region %s, %s, using existing pricing data, on-demand: %s, spot: %s", p.region, err, err.lastOnDemandUpdateTime.Format(time.RFC3339), err.lastSpotUpdateTime.Format(time.RFC3339))
+		log.FromContext(ctx).Error(err, "error fetching updated pricing for region %s, using existing pricing data, on-demand: %s, spot: %s", p.region, err.lastOnDemandUpdateTime.Format(time.RFC3339), err.lastSpotUpdateTime.Format(time.RFC3339))
 		return
 	}
 
@@ -173,7 +173,7 @@ func (p *Provider) updatePricing(ctx context.Context) {
 	go func() {
 		defer wg.Done()
 		if err := p.UpdateOnDemandPricing(ctx, onDemandPrices); err != nil {
-			logging.FromContext(ctx).Errorf("error updating on-demand pricing for region %s, %s, using existing pricing data from %s", p.region, err, err.lastOnDemandUpdateTime.Format(time.RFC3339))
+			log.FromContext(ctx).Error(err, "error updating on-demand pricing for region %s, using existing pricing data from %s", p.region, err.lastOnDemandUpdateTime.Format(time.RFC3339))
 		}
 	}()
 
@@ -181,7 +181,7 @@ func (p *Provider) updatePricing(ctx context.Context) {
 	go func() {
 		defer wg.Done()
 		if err := p.UpdateSpotPricing(ctx, spotPrices); err != nil {
-			logging.FromContext(ctx).Errorf("error updating spot pricing for region %s, %s, using existing pricing data from %s", p.region, err, err.lastSpotUpdateTime.Format(time.RFC3339))
+			log.FromContext(ctx).Error(err, "error updating spot pricing for region %s, using existing pricing data from %s", p.region, err.lastSpotUpdateTime.Format(time.RFC3339))
 		}
 	}()
 
@@ -198,7 +198,7 @@ func (p *Provider) UpdateOnDemandPricing(ctx context.Context, onDemandPrices map
 	p.onDemandPrices = lo.Assign(onDemandPrices)
 	p.onDemandUpdateTime = time.Now()
 	if p.cm.HasChanged("on-demand-prices", p.onDemandPrices) {
-		logging.FromContext(ctx).With("instance-type-count", len(p.onDemandPrices)).Infof("updated on-demand pricing for region %s", p.region)
+		log.FromContext(ctx).WithValues("instance-type-count", len(p.onDemandPrices)).Info("updated on-demand pricing for region %s", p.region)
 	}
 	return nil
 }
@@ -264,7 +264,7 @@ func (p *Provider) UpdateSpotPricing(ctx context.Context, spotPrices map[string]
 	p.spotPrices = lo.Assign(spotPrices)
 	p.spotUpdateTime = time.Now()
 	if p.cm.HasChanged("spot-prices", p.spotPrices) {
-		logging.FromContext(ctx).With("instance-type-count", len(p.spotPrices)).Infof("updated spot pricing for region %s", p.region)
+		log.FromContext(ctx).WithValues("instance-type-count", len(p.spotPrices)).Info("updated spot pricing for region %s", p.region)
 	}
 	return nil
 }

--- a/pkg/providers/pricing/suite_test.go
+++ b/pkg/providers/pricing/suite_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/Azure/karpenter-provider-azure/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "knative.dev/pkg/logging/testing"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/fake"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing"

--- a/test/pkg/debug/monitor.go
+++ b/test/pkg/debug/monitor.go
@@ -20,16 +20,15 @@ import (
 	"context"
 	"sync"
 
-	"github.com/go-logr/zapr"
 	"github.com/samber/lo"
 	"k8s.io/client-go/rest"
-	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/karpenter/pkg/operator/controller"
 	"sigs.k8s.io/karpenter/pkg/operator/scheme"
 )
@@ -42,14 +41,13 @@ type Monitor struct {
 }
 
 func New(ctx context.Context, config *rest.Config, kubeClient client.Client) *Monitor {
-	logger := logging.FromContext(ctx)
-	ctrl.SetLogger(zapr.NewLogger(logger.Desugar()))
+	logger := log.FromContext(ctx)
+	log.SetLogger(logzap.New())
 	mgr := lo.Must(controllerruntime.NewManager(config, controllerruntime.Options{
 		Scheme: scheme.Scheme,
 		BaseContext: func() context.Context {
 			ctx := context.Background()
-			ctx = logging.WithLogger(ctx, logger)
-			logger.WithOptions()
+			ctx = log.IntoContext(ctx, logger)
 			return ctx
 		},
 		Metrics: server.Options{

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	loggingtesting "github.com/Azure/karpenter-provider-azure/pkg/utils"
 	"github.com/onsi/gomega"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
@@ -32,7 +33,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	loggingtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/system"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"

--- a/test/pkg/environment/common/monitor.go
+++ b/test/pkg/environment/common/monitor.go
@@ -25,8 +25,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/samber/lo"
 
@@ -172,11 +172,11 @@ func (m *Monitor) RunningPodsCount(selector labels.Selector) int {
 func (m *Monitor) poll() state {
 	var nodes v1.NodeList
 	if err := m.kubeClient.List(m.ctx, &nodes); err != nil {
-		logging.FromContext(m.ctx).Errorf("listing nodes, %s", err)
+		log.FromContext(m.ctx).Error(err, "listing nodes, %s")
 	}
 	var pods v1.PodList
 	if err := m.kubeClient.List(m.ctx, &pods); err != nil {
-		logging.FromContext(m.ctx).Errorf("listing pods, %s", err)
+		log.FromContext(m.ctx).Error(err, "listing pods, %s")
 	}
 	st := state{
 		nodes:        map[string]*v1.Node{},


### PR DESCRIPTION
Fixes # NA

**Description**
Migrate knative logger to controller-runtime injected logger. This is done similarly to https://github.com/kubernetes-sigs/karpenter/pull/1050.

**How was this change tested?**

*

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NA
```
