### PR TITLE
fix: managed identity not being enabled for nodes

### DIFF
--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -135,7 +135,7 @@ type NodeBootstrapVariables struct {
 	CloudProviderRatelimitBucket      string   // s
 	CloudProviderRatelimitBucketWrite string   // s
 	LoadBalancerDisableOutboundSNAT   bool     // xd  [= false for now]
-	UseManagedIdentityExtension       bool     // s   [always false?]
+	UseManagedIdentityExtension       bool     // s   [always true, as long as we only support managed identity]
 	UseInstanceMetadata               bool     // s   [always true?]
 	LoadBalancerSKU                   string   // xd  [= "Standard" for now]
 	ExcludeMasterFromStandardLB       bool     // s   [always true?]
@@ -314,7 +314,7 @@ var (
 		CloudProviderRatelimitBucket:      "100",                  // s
 		CloudProviderRatelimitBucketWrite: "100",                  // s
 		LoadBalancerDisableOutboundSNAT:   false,                  // xd
-		UseManagedIdentityExtension:       false,                  // s
+		UseManagedIdentityExtension:       true,                   // s
 		UseInstanceMetadata:               true,                   // s
 		LoadBalancerSKU:                   "Standard",             // xd
 		ExcludeMasterFromStandardLB:       true,                   // s


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #197  <!-- issue number -->

**Description**
We currently hardcode managed identity enablement for AKS node bootstrapping script to be `false`, which is incorrect as we need it to be `true` per our managed identity support. This PR is a quick fix for this. See the linked issue for a consequence of this bug.

**How was this change tested?**

* Manually in NAP environment by assigning `acrpull` role to the kubelet identity and compare the results before and after the fix. This role assignment should be equivalent to `attach-acr`.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
- Fix an issue where provisioned node(s) do not have permission to pull images from Azure Container Registry (ACR) for pods even after integrating with the cluster
```
