### PR TITLE
chore: removing eni helpers

### DIFF
--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -222,30 +222,6 @@ func (env *Environment) ExpectConfigMapDataOverridden(key types.NamespacedName, 
 	return true
 }
 
-func (env *Environment) ExpectPodENIEnabled() {
-	GinkgoHelper()
-	env.ExpectDaemonSetEnvironmentVariableUpdated(types.NamespacedName{Namespace: "kube-system", Name: "aws-node"},
-		"ENABLE_POD_ENI", "true", "aws-node")
-}
-
-func (env *Environment) ExpectPodENIDisabled() {
-	GinkgoHelper()
-	env.ExpectDaemonSetEnvironmentVariableUpdated(types.NamespacedName{Namespace: "kube-system", Name: "aws-node"},
-		"ENABLE_POD_ENI", "false", "aws-node")
-}
-
-func (env *Environment) ExpectPrefixDelegationEnabled() {
-	GinkgoHelper()
-	env.ExpectDaemonSetEnvironmentVariableUpdated(types.NamespacedName{Namespace: "kube-system", Name: "aws-node"},
-		"ENABLE_PREFIX_DELEGATION", "true", "aws-node")
-}
-
-func (env *Environment) ExpectPrefixDelegationDisabled() {
-	GinkgoHelper()
-	env.ExpectDaemonSetEnvironmentVariableUpdated(types.NamespacedName{Namespace: "kube-system", Name: "aws-node"},
-		"ENABLE_PREFIX_DELEGATION", "false", "aws-node")
-}
-
 func (env *Environment) ExpectExists(obj client.Object) {
 	GinkgoHelper()
 	Eventually(func(g Gomega) {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # NA 

**Description**
Removing some old helpers remaining from aws port of e2es
**How was this change tested?**
/test

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
