### PR TITLE
test: output of grep command is capital letter and AZURE_ACR_NAME should be unique 

### DIFF
--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -1,5 +1,5 @@
 AZURE_LOCATION ?= westus2
-COMMON_NAME ?= karpenter2test
+COMMON_NAME ?= karpenter
 ifeq ($(CODESPACES),true)
   AZURE_RESOURCE_GROUP ?= $(CODESPACE_NAME)
   AZURE_ACR_NAME ?= $(subst -,,$(CODESPACE_NAME))

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -23,7 +23,7 @@ az-login: ## Login into Azure
 	az account set --subscription $(AZURE_SUBSCRIPTION_ID)
 
 az-mkrg: ## Create resource group
-	if az group exists --name $(AZURE_RESOURCE_GROUP) | grep -q "False"; then \
+	if az group exists --name $(AZURE_RESOURCE_GROUP) | grep -qi "false"; then \
 		az group create --name $(AZURE_RESOURCE_GROUP) --location $(AZURE_LOCATION) -o none; \
 	fi
 

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -1,13 +1,14 @@
 AZURE_LOCATION ?= westus2
+COMMON_NAME ?= karpenter2test
 ifeq ($(CODESPACES),true)
   AZURE_RESOURCE_GROUP ?= $(CODESPACE_NAME)
   AZURE_ACR_NAME ?= $(subst -,,$(CODESPACE_NAME))
 else
-  AZURE_RESOURCE_GROUP ?= karpenter
-  AZURE_ACR_NAME ?= karpenter
+  AZURE_RESOURCE_GROUP ?= $(COMMON_NAME)
+  AZURE_ACR_NAME ?= $(COMMON_NAME)
 endif
 
-AZURE_CLUSTER_NAME ?= karpenter
+AZURE_CLUSTER_NAME ?= $(COMMON_NAME)
 AZURE_RESOURCE_GROUP_MC = MC_$(AZURE_RESOURCE_GROUP)_$(AZURE_CLUSTER_NAME)_$(AZURE_LOCATION)
 
 KARPENTER_SERVICE_ACCOUNT_NAME ?= karpenter-sa
@@ -22,7 +23,7 @@ az-login: ## Login into Azure
 	az account set --subscription $(AZURE_SUBSCRIPTION_ID)
 
 az-mkrg: ## Create resource group
-	if az group exists --name $(AZURE_RESOURCE_GROUP) | grep -q "false"; then \
+	if az group exists --name $(AZURE_RESOURCE_GROUP) | grep -q "False"; then \
 		az group create --name $(AZURE_RESOURCE_GROUP) --location $(AZURE_LOCATION) -o none; \
 	fi
 


### PR DESCRIPTION
* changed to False from false. 
* can make a unique AZURE_ACR_NAME

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
'az group exists' printed true/false as capital letter.
So i added the ignore-case option(-i).
Also AZURE_ACR_NAME should be unique. but if the codespace is not using, only set karpenter as the AZURE_ACR_NAME 

**How was this change tested?**
make az-all

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**
NONE
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
