### PR TITLE
fix: amending release scripts to work for macos

### DIFF
--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -152,10 +152,18 @@ dateEpoch() {
   git log -1 --format='%ct'
 }
 
+
+
 buildDate() {
   local date_epoch
 
   date_epoch="${1}"
 
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+		# Date for macOS is different from GNU date
+        date -u -r "${date_epoch}" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null
+		return
+  fi
+  # This logic is for GNU date
   date -u --date="@${date_epoch}" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null
 }

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -158,9 +158,9 @@ buildDate() {
   date_epoch="${1}"
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
-		# Date for macOS is different from GNU date
+        # Date for macOS is different from GNU date
         date -u -r "${date_epoch}" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null
-		return
+	return
   fi
   # This logic is for GNU date
   date -u --date="@${date_epoch}" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -152,8 +152,6 @@ dateEpoch() {
   git log -1 --format='%ct'
 }
 
-
-
 buildDate() {
   local date_epoch
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
This PR adds the required changes to support running these release scripts for macos. The only conflict is the date module as macos date is different from the gnu date format. 
**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
