### PR TITLE
chore(release): onboard to 1ES

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -14,11 +14,12 @@ permissions:
 
 env:
   REGISTRY_REPO: public/aks/karpenter
+  RELEASE_1ES_POOL: ${{ secrets.RELEASE_1ES_POOL }}
 
 jobs:
   prepare-variables:
     runs-on:
-      labels: [self-hosted, "1ES.Pool=${{ secrets.RELEASE_1ES_POOL }}"]
+      labels: [self-hosted, "1ES.Pool=${{ env.RELEASE_1ES_POOL }}"]
     outputs:
       release_tag: ${{ steps.vars.outputs.release_tag }}
     steps:
@@ -45,7 +46,7 @@ jobs:
       contents: read
       id-token: write # This is required for requesting the JWT
     runs-on:
-      labels: [self-hosted, "1ES.Pool=${{ secrets.RELEASE_1ES_POOL }}"]
+      labels: [self-hosted, "1ES.Pool=${{ env.RELEASE_1ES_POOL }}"]
     needs: prepare-variables
     steps:
     - name: Harden Runner

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -14,12 +14,11 @@ permissions:
 
 env:
   REGISTRY_REPO: public/aks/karpenter
-  RELEASE_1ES_POOL: ${{ secrets.RELEASE_1ES_POOL }}
 
 jobs:
   prepare-variables:
     runs-on:
-      labels: [self-hosted, "1ES.Pool=${{ env.RELEASE_1ES_POOL }}"]
+      labels: [self-hosted, "1ES.Pool=${{ var.RELEASE_1ES_POOL }}"]
     outputs:
       release_tag: ${{ steps.vars.outputs.release_tag }}
     steps:
@@ -46,7 +45,7 @@ jobs:
       contents: read
       id-token: write # This is required for requesting the JWT
     runs-on:
-      labels: [self-hosted, "1ES.Pool=${{ env.RELEASE_1ES_POOL }}"]
+      labels: [self-hosted, "1ES.Pool=${{ var.RELEASE_1ES_POOL }}"]
     needs: prepare-variables
     steps:
     - name: Harden Runner

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -17,7 +17,8 @@ env:
 
 jobs:
   prepare-variables:
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: [self-hosted, "1ES.Pool=${{ secrets.RELEASE_1ES_POOL }}"]
     outputs:
       release_tag: ${{ steps.vars.outputs.release_tag }}
     steps:
@@ -43,7 +44,8 @@ jobs:
     permissions:
       contents: read
       id-token: write # This is required for requesting the JWT
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: [self-hosted, "1ES.Pool=${{ secrets.RELEASE_1ES_POOL }}"]
     needs: prepare-variables
     steps:
     - name: Harden Runner
@@ -56,14 +58,6 @@ jobs:
         ref: ${{ needs.prepare-variables.outputs.release_tag }}
         
     - uses: ./.github/actions/install-deps
-
-    # reference: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure
-    - name: Login to Azure
-      uses: azure/login@8c334a195cbb38e46038007b304988d888bf676a # v2.0.0
-      with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   
     - name: Build and publish image
       env:

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -72,7 +72,6 @@ jobs:
           flags: ['-tags','ccp']
         EOF
         ko build github.com/Azure/karpenter-provider-azure/cmd/controller \
-          --push=false \
           --platform linux/amd64,linux/arm64 \
           --base-import-paths \
           --sbom none \

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -72,6 +72,7 @@ jobs:
           flags: ['-tags','ccp']
         EOF
         ko build github.com/Azure/karpenter-provider-azure/cmd/controller \
+          --push=false \
           --platform linux/amd64,linux/arm64 \
           --base-import-paths \
           --sbom none \

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   prepare-variables:
     runs-on:
-      labels: [self-hosted, "1ES.Pool=${{ var.RELEASE_1ES_POOL }}"]
+      labels: [self-hosted, "1ES.Pool=${{ vars.RELEASE_1ES_POOL }}"]
     outputs:
       release_tag: ${{ steps.vars.outputs.release_tag }}
     steps:
@@ -45,7 +45,7 @@ jobs:
       contents: read
       id-token: write # This is required for requesting the JWT
     runs-on:
-      labels: [self-hosted, "1ES.Pool=${{ var.RELEASE_1ES_POOL }}"]
+      labels: [self-hosted, "1ES.Pool=${{ vars.RELEASE_1ES_POOL }}"]
     needs: prepare-variables
     steps:
     - name: Harden Runner

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -63,6 +63,7 @@ jobs:
       env:
         KO_DOCKER_REPO: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO }}
       run: |
+        az login --identity
         az acr login -n ${{ secrets.AZURE_REGISTRY }}
         cat >.ko.yaml <<EOF
         builds:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
We have a set of overall work to switch the build and release pipeline to 1ES. This step converts the workflow within the repo.

**How was this change tested?**
Ensured that the updated workflow will succeed by running it with the build, but not publishing:
- https://github.com/Azure/karpenter-provider-azure/actions/runs/8333362669/job/22806353399

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
