### PR TITLE
test(logging): allow for overriding and enabling logging of caller field

### DIFF
--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -191,6 +191,9 @@ az-run-sample: ## Deploy sample Provisioner and workload (with 0 replicas, to be
 	kubectl apply -f examples/v1beta1/general-purpose.yaml
 	kubectl apply -f examples/workloads/inflate.yaml
 
+az-enable-logging-caller: ## Enable logging the caller field (file path, name, and line number)
+	yq -i  '.manifests.helm.releases[0].overrides.logConfig ."disableCaller" = false' skaffold.yaml
+
 az-mc-show: ## show managed cluster
 	az aks show --name $(AZURE_CLUSTER_NAME) --resource-group $(AZURE_RESOURCE_GROUP)
 

--- a/charts/karpenter/templates/configmap-logging.yaml
+++ b/charts/karpenter/templates/configmap-logging.yaml
@@ -17,7 +17,7 @@ data:
       "level": "{{ .Values.logConfig.logLevel.global }}",
       "development": false,
       "disableStacktrace": true,
-      "disableCaller": true,
+      "disableCaller": {{ .Values.logConfig.disableCaller }},
       "sampling": {
         "initial": 100,
         "thereafter": 100
@@ -33,7 +33,8 @@ data:
         "messageKey": "message",
         "stacktraceKey": "stacktrace",
         "levelEncoder": "capital",
-        "timeEncoder": "iso8601"
+        "timeEncoder": "iso8601",
+        "callerEncoder": "full"
       }
     }
   loglevel.controller: {{ or .Values.controller.logLevel .Values.logConfig.logLevel.controller }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -152,6 +152,8 @@ logConfig:
   # -- Log errorOutputPaths - defaults to stderr only
   errorOutputPaths:
     - stderr
+  # -- Log disableCaller - can be overridden to false to log the caller field (file path, name, and line number)
+  disableCaller: true
   # -- Log encoding - defaults to json - must be one of 'json', 'console'
   logEncoding: json
   # -- Component-based log configuration


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Allow for overriding and enabling the caller field which contains file path, name, and line number of the log. Also, adds a make command to enable it.

**How was this change tested?**
created a standalone setup in codespaces, and tested both with, and without `az-enable-logging-caller` to ensure the `caller` field shows up correctly.
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
