### PR TITLE
perf: use vmname-nic for network interface names

### DIFF
--- a/pkg/providers/instance/armutils.go
+++ b/pkg/providers/instance/armutils.go
@@ -107,7 +107,15 @@ func deleteNicIfExists(ctx context.Context, client NetworkInterfacesAPI, rg, nic
 	_, err := client.Get(ctx, rg, nicName, nil)
 	if err != nil {
 		if sdkerrors.IsNotFoundErr(err) {
-			return nil
+			// try older name; remove the -nic suffix from the nicName, if exists
+			if len(nicName) > 4 && nicName[len(nicName)-4:] == "-nic" {
+				nicName = nicName[:len(nicName)-4]
+				_, oerr := client.Get(ctx, rg, nicName, nil)
+				if sdkerrors.IsNotFoundErr(oerr) {
+					return nil
+				}
+				return oerr
+			}
 		}
 		return err
 	}

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -178,7 +178,7 @@ func (p *Provider) List(ctx context.Context) ([]*armcompute.VirtualMachine, erro
 }
 
 func (p *Provider) Delete(ctx context.Context, resourceName string) error {
-	logging.FromContext(ctx).Debugf("Deleting virtual machine %s and associated resources")
+	logging.FromContext(ctx).Debugf("Deleting virtual machine %s and associated resources", resourceName)
 	return p.cleanupAzureResources(ctx, resourceName)
 }
 
@@ -196,7 +196,7 @@ func (p *Provider) createAKSIdentifyingExtension(ctx context.Context, vmName str
 	return nil
 }
 
-func (p *Provider) newNetworkInterfaceForVM(vmName string, backendPools *loadbalancer.BackendAddressPools, instanceType *corecloudprovider.InstanceType) armnetwork.Interface {
+func (p *Provider) newNetworkInterfaceForVM(backendPools *loadbalancer.BackendAddressPools, instanceType *corecloudprovider.InstanceType) armnetwork.Interface {
 	var ipv4BackendPools []*armnetwork.BackendAddressPool
 	for _, poolID := range backendPools.IPv4PoolIDs {
 		poolID := poolID
@@ -217,7 +217,7 @@ func (p *Provider) newNetworkInterfaceForVM(vmName string, backendPools *loadbal
 		Properties: &armnetwork.InterfacePropertiesFormat{
 			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
 				{
-					Name: &vmName,
+					Name: to.Ptr("ipconfig1"),
 					Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 						Primary:                   to.Ptr(true),
 						PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
@@ -244,7 +244,7 @@ func (p *Provider) createNetworkInterface(ctx context.Context, nicName string, l
 		return "", err
 	}
 
-	nic := p.newNetworkInterfaceForVM(nicName, backendPools, instanceType)
+	nic := p.newNetworkInterfaceForVM(backendPools, instanceType)
 	p.applyTemplateToNic(&nic, launchTemplateConfig)
 	logging.FromContext(ctx).Debugf("Creating network interface %s", nicName)
 	res, err := createNic(ctx, p.azClient.networkInterfacesClient, p.resourceGroup, nicName, nic)
@@ -386,7 +386,7 @@ func (p *Provider) launchInstance(
 	resourceName := GenerateResourceName(nodeClaim.Name)
 
 	// create network interface
-	nicReference, err := p.createNetworkInterface(ctx, resourceName, launchTemplate, instanceType)
+	nicReference, err := p.createNetworkInterface(ctx, getNetworkInterfaceName(resourceName), launchTemplate, instanceType)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -408,6 +408,11 @@ func (p *Provider) launchInstance(
 		return nil, nil, err
 	}
 	return resp, instanceType, nil
+}
+
+func getNetworkInterfaceName(vmName string) string {
+	// cloud-provider-azure has certain optimizations (can avoid extra API calls) if this pattern is followed
+	return vmName + "-nic"
 }
 
 // nolint:gocyclo
@@ -560,9 +565,10 @@ func (p *Provider) cleanupAzureResources(ctx context.Context, resourceName strin
 	// The order here is intentional, if the VM was created successfully, then we attempt to delete the vm, the
 	// nic, disk and all associated resources will be removed. If the VM was not created successfully and a nic was found,
 	// then we attempt to delete the nic.
-	nicErr := deleteNicIfExists(ctx, p.azClient.networkInterfacesClient, p.resourceGroup, resourceName)
+	nicName := getNetworkInterfaceName(resourceName)
+	nicErr := deleteNicIfExists(ctx, p.azClient.networkInterfacesClient, p.resourceGroup, nicName)
 	if nicErr != nil {
-		logging.FromContext(ctx).Errorf("networkInterface.Delete for %s failed: %v", resourceName, nicErr)
+		logging.FromContext(ctx).Errorf("networkInterface.Delete for %s failed: %v", nicName, nicErr)
 	}
 
 	return errors.Join(vmErr, nicErr)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Uses "vmname-nic" when naming network interfaces, as cloud-provider-azure has some optimizations for this case. Minor other cleanup.

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
