### PR TITLE
WIP: Support for VnetSubnetID as a nodeclass field enabling BYO Subnet scenarios

### DIFF
--- a/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
@@ -67,6 +67,9 @@ spec:
                   type: string
                 description: Tags to be applied on Azure resources like instances.
                 type: object
+              vnetSubnetID:
+                description: VnetSubnetID is the ID of the subnet in the VNet.
+                type: string
             type: object
           status:
             description: AKSNodeClassStatus contains the resolved state of the AKSNodeClass

--- a/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
@@ -68,7 +68,9 @@ spec:
                 description: Tags to be applied on Azure resources like instances.
                 type: object
               vnetSubnetID:
-                description: VnetSubnetID is the ID of the subnet in the VNet.
+                description: VnetSubnetID is the ID of the subnet in the custom vnet
+                  specifed on the aks cluster in the field --vnet-subnet-id.
+                pattern: (?i)^\/subscriptions\/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\/resourceGroups\/[a-zA-Z0-9][a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9]\/providers\/Microsoft\.Network\/virtualNetworks\/[a-zA-Z0-9][a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9]\/subnets\/[a-zA-Z0-9][a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9]$
                 type: string
             type: object
           status:

--- a/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
@@ -69,7 +69,7 @@ spec:
                 type: object
               vnetSubnetID:
                 description: VnetSubnetID is the ID of the subnet in the custom vnet
-                  specifed on the aks cluster in the field --vnet-subnet-id.
+                  specified on the aks cluster in the field --vnet-subnet-id.
                 pattern: (?i)^\/subscriptions\/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\/resourceGroups\/[a-zA-Z0-9][a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9]\/providers\/Microsoft\.Network\/virtualNetworks\/[a-zA-Z0-9][a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9]\/subnets\/[a-zA-Z0-9][a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9]$
                 type: string
             type: object

--- a/pkg/apis/v1alpha2/aksnodeclass.go
+++ b/pkg/apis/v1alpha2/aksnodeclass.go
@@ -27,6 +27,9 @@ import (
 // AKSNodeClassSpec is the top level specification for the AKS Karpenter Provider.
 // This will contain configuration necessary to launch instances in AKS.
 type AKSNodeClassSpec struct {
+	// VnetSubnetID is the ID of the subnet in the VNet.
+	// +optional
+	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
 	// +kubebuilder:default=128
 	// +kubebuilder:validation:Minimum=100
 	// osDiskSizeGB is the size of the OS disk in GB.

--- a/pkg/apis/v1alpha2/aksnodeclass.go
+++ b/pkg/apis/v1alpha2/aksnodeclass.go
@@ -27,7 +27,8 @@ import (
 // AKSNodeClassSpec is the top level specification for the AKS Karpenter Provider.
 // This will contain configuration necessary to launch instances in AKS.
 type AKSNodeClassSpec struct {
-	// VnetSubnetID is the ID of the subnet in the VNet.
+	// VnetSubnetID is the ID of the subnet in the custom vnet specified on the aks cluster in the field --vnet-subnet-id.
+	// +kubebuilder:validation:Pattern=`(?i)^\/subscriptions\/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\/resourceGroups\/[a-zA-Z0-9][a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9]\/providers\/Microsoft\.Network\/virtualNetworks\/[a-zA-Z0-9][a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9]\/subnets\/[a-zA-Z0-9][a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9]$`
 	// +optional
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
 	// +kubebuilder:default=128

--- a/pkg/apis/v1alpha2/nodepool_validation_cel_test.go
+++ b/pkg/apis/v1alpha2/nodepool_validation_cel_test.go
@@ -109,19 +109,19 @@ var _ = Describe("CEL/Validation", func() {
 				Expect(env.Client.Create(ctx, nodeClass)).ToNot(Succeed())
 			}
 		},
-		        Entry("valid VnetSubnetID", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", true),
-        Entry("should allow mixed casing in all the names", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgName/providers/Microsoft.Network/virtualNetworks/vnetName/subnets/subnetName", true),
-        Entry("valid format with different subnet name", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/vnet/subnets/anotherSubnet", true),
-        Entry("valid format with uppercase subnet name", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/vnet/subnets/SUBNET", true),
-        Entry("valid format with mixed-case resource group and subnet name", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVirtualNetwork/subnets/MySubnet", true),
-        Entry("invalid subnet with too short ID", "/subscriptions/123/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", false),
-        Entry("missing resourceGroups in path", "/subscriptions/12345678-1234-1234-1234-123456789012/rgname/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", false),
-        Entry("invalid provider in path", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Storage/virtualNetworks/vnet/subnets/subnet", false),
-        Entry("missing virtualNetworks in path", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Network/subnets/subnet", false),
-        Entry("valid VnetSubnetID at max length", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/"+strings.Repeat("a", 63)+"/providers/Microsoft.Network/virtualNetworks/"+strings.Repeat("b", 63)+"/subnets/"+strings.Repeat("c", 63), true),
-        Entry("subnet name too long", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/vnetname/subnets/"+strings.Repeat("d", 64), false),
-        Entry("VNET name too long", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/"+strings.Repeat("e", 64)+"/subnets/subnet", false),
-        Entry("resource group name too long", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/"+strings.Repeat("f", 64)+"/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", false),
+			Entry("valid VnetSubnetID", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", true),
+			Entry("should allow mixed casing in all the names", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgName/providers/Microsoft.Network/virtualNetworks/vnetName/subnets/subnetName", true),
+			Entry("valid format with different subnet name", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/vnet/subnets/anotherSubnet", true),
+			Entry("valid format with uppercase subnet name", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/vnet/subnets/SUBNET", true),
+			Entry("valid format with mixed-case resource group and subnet name", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVirtualNetwork/subnets/MySubnet", true),
+			Entry("invalid subnet with too short ID", "/subscriptions/123/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", false),
+			Entry("missing resourceGroups in path", "/subscriptions/12345678-1234-1234-1234-123456789012/rgname/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", false),
+			Entry("invalid provider in path", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Storage/virtualNetworks/vnet/subnets/subnet", false),
+			Entry("missing virtualNetworks in path", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Network/subnets/subnet", false),
+			Entry("valid VnetSubnetID at max length", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/"+strings.Repeat("a", 63)+"/providers/Microsoft.Network/virtualNetworks/"+strings.Repeat("b", 63)+"/subnets/"+strings.Repeat("c", 63), true),
+			Entry("subnet name too long", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/vnetname/subnets/"+strings.Repeat("d", 64), false),
+			Entry("VNET name too long", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rgname/providers/Microsoft.Network/virtualNetworks/"+strings.Repeat("e", 64)+"/subnets/subnet", false),
+			Entry("resource group name too long", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/"+strings.Repeat("f", 64)+"/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", false),
 		)
 	})
 	Context("Labels", func() {

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -389,9 +389,9 @@ var (
 )
 
 const (
-	ciliumDataPlane         = "cilium"
-	overlayNetworkType      = "overlay"
-	globalAKSMirror         = "https://acs-mirror.azureedge.net"
+	ciliumDataPlane    = "cilium"
+	overlayNetworkType = "overlay"
+	globalAKSMirror    = "https://acs-mirror.azureedge.net"
 )
 
 func (a AKS) aksBootstrapScript() (string, error) {

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -21,7 +21,6 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"strings"
 	"text/template"
 
@@ -389,14 +388,7 @@ var (
 	}
 )
 
-// Node Labels for Vnet
 const (
-	vnetDataPlaneLabel      = "kubernetes.azure.com/ebpf-dataplane"
-	vnetNetworkNameLabel    = "kubernetes.azure.com/network-name"
-	vnetSubnetNameLabel     = "kubernetes.azure.com/network-subnet"
-	vnetSubscriptionIDLabel = "kubernetes.azure.com/network-subscription"
-	vnetGUIDLabel           = "kubernetes.azure.com/nodenetwork-vnetguid"
-	vnetPodNetworkTypeLabel = "kubernetes.azure.com/podnetwork-type"
 	ciliumDataPlane         = "cilium"
 	overlayNetworkType      = "overlay"
 	globalAKSMirror         = "https://acs-mirror.azureedge.net"
@@ -464,21 +456,6 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 	kubeletLabels := lo.Assign(kubeletNodeLabelsBase, a.Labels)
 	getAgentbakerGeneratedLabels(a.ResourceGroup, kubeletLabels)
 
-	//Adding vnet-related labels to the nodeLabels.
-	azureVnetGUID := os.Getenv("AZURE_VNET_GUID")
-	azureVnetName := os.Getenv("AZURE_VNET_NAME")
-	azureSubnetName := os.Getenv("AZURE_SUBNET_NAME")
-
-	vnetLabels := map[string]string{
-		vnetDataPlaneLabel:      ciliumDataPlane,
-		vnetNetworkNameLabel:    azureVnetName,
-		vnetSubnetNameLabel:     azureSubnetName,
-		vnetSubscriptionIDLabel: a.SubscriptionID,
-		vnetGUIDLabel:           azureVnetGUID,
-		vnetPodNetworkTypeLabel: overlayNetworkType,
-	}
-
-	kubeletLabels = lo.Assign(kubeletLabels, vnetLabels)
 	nbv.KubeletNodeLabels = strings.Join(lo.MapToSlice(kubeletLabels, func(k, v string) string {
 		return fmt.Sprintf("%s=%s", k, v)
 	}), ",")

--- a/pkg/providers/imagefamily/resolver.go
+++ b/pkg/providers/imagefamily/resolver.go
@@ -38,8 +38,8 @@ import (
 const (
 	networkPluginAzure   = "azure"
 	networkPluginKubenet = "kubenet"
-	networkPolicyCilium = "cilium"
-	
+	networkPolicyCilium  = "cilium"
+
 	// defaultMaxPodsAzure is the maximum number of pods to run on a node for Azure CNI Overlay.
 	defaultMaxPodsAzure = 250
 	// defaultMaxPodsKubenet is the maximum number of pods to run on a node for Kubenet.
@@ -54,8 +54,8 @@ const (
 	vnetSubscriptionIDLabel = "kubernetes.azure.com/network-subscription"
 	vnetGUIDLabel           = "kubernetes.azure.com/nodenetwork-vnetguid"
 	vnetPodNetworkTypeLabel = "kubernetes.azure.com/podnetwork-type"
-	
-	overlayNetworkType  = "overlay"
+
+	overlayNetworkType = "overlay"
 )
 
 // Resolver is able to fill-in dynamic launch template parameters
@@ -96,7 +96,6 @@ func (r Resolver) Resolve(ctx context.Context, nodeClass *v1alpha2.AKSNodeClass,
 		return nil, err
 	}
 	logging.FromContext(ctx).Infof("Resolved image %s for instance type %s", imageID, instanceType.Name)
-	
 
 	kubeletConfig := nodeClaim.Spec.Kubelet
 	if kubeletConfig == nil {
@@ -128,7 +127,7 @@ func (r Resolver) Resolve(ctx context.Context, nodeClass *v1alpha2.AKSNodeClass,
 		),
 		ImageID: imageID,
 	}
-	
+
 	return template, nil
 }
 
@@ -158,14 +157,12 @@ func getAzureCNILabels(nodeClass *v1alpha2.AKSNodeClass) map[string]string {
 	vnetSubnetID := lo.Ternary(nodeClass.Spec.VnetSubnetID != nil, lo.FromPtr(nodeClass.Spec.VnetSubnetID), os.Getenv("AZURE_SUBNET_ID"))
 	vnetSubnetParts := strings.Split(vnetSubnetID, "/")
 	vnetLabels := map[string]string{
-		vnetDataPlaneLabel: networkPolicyCilium,
-		vnetNetworkNameLabel: vnetSubnetParts[len(vnetSubnetParts)-3],
-		vnetSubnetNameLabel:vnetSubnetParts[len(vnetSubnetParts)-1],
+		vnetDataPlaneLabel:      networkPolicyCilium,
+		vnetNetworkNameLabel:    vnetSubnetParts[len(vnetSubnetParts)-3],
+		vnetSubnetNameLabel:     vnetSubnetParts[len(vnetSubnetParts)-1],
 		vnetSubscriptionIDLabel: vnetSubnetParts[2],
-		vnetGUIDLabel: os.Getenv("AZURE_VNET_GUID"), 
+		vnetGUIDLabel:           os.Getenv("AZURE_VNET_GUID"),
 		vnetPodNetworkTypeLabel: overlayNetworkType,
 	}
 	return vnetLabels
 }
-
-

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -86,7 +86,7 @@ type Provider struct {
 	launchTemplateProvider *launchtemplate.Provider
 	loadBalancerProvider   *loadbalancer.Provider
 	resourceGroup          string
-	defaultSubnetID               string
+	defaultSubnetID        string
 	subscriptionID         string
 	unavailableOfferings   *cache.UnavailableOfferings
 }

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -386,7 +386,7 @@ func (p *Provider) launchInstance(
 	resourceName := GenerateResourceName(nodeClaim.Name)
 
 	// create network interface
-	nicReference, err := p.createNetworkInterface(ctx, resourceName, launchTemplate, instanceType)
+	nicReference, err := p.createNetworkInterface(ctx, resourceName, launchTemplate, instanceType, nodeClass)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -115,7 +115,7 @@ var _ = Describe("InstanceType Provider", func() {
 
 	BeforeEach(func() {
 		os.Setenv("AZURE_VNET_GUID", "test-vnet-guid")
-		os.Setenv("AZURE_SUBNET_ID", "/subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub")
+		os.Setenv("AZURE_SUBNET_ID", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub")
 		nodeClass = test.AKSNodeClass()
 		nodePool = coretest.NodePool(corev1beta1.NodePool{
 			Spec: corev1beta1.NodePoolSpec{
@@ -148,18 +148,18 @@ var _ = Describe("InstanceType Provider", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop()
 			Expect(nic).NotTo(BeNil())
-			Expect(lo.FromPtr(nic.Interface.Properties.IPConfigurations[0].Properties.Subnet.ID)).To(Equal("/subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub"))
+			Expect(lo.FromPtr(nic.Interface.Properties.IPConfigurations[0].Properties.Subnet.ID)).To(Equal("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub"))
 		})
 
 		It("should use the subnet specified in the nodeclass", func() {
-			nodeClass.Spec.VnetSubnetID = lo.ToPtr("/subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpenter/subnets/nodeclassSubnet")
+			nodeClass.Spec.VnetSubnetID = lo.ToPtr("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpenter/subnets/nodeclassSubnet")
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
 			ExpectScheduled(ctx, env.Client, pod)
 			nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop()
 			Expect(nic).NotTo(BeNil())
-			Expect(lo.FromPtr(nic.Interface.Properties.IPConfigurations[0].Properties.Subnet.ID)).To(Equal("/subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpenter/subnets/nodeclassSubnet"))
+			Expect(lo.FromPtr(nic.Interface.Properties.IPConfigurations[0].Properties.Subnet.ID)).To(Equal("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpenter/subnets/nodeclassSubnet"))
 		})
 
 		It("should produce all required azure cni labels", func() {
@@ -179,7 +179,7 @@ var _ = Describe("InstanceType Provider", func() {
 				ContainSubstring("kubernetes.azure.com/ebpf-dataplane=cilium"),
 				ContainSubstring("kubernetes.azure.com/network-name=karpentervnet"),
 				ContainSubstring("kubernetes.azure.com/network-subnet=karpentersub"),
-				ContainSubstring("kubernetes.azure.com/network-subscription=00000000-0000-0000-0000-00000000000"),
+				ContainSubstring("kubernetes.azure.com/network-subscription=12345678-1234-1234-1234-123456789012"),
 				ContainSubstring("kubernetes.azure.com/nodenetwork-vnetguid=test-vnet-guid"),
 				ContainSubstring("kubernetes.azure.com/podnetwork-type=overlay"),
 			))

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -186,7 +186,6 @@ var _ = Describe("InstanceType Provider", func() {
 		})
 	})
 	Context("VM Creation Failures", func() {
-		//It("should not continue to use a nodepool with a full subnet", func() {})
 		It("should delete the network interface on failure to create the vm", func() {
 			ErrMsg := "test error"
 			ErrCode := fmt.Sprint(http.StatusNotFound)

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -110,15 +110,12 @@ var _ = AfterSuite(func() {
 })
 
 var _ = Describe("InstanceType Provider", func() {
-
 	var nodeClass *v1alpha2.AKSNodeClass
 	var nodePool *corev1beta1.NodePool
 
 	BeforeEach(func() {
 		os.Setenv("AZURE_VNET_GUID", "test-vnet-guid")
-		os.Setenv("AZURE_VNET_NAME", "aks-vnet-00000000")
-		os.Setenv("AZURE_SUBNET_NAME", "test-subnet-name")
-
+		os.Setenv("AZURE_SUBNET_ID", "/subscriptions/<subscription>/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub") 
 		nodeClass = test.AKSNodeClass()
 		nodePool = coretest.NodePool(corev1beta1.NodePool{
 			Spec: corev1beta1.NodePoolSpec{
@@ -141,8 +138,56 @@ var _ = Describe("InstanceType Provider", func() {
 	AfterEach(func() {
 		ExpectCleanedUp(ctx, env.Client)
 	})
+	
 
-	Context("VM Creation Failures", func() {
+	Context("Subnet", func() { 
+		It("should use the AZURE_SUBNET_ID if no subnet is specified in the nodeclass", func() {
+			Expect(nodeClass.Spec.VnetSubnetID).To(BeNil())	
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass) 
+			pod := coretest.UnschedulablePod() 
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod) 
+			ExpectScheduled(ctx, env.Client, pod) 
+			nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop()	 
+			Expect(nic).NotTo(BeNil()) 
+			Expect(lo.FromPtr(nic.Interface.Properties.IPConfigurations[0].Properties.Subnet.ID)).To(Equal("/subscriptions/<subscription>/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub"))
+		})
+
+		It("should use the subnet specified in the nodeclass", func() { 
+			nodeClass.Spec.VnetSubnetID = lo.ToPtr("/subscriptions/<subscription>/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpenter/subnets/nodeclassSubnet")
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass) 
+			pod := coretest.UnschedulablePod() 
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod) 
+			ExpectScheduled(ctx, env.Client, pod) 
+			nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop() 
+			Expect(nic).NotTo(BeNil()) 
+			Expect(lo.FromPtr(nic.Interface.Properties.IPConfigurations[0].Properties.Subnet.ID)).To(Equal("/subscriptions/<subscription>/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpenter/subnets/nodeclassSubnet")) 
+		})
+
+		It("should produce all required azure cni labels", func() { 
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+			pod := coretest.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
+			ExpectScheduled(ctx, env.Client, pod)
+
+			Expect(azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			vm := azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Pop().VM
+			customData := *vm.Properties.OSProfile.CustomData
+			Expect(customData).ToNot(BeNil())
+			decodedBytes, err := base64.StdEncoding.DecodeString(customData)
+			Expect(err).To(Succeed())
+			decodedString := string(decodedBytes[:])
+			Expect(decodedString).To(SatisfyAll(
+				ContainSubstring("kubernetes.azure.com/ebpf-dataplane=cilium"),
+				ContainSubstring("kubernetes.azure.com/network-name=karpentervnet"),
+				ContainSubstring("kubernetes.azure.com/network-subnet=karpentersub"),
+				ContainSubstring("kubernetes.azure.com/network-subscription=<subscription>"),
+				ContainSubstring("kubernetes.azure.com/nodenetwork-vnetguid=test-vnet-guid"),
+				ContainSubstring("kubernetes.azure.com/podnetwork-type=overlay"),
+			))
+		})
+	})
+	Context("VM Creation Failures", func() {	
+		//It("should not continue to use a nodepool with a full subnet", func() {})
 		It("should delete the network interface on failure to create the vm", func() {
 			ErrMsg := "test error"
 			ErrCode := fmt.Sprint(http.StatusNotFound)
@@ -531,6 +576,26 @@ var _ = Describe("InstanceType Provider", func() {
 			Expect(kubeletFlags).To(ContainSubstring("--image-gc-high-threshold=30"))
 			Expect(kubeletFlags).To(ContainSubstring("--cpu-cfs-quota=true"))
 		})
+		It("should not contain the azure cni vnet labels", func() { 
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass) 
+			pod := coretest.UnschedulablePod() 
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod) 
+			ExpectScheduled(ctx, env.Client, pod) 
+
+			Expect(azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			vm := azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Pop().VM 
+			customData := *vm.Properties.OSProfile.CustomData 
+			Expect(customData).ToNot(BeNil()) 
+			decodedBytes, err := base64.StdEncoding.DecodeString(customData) 
+			Expect(err).To(Succeed()) 
+			decodedString := string(decodedBytes[:]) 
+			Expect(decodedString).ToNot(ContainSubstring("kubernetes.azure.com/ebpf-dataplane=cilium"))
+			Expect(decodedString).ToNot(ContainSubstring("kubernetes.azure.com/network-name=karpentervnet"))
+			Expect(decodedString).ToNot(ContainSubstring("kubernetes.azure.com/network-subnet=karpentersub"))
+			Expect(decodedString).ToNot(ContainSubstring("kubernetes.azure.com/network-subscription=<subscription>"))
+			Expect(decodedString).ToNot(ContainSubstring("kubernetes.azure.com/nodenetwork-vnetguid=test-vnet-guid"))
+			Expect(decodedString).ToNot(ContainSubstring("kubernetes.azure.com/podnetwork-type=overlay"))
+		})
 		It("should support provisioning with kubeletConfig, computeResources and maxPods specified", func() {
 			nodePool.Spec.Template.Spec.Kubelet = &corev1beta1.KubeletConfiguration{
 				PodsPerCore: lo.ToPtr(int32(110)),
@@ -589,31 +654,6 @@ var _ = Describe("InstanceType Provider", func() {
 			Expect(kubeletFlags).To(ContainSubstring("--image-gc-low-threshold=20"))
 			Expect(kubeletFlags).To(ContainSubstring("--image-gc-high-threshold=30"))
 			Expect(kubeletFlags).To(ContainSubstring("--cpu-cfs-quota=true"))
-		})
-	})
-
-	Context("Provisioner with VNetNodeLabel", func() {
-		It("should support provisioning with VNet node labels", func() {
-			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-			pod := coretest.UnschedulablePod()
-			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
-			ExpectScheduled(ctx, env.Client, pod)
-
-			Expect(azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
-			vm := azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Pop().VM
-			customData := *vm.Properties.OSProfile.CustomData
-			Expect(customData).ToNot(BeNil())
-			decodedBytes, err := base64.StdEncoding.DecodeString(customData)
-			Expect(err).To(Succeed())
-			decodedString := string(decodedBytes[:])
-			Expect(decodedString).To(SatisfyAll(
-				ContainSubstring("kubernetes.azure.com/ebpf-dataplane=cilium"),
-				ContainSubstring("kubernetes.azure.com/network-name=aks-vnet-00000000"),
-				ContainSubstring("kubernetes.azure.com/network-subnet=test-subnet-name"),
-				ContainSubstring("kubernetes.azure.com/network-subscription=test-subscription"),
-				ContainSubstring("kubernetes.azure.com/nodenetwork-vnetguid=test-vnet-guid"),
-				ContainSubstring("kubernetes.azure.com/podnetwork-type=overlay"),
-			))
 		})
 	})
 

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -18,7 +18,6 @@ package launchtemplate
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/to"
@@ -38,16 +37,6 @@ import (
 const (
 	karpenterManagedTagKey = "karpenter.azure.com/cluster"
 
-	// AzureCNI VNET Labels
-	vnetDataPlaneLabel      = "kubernetes.azure.com/ebpf-dataplane"
-	vnetNetworkNameLabel    = "kubernetes.azure.com/network-name"
-	vnetSubnetNameLabel     = "kubernetes.azure.com/network-subnet"
-	vnetSubscriptionIDLabel = "kubernetes.azure.com/network-subscription"
-	vnetGUIDLabel           = "kubernetes.azure.com/nodenetwork-vnetguid"
-	vnetPodNetworkTypeLabel = "kubernetes.azure.com/podnetwork-type"
-	
-	ciliumNetworkPlugin = "cilium" 
-	overlayNetworkType  = "overlay"
 )
 
 type Template struct {
@@ -112,7 +101,6 @@ func (p *Provider) getStaticParameters(ctx context.Context, instanceType *cloudp
 		arch = corev1beta1.ArchitectureArm64
 	}
 	
-	labels = lo.Assign(labels, getVnetLabelValues(nodeClass)) 
 	return &parameters.StaticParameters{
 		ClusterName:                    options.FromContext(ctx).ClusterName,
 		ClusterEndpoint:                p.clusterEndpoint,
@@ -154,25 +142,6 @@ func (p *Provider) createLaunchTemplate(_ context.Context, options *parameters.P
 }
 
 
-
-// getVnetLabelValues returns the labels for AzureCNI for the vnet and subnet. 
-// See how split logic works here: https://go.dev/play/p/l3l7Zrg_pdd
-func getVnetLabelValues(nodeClass *v1alpha2.AKSNodeClass) map[string]string {
-	// this assumes that we would panic if AZURE_SUBNET_ID is not set
-	vnetSubnetID := lo.Ternary(nodeClass.Spec.VnetSubnetID != nil, *nodeClass.Spec.VnetSubnetID, os.Getenv("AZURE_SUBNET_ID"))
-	vnetSubnetParts := strings.Split(vnetSubnetID, "/")
-
-	vnetLabels := map[string]string{
-		vnetDataPlaneLabel: ciliumNetworkPlugin,
-		vnetNetworkNameLabel: vnetSubnetParts[len(vnetSubnetParts)-3],
-		vnetSubnetNameLabel:vnetSubnetParts[len(vnetSubnetParts)-1],
-		vnetSubscriptionIDLabel: vnetSubnetParts[2],
-		vnetGUIDLabel: os.Getenv("AZURE_VNET_GUID"), // this configuration is resolved in handleVNET inside of the azure_clients
-		vnetPodNetworkTypeLabel: overlayNetworkType,
-	}
-
-	return vnetLabels
-}
 
 // MergeTags takes a variadic list of maps and merges them together
 // with format acceptable to ARM (no / in keys, pointer to strings as values)

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -18,6 +18,7 @@ package launchtemplate
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/to"
@@ -36,6 +37,17 @@ import (
 
 const (
 	karpenterManagedTagKey = "karpenter.azure.com/cluster"
+
+	// AzureCNI VNET Labels
+	vnetDataPlaneLabel      = "kubernetes.azure.com/ebpf-dataplane"
+	vnetNetworkNameLabel    = "kubernetes.azure.com/network-name"
+	vnetSubnetNameLabel     = "kubernetes.azure.com/network-subnet"
+	vnetSubscriptionIDLabel = "kubernetes.azure.com/network-subscription"
+	vnetGUIDLabel           = "kubernetes.azure.com/nodenetwork-vnetguid"
+	vnetPodNetworkTypeLabel = "kubernetes.azure.com/podnetwork-type"
+	
+	ciliumNetworkPlugin = "cilium" 
+	overlayNetworkType  = "overlay"
 )
 
 type Template struct {
@@ -99,7 +111,8 @@ func (p *Provider) getStaticParameters(ctx context.Context, instanceType *cloudp
 	if err := instanceType.Requirements.Compatible(scheduling.NewRequirements(scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureArm64))); err == nil {
 		arch = corev1beta1.ArchitectureArm64
 	}
-
+	
+	labels = lo.Assign(labels, getVnetLabelValues(nodeClass)) 
 	return &parameters.StaticParameters{
 		ClusterName:                    options.FromContext(ctx).ClusterName,
 		ClusterEndpoint:                p.clusterEndpoint,
@@ -138,6 +151,27 @@ func (p *Provider) createLaunchTemplate(_ context.Context, options *parameters.P
 		Tags:     azureTags,
 	}
 	return template, nil
+}
+
+
+
+// getVnetLabelValues returns the labels for AzureCNI for the vnet and subnet. 
+// See how split logic works here: https://go.dev/play/p/l3l7Zrg_pdd
+func getVnetLabelValues(nodeClass *v1alpha2.AKSNodeClass) map[string]string {
+	// this assumes that we would panic if AZURE_SUBNET_ID is not set
+	vnetSubnetID := lo.Ternary(nodeClass.Spec.VnetSubnetID != nil, *nodeClass.Spec.VnetSubnetID, os.Getenv("AZURE_SUBNET_ID"))
+	vnetSubnetParts := strings.Split(vnetSubnetID, "/")
+
+	vnetLabels := map[string]string{
+		vnetDataPlaneLabel: ciliumNetworkPlugin,
+		vnetNetworkNameLabel: vnetSubnetParts[len(vnetSubnetParts)-3],
+		vnetSubnetNameLabel:vnetSubnetParts[len(vnetSubnetParts)-1],
+		vnetSubscriptionIDLabel: vnetSubnetParts[2],
+		vnetGUIDLabel: os.Getenv("AZURE_VNET_GUID"), // this configuration is resolved in handleVNET inside of the azure_clients
+		vnetPodNetworkTypeLabel: overlayNetworkType,
+	}
+
+	return vnetLabels
 }
 
 // MergeTags takes a variadic list of maps and merges them together

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -36,7 +36,6 @@ import (
 
 const (
 	karpenterManagedTagKey = "karpenter.azure.com/cluster"
-
 )
 
 type Template struct {
@@ -100,7 +99,7 @@ func (p *Provider) getStaticParameters(ctx context.Context, instanceType *cloudp
 	if err := instanceType.Requirements.Compatible(scheduling.NewRequirements(scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureArm64))); err == nil {
 		arch = corev1beta1.ArchitectureArm64
 	}
-	
+
 	return &parameters.StaticParameters{
 		ClusterName:                    options.FromContext(ctx).ClusterName,
 		ClusterEndpoint:                p.clusterEndpoint,
@@ -140,8 +139,6 @@ func (p *Provider) createLaunchTemplate(_ context.Context, options *parameters.P
 	}
 	return template, nil
 }
-
-
 
 // MergeTags takes a variadic list of maps and merges them together
 // with format acceptable to ARM (no / in keys, pointer to strings as values)

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -41,8 +41,10 @@ func init() {
 	corev1beta1.NormalizedLabels = lo.Assign(corev1beta1.NormalizedLabels, map[string]string{"topology.disk.csi.azure.com/zone": corev1.LabelTopologyZone})
 }
 
-var resourceGroup = "test-resourceGroup"
-
+var (
+	resourceGroup = "test-resourceGroup"
+	defaultVnetSubnetID = "/subscriptions/<subscription>/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub"
+)
 type Environment struct {
 	// API
 	VirtualMachinesAPI          *fake.VirtualMachinesAPI
@@ -139,7 +141,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		unavailableOfferingsCache,
 		region,        // region
 		resourceGroup, // resourceGroup
-		"",            // subnet
+		defaultVnetSubnetID, // default subnet
 		"",            // subscriptionID
 	)
 

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -43,7 +43,7 @@ func init() {
 
 var (
 	resourceGroup       = "test-resourceGroup"
-	defaultVnetSubnetID = "/subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub"
+	defaultVnetSubnetID = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub"
 )
 
 type Environment struct {

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -42,9 +42,10 @@ func init() {
 }
 
 var (
-	resourceGroup = "test-resourceGroup"
-	defaultVnetSubnetID = "/subscriptions/<subscription>/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub"
+	resourceGroup       = "test-resourceGroup"
+	defaultVnetSubnetID = "/subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub"
 )
+
 type Environment struct {
 	// API
 	VirtualMachinesAPI          *fake.VirtualMachinesAPI
@@ -139,10 +140,10 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		launchTemplateProvider,
 		loadBalancerProvider,
 		unavailableOfferingsCache,
-		region,        // region
-		resourceGroup, // resourceGroup
+		region,              // region
+		resourceGroup,       // resourceGroup
 		defaultVnetSubnetID, // default subnet
-		"",            // subscriptionID
+		"",                  // subscriptionID
 	)
 
 	return &Environment{

--- a/pkg/utils/subnet_parser.go
+++ b/pkg/utils/subnet_parser.go
@@ -1,0 +1,56 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+// this package replaces three different functions in different pacakages that all had bugs. Please don't use a regex to parse these
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+type vnetSubnetResource struct {
+	SubscriptionID    string
+	ResourceGroupName string
+	VNetName          string
+	SubnetName        string
+}
+
+// GetSubnetResourceID constructs the subnet resource id
+func GetSubnetResourceID(subscriptionID, resourceGroupName, virtualNetworkName, subnetName string) string {
+	// an example subnet resource: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s", subscriptionID, resourceGroupName, virtualNetworkName, subnetName)
+}
+
+func GetVnetSubnetIDComponents(vnetSubnetID string) (vnetSubnetResource, error) {
+	parts := strings.Split(vnetSubnetID, "/")
+	if len(parts) != 11 {
+		return vnetSubnetResource{}, fmt.Errorf("invalid vnet subnet id: %s", vnetSubnetID)
+	}
+
+	vs := vnetSubnetResource{
+		SubscriptionID:    parts[2],
+		ResourceGroupName: parts[4],
+		VNetName:          parts[8],
+		SubnetName:        parts[10],
+	}
+
+	//this is a cheap way of ensure all the names match
+	mirror := GetSubnetResourceID(vs.SubscriptionID, vs.ResourceGroupName, vs.VNetName, vs.SubnetName)
+	if !strings.EqualFold(mirror, vnetSubnetID) {
+		return vnetSubnetResource{}, fmt.Errorf("invalid vnet subnet id: %s", vnetSubnetID)
+	}
+	return vs, nil
+}

--- a/pkg/utils/subnet_parser_test.go
+++ b/pkg/utils/subnet_parser_test.go
@@ -1,0 +1,126 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCustomvnet(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "GetVnetSubnetIDComponents")
+}
+
+func Benchmark(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := GetVnetSubnetIDComponents("/subscriptions/00000000-0000-0000-0000-0000000000/resourceGroups/myrg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/default1")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+var _ = Describe("GetVnetSubnetIDComponents", func() {
+	It("should return correct subnet id components", func() {
+		subnetResource, err := GetVnetSubnetIDComponents("/subscriptions/00000000-0000-0000-0000-0000000000/resourceGroups/myrg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/default1")
+		Expect(err).ToNot(HaveOccurred())
+		subscriptionID := subnetResource.SubscriptionID
+		resourceGroupName := subnetResource.ResourceGroupName
+		vNetName := subnetResource.VNetName
+		subnetName := subnetResource.SubnetName
+
+		Expect(subscriptionID).To(Equal("00000000-0000-0000-0000-0000000000"))
+		Expect(resourceGroupName).To(Equal("myrg"))
+		Expect(vNetName).To(Equal("my-vnet"))
+		Expect(subnetName).To(Equal("default1"))
+	})
+	It("should return error when unable to parse vnet subnet id", func() {
+		// "/subscriptions/00000000-0000-0000-0000-0000000000/resourceGroups/myrg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/default1"
+		customVnetSubnetID := "someSubnetID" // invalid format
+		_, err := GetVnetSubnetIDComponents(customVnetSubnetID)
+		Expect(err).To(HaveOccurred())
+
+		// "resourceGr" instead of "resourceGroups" in customVnetSubnetID
+		customVnetSubnetID = "/subscriptions/00000000-0000-0000-0000-0000000000/resourceGr/myrg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/default1"
+		_, err = GetVnetSubnetIDComponents(customVnetSubnetID)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Is reflexive", func() {
+		vnetsubnetid := GetSubnetResourceID("sam", "red", "violet", "subaru")
+		vnet, err := GetVnetSubnetIDComponents(vnetsubnetid)
+		Expect(err).To(BeNil())
+
+		Expect(vnet.SubscriptionID).To(Equal("sam"))
+		Expect(vnet.ResourceGroupName).To(Equal("red"))
+		Expect(vnet.VNetName).To(Equal("violet"))
+		Expect(vnet.SubnetName).To(Equal("subaru"))
+	})
+
+	It("real world wierdness (subnets is repeated broke old regex)", func() {
+		vnetsubnetid := "/subscriptions/2d79d671-fc69-4b47-be2f-493535cc2485/resourceGroups/piotrsk/providers/Microsoft.Network/virtualNetworks/piotrsk-VNET/subnets/subnets/AKSMgmtv2-Subnet"
+		_, err := GetVnetSubnetIDComponents(vnetsubnetid)
+		Expect(err).ToNot(BeNil())
+	})
+
+	It("Is case insensitive (subnetparser.GetVnetSubnetIDComponents)", func() {
+		vnetsubnetid := "/SubscRiptionS/mySubscRiption/ResourceGroupS/myResourceGroup/ProviDerS/MicrOsofT.NetWorK/VirtualNetwOrkS/myVirtualNetwork/SubNetS/mySubnet"
+		vnet, err := GetVnetSubnetIDComponents(vnetsubnetid)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vnet.SubscriptionID).To(Equal("mySubscRiption"))
+		Expect(vnet.ResourceGroupName).To(Equal("myResourceGroup"))
+		Expect(vnet.VNetName).To(Equal("myVirtualNetwork"))
+		Expect(vnet.SubnetName).To(Equal("mySubnet"))
+	})
+
+	It("Fails when appropriate", func() {
+		_, err := GetVnetSubnetIDComponents("what/a/bunch/of/junk")
+		Expect(err).ToNot(BeNil())
+		_, err = GetVnetSubnetIDComponents("/subscriptions/sam/resourceGroups/red/providers/Microsoft.Network/virtualNetworks/soclose")
+		Expect(err).ToNot(BeNil())
+	})
+
+	It("Test GetVNETSubnetIDComponents", func() {
+		vnetSubnetID := "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME"
+		vs, err := GetVnetSubnetIDComponents(vnetSubnetID)
+		Expect(err).To(BeNil())
+		Expect(vs.SubscriptionID).To(Equal("SUB_ID"))
+		Expect(vs.ResourceGroupName).To(Equal("RG_NAME"))
+		Expect(vs.VNetName).To(Equal("VNET_NAME"))
+		Expect(vs.SubnetName).To(Equal("SUBNET_NAME"))
+
+		// case-insensitive match
+		vnetSubnetID = "/SubscriPtioNS/SUB_ID/REsourceGroupS/RG_NAME/ProViderS/MicrosoFT.NetWorK/VirtualNetWorKS/VNET_NAME/SubneTS/SUBNET_NAME"
+		vs, err = GetVnetSubnetIDComponents(vnetSubnetID)
+		Expect(err).To(BeNil())
+		Expect(vs.SubscriptionID).To(Equal("SUB_ID"))
+		Expect(vs.ResourceGroupName).To(Equal("RG_NAME"))
+		Expect(vs.VNetName).To(Equal("VNET_NAME"))
+		Expect(vs.SubnetName).To(Equal("SUBNET_NAME"))
+
+		//wtwo bad ones
+		vnetSubnetID = "/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME"
+		_, err = GetVnetSubnetIDComponents(vnetSubnetID)
+		Expect(err).ToNot(BeNil())
+
+		vnetSubnetID = "badVnetSubnetID"
+		_, err = GetVnetSubnetIDComponents(vnetSubnetID)
+		Expect(err).ToNot(BeNil())
+	})
+})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #231

**Description**
This PR Introduces the `VnetSubnetID field from the aks api into the v1alpha2 AKSNodeclass api. This will allow customers to specify individual subnets outside of the default subnet. 

This paired with https://github.com/Azure/karpenter-provider-azure/pull/238 will allow users to bring their own VNET, and pick their own node subnets. 

This change does not add support for pod subnet since overlay uses fake ips for pods on each node, and only uses real ips for Nodes. Pod subnet will need to be introduced alongside the azure cni without overlay. 

**How was this change tested?**
- make test 
- e2e 

**Followup Work** 
- Subnet Drift should be supported and have e2e tests 
- e2e test case for allocating to an additional subnet

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adding support for BYO subnet, allowing users to configure a subnet per nodeclass
```
