### PR TITLE
fix: karpenter-values-template

### DIFF
--- a/karpenter-values-template.yaml
+++ b/karpenter-values-template.yaml
@@ -13,7 +13,7 @@ controller:
 
     # options
     - name: CLUSTER_NAME
-      value: $CLUSTER_NAME}
+      value: ${CLUSTER_NAME}
     - name: CLUSTER_ENDPOINT
       value: ${CLUSTER_ENDPOINT}
     - name: KUBELET_BOOTSTRAP_TOKEN


### PR DESCRIPTION
This adds the missing opening brace for the CLUSTER_NAME variable.

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

**How was this change tested?**

I was trying to use the helm deployment, it didn't work. So I fixed the troublesome variable.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
