### PR TITLE
chore(make): fix create-cluster.sh deployment script to work with correct namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOFLAGS ?= $(LDFLAGS)
 WITH_GOFLAGS = GOFLAGS="$(GOFLAGS)"
 
 # # CR for local builds of Karpenter
-SYSTEM_NAMESPACE ?= karpenter
+KARPENTER_NAMESPACE ?= karpenter
 
 # Common Directories
 # TODO: revisit testing tools (temporarily excluded here, for make verify)

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -285,12 +285,12 @@ az-ratelimits: ## Show remaining ARM requests for subscription
 	@az group show   --name $(AZURE_RESOURCE_GROUP)                              --debug 2>&1 | grep x-ms-ratelimit-remaining-subscription-reads
 
 az-kdebug: ## Inject ephemeral debug container (kubectl debug) into Karpenter pod
-	$(eval POD=$(shell kubectl get pods -l app.kubernetes.io/name=karpenter -n karpenter -o name))
-	kubectl debug -n karpenter $(POD) --image wbitt/network-multitool -it -- sh
+	$(eval POD=$(shell kubectl get pods -l app.kubernetes.io/name=karpenter -n "${SYSTEM_NAMESPACE}" -o name))
+	kubectl debug -n "${SYSTEM_NAMESPACE}" $(POD) --image wbitt/network-multitool -it -- sh
 
 az-klogs: ## Karpenter logs
-	$(eval POD=$(shell kubectl get pods -l app.kubernetes.io/name=karpenter -n karpenter -o name))
-	kubectl logs -f -n karpenter $(POD)
+	$(eval POD=$(shell kubectl get pods -l app.kubernetes.io/name=karpenter -n "${SYSTEM_NAMESPACE}" -o name))
+	kubectl logs -f -n "${SYSTEM_NAMESPACE}" $(POD)
 
 az-kevents: ## Karpenter events
 	kubectl get events -A --field-selector source=karpenter
@@ -307,17 +307,17 @@ az-pprof-enable: ## Enable profiling
 	yq -i '.manifests.helm.releases[0].overrides.controller.env += [{"name":"ENABLE_PROFILING","value":"true"}]' skaffold.yaml
 
 az-pprof: ## Profile
-	kubectl port-forward service/karpenter -n karpenter 8000 &
+	kubectl port-forward service/karpenter -n "${SYSTEM_NAMESPACE}" 8000 &
 	sleep 2 && go tool pprof -http 0.0.0.0:9000 localhost:8000/debug/pprof/heap
 
 az-mkaks-user: az-mkrg ## Create compatible AKS cluster, the way we tell users to
-	hack/deploy/create-cluster.sh $(AZURE_CLUSTER_NAME) $(AZURE_RESOURCE_GROUP)
+	hack/deploy/create-cluster.sh $(AZURE_CLUSTER_NAME) $(AZURE_RESOURCE_GROUP) "${SYSTEM_NAMESPACE}"
 
 az-helm-install-snapshot: az-configure-values ## Install Karpenter snapshot release
 	$(eval SNAPSHOT_VERSION ?= $(shell git rev-parse HEAD)) # guess which, specify explicitly with SNAPSHOT_VERSION=...
 	helm upgrade --install karpenter oci://ksnap.azurecr.io/karpenter/snapshot/karpenter \
 		--version 0-$(SNAPSHOT_VERSION) \
-		--namespace karpenter --create-namespace \
+		--namespace "${SYSTEM_NAMESPACE}" --create-namespace \
 		--values karpenter-values.yaml \
 		--set controller.resources.requests.cpu=1 \
 		--set controller.resources.requests.memory=1Gi \

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -72,7 +72,7 @@ az-create-federated-cred:
 	$(eval AKS_OIDC_ISSUER=$(shell az aks show -n "${AZURE_CLUSTER_NAME}" -g "${AZURE_RESOURCE_GROUP}" --query "oidcIssuerProfile.issuerUrl" -otsv))
 
 	# create federated credential linked to the karpenter service account for auth usage
-	az identity federated-credential create --name ${KARPENTER_FEDERATED_IDENTITY_CREDENTIAL_NAME} --identity-name "${AZURE_KARPENTER_USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${AZURE_RESOURCE_GROUP}" --issuer "${AKS_OIDC_ISSUER}" --subject system:serviceaccount:"${SYSTEM_NAMESPACE}":"${KARPENTER_SERVICE_ACCOUNT_NAME}" --audience api://AzureADTokenExchange
+	az identity federated-credential create --name ${KARPENTER_FEDERATED_IDENTITY_CREDENTIAL_NAME} --identity-name "${AZURE_KARPENTER_USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${AZURE_RESOURCE_GROUP}" --issuer "${AKS_OIDC_ISSUER}" --subject system:serviceaccount:"${KARPENTER_NAMESPACE}":"${KARPENTER_SERVICE_ACCOUNT_NAME}" --audience api://AzureADTokenExchange
 
 az-mkaks-savm: az-mkrg ## Create experimental cluster with standalone VMs (+ ACR)
 	az deployment group create --resource-group $(AZURE_RESOURCE_GROUP) --template-file hack/azure/aks-savm.bicep --parameters aksname=$(AZURE_CLUSTER_NAME) acrname=$(AZURE_ACR_NAME)
@@ -285,12 +285,12 @@ az-ratelimits: ## Show remaining ARM requests for subscription
 	@az group show   --name $(AZURE_RESOURCE_GROUP)                              --debug 2>&1 | grep x-ms-ratelimit-remaining-subscription-reads
 
 az-kdebug: ## Inject ephemeral debug container (kubectl debug) into Karpenter pod
-	$(eval POD=$(shell kubectl get pods -l app.kubernetes.io/name=karpenter -n "${SYSTEM_NAMESPACE}" -o name))
-	kubectl debug -n "${SYSTEM_NAMESPACE}" $(POD) --image wbitt/network-multitool -it -- sh
+	$(eval POD=$(shell kubectl get pods -l app.kubernetes.io/name=karpenter -n "${KARPENTER_NAMESPACE}" -o name))
+	kubectl debug -n "${KARPENTER_NAMESPACE}" $(POD) --image wbitt/network-multitool -it -- sh
 
 az-klogs: ## Karpenter logs
-	$(eval POD=$(shell kubectl get pods -l app.kubernetes.io/name=karpenter -n "${SYSTEM_NAMESPACE}" -o name))
-	kubectl logs -f -n "${SYSTEM_NAMESPACE}" $(POD)
+	$(eval POD=$(shell kubectl get pods -l app.kubernetes.io/name=karpenter -n "${KARPENTER_NAMESPACE}" -o name))
+	kubectl logs -f -n "${KARPENTER_NAMESPACE}" $(POD)
 
 az-kevents: ## Karpenter events
 	kubectl get events -A --field-selector source=karpenter
@@ -307,17 +307,17 @@ az-pprof-enable: ## Enable profiling
 	yq -i '.manifests.helm.releases[0].overrides.controller.env += [{"name":"ENABLE_PROFILING","value":"true"}]' skaffold.yaml
 
 az-pprof: ## Profile
-	kubectl port-forward service/karpenter -n "${SYSTEM_NAMESPACE}" 8000 &
+	kubectl port-forward service/karpenter -n "${KARPENTER_NAMESPACE}" 8000 &
 	sleep 2 && go tool pprof -http 0.0.0.0:9000 localhost:8000/debug/pprof/heap
 
 az-mkaks-user: az-mkrg ## Create compatible AKS cluster, the way we tell users to
-	hack/deploy/create-cluster.sh $(AZURE_CLUSTER_NAME) $(AZURE_RESOURCE_GROUP) "${SYSTEM_NAMESPACE}"
+	hack/deploy/create-cluster.sh $(AZURE_CLUSTER_NAME) $(AZURE_RESOURCE_GROUP) "${KARPENTER_NAMESPACE}"
 
 az-helm-install-snapshot: az-configure-values ## Install Karpenter snapshot release
 	$(eval SNAPSHOT_VERSION ?= $(shell git rev-parse HEAD)) # guess which, specify explicitly with SNAPSHOT_VERSION=...
 	helm upgrade --install karpenter oci://ksnap.azurecr.io/karpenter/snapshot/karpenter \
 		--version 0-$(SNAPSHOT_VERSION) \
-		--namespace "${SYSTEM_NAMESPACE}" --create-namespace \
+		--namespace "${KARPENTER_NAMESPACE}" --create-namespace \
 		--values karpenter-values.yaml \
 		--set controller.resources.requests.cpu=1 \
 		--set controller.resources.requests.memory=1Gi \

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Install these tools before proceeding:
 
 Create a new AKS cluster with the required configuration, and ready to run Karpenter using workload identity.
 
-> Note: You can use `hack/deploy/create-cluster.sh <cluster-name> <resource-group>` to automate the following steps.
+> Note: You can use `hack/deploy/create-cluster.sh <cluster-name> <resource-group> <namespace>` to automate the following steps.
 
 Set environment variables:
 
@@ -71,7 +71,7 @@ Set environment variables:
 export CLUSTER_NAME=karpenter
 export RG=karpenter
 export LOCATION=eastus
-export KARPENTER_NAMESPACE=karpenter
+export SYSTEM_NAMESPACE=karpenter
 
 ```
 
@@ -104,7 +104,7 @@ Create federated credential linked to the karpenter service account for auth usa
 ```bash
 az identity federated-credential create --name KARPENTER_FID --identity-name karpentermsi --resource-group "${RG}" \
   --issuer "$(jq -r ".oidcIssuerProfile.issuerUrl" <<< "$AKS_JSON")" \
-  --subject system:serviceaccount:${KARPENTER_NAMESPACE}:karpenter-sa \
+  --subject system:serviceaccount:${SYSTEM_NAMESPACE}:karpenter-sa \
   --audience api://AzureADTokenExchange
 ```
 
@@ -139,7 +139,7 @@ export KARPENTER_VERSION=v0.3.0
 
 helm upgrade --install karpenter oci://mcr.microsoft.com/aks/karpenter/karpenter \
   --version "${KARPENTER_VERSION}" \
-  --namespace "${KARPENTER_NAMESPACE}" --create-namespace \
+  --namespace "${SYSTEM_NAMESPACE}" --create-namespace \
   --values karpenter-values.yaml \
   --set controller.resources.requests.cpu=1 \
   --set controller.resources.requests.memory=1Gi \
@@ -147,18 +147,18 @@ helm upgrade --install karpenter oci://mcr.microsoft.com/aks/karpenter/karpenter
   --set controller.resources.limits.memory=1Gi \
   --wait
 
-kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
+kubectl logs -f -n "${SYSTEM_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
-Snapshot versions can be installed in a similar way:
+Snapshot versions can be installed in a similar way for development:
 
 ```bash
-export KARPENTER_NAMESPACE=karpenter
+export SYSTEM_NAMESPACE=karpenter
 export KARPENTER_VERSION=0-f83fadf2c99ffc2b7429cb40a316fcefc0c4752a
 
 helm upgrade --install karpenter oci://ksnap.azurecr.io/karpenter/snapshot/karpenter \
   --version "${KARPENTER_VERSION}" \
-  --namespace "${KARPENTER_NAMESPACE}" --create-namespace \
+  --namespace "${SYSTEM_NAMESPACE}" --create-namespace \
   --values karpenter-values.yaml \
   --set controller.resources.requests.cpu=1 \
   --set controller.resources.requests.memory=1Gi \
@@ -166,7 +166,7 @@ helm upgrade --install karpenter oci://ksnap.azurecr.io/karpenter/snapshot/karpe
   --set controller.resources.limits.memory=1Gi \
   --wait
 
-kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
+kubectl logs -f -n "${SYSTEM_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 ### Create NodePool
@@ -252,7 +252,7 @@ spec:
 EOF
 
 kubectl scale deployment inflate --replicas 5
-kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
+kubectl logs -f -n "${SYSTEM_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 ### Scale down deployment
@@ -261,7 +261,7 @@ Now, delete the deployment. After a short amount of time, Karpenter should termi
 
 ```bash
 kubectl delete deployment inflate
-kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
+kubectl logs -f -n "${SYSTEM_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 ### Delete Karpenter nodes manually
@@ -277,7 +277,7 @@ kubectl delete node $NODE_NAME
 To avoid additional charges, remove the demo infrastructure from your AKS account.
 
 ```bash
-helm uninstall karpenter --namespace "${KARPENTER_NAMESPACE}"
+helm uninstall karpenter --namespace "${SYSTEM_NAMESPACE}"
 az aks delete --name "${CLUSTER_NAME}" --resource-group "${RG}"
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Set environment variables:
 export CLUSTER_NAME=karpenter
 export RG=karpenter
 export LOCATION=eastus
-export SYSTEM_NAMESPACE=karpenter
+export SYSTEM_NAMESPACE=kube-system
 
 ```
 
@@ -153,7 +153,7 @@ kubectl logs -f -n "${SYSTEM_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c 
 Snapshot versions can be installed in a similar way for development:
 
 ```bash
-export SYSTEM_NAMESPACE=karpenter
+export SYSTEM_NAMESPACE=kube-system
 export KARPENTER_VERSION=0-f83fadf2c99ffc2b7429cb40a316fcefc0c4752a
 
 helm upgrade --install karpenter oci://ksnap.azurecr.io/karpenter/snapshot/karpenter \

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Set environment variables:
 export CLUSTER_NAME=karpenter
 export RG=karpenter
 export LOCATION=eastus
-export KARPENTER_NAMESPACE=kube-system
+export KARPENTER_NAMESPACE=karpenter
 
 ```
 
@@ -153,7 +153,7 @@ kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter 
 Snapshot versions can be installed in a similar way:
 
 ```bash
-export KARPENTER_NAMESPACE=kube-system
+export KARPENTER_NAMESPACE=karpenter
 export KARPENTER_VERSION=0-f83fadf2c99ffc2b7429cb40a316fcefc0c4752a
 
 helm upgrade --install karpenter oci://ksnap.azurecr.io/karpenter/snapshot/karpenter \

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Set environment variables:
 export CLUSTER_NAME=karpenter
 export RG=karpenter
 export LOCATION=eastus
-export SYSTEM_NAMESPACE=kube-system
+export KARPENTER_NAMESPACE=kube-system
 
 ```
 
@@ -104,7 +104,7 @@ Create federated credential linked to the karpenter service account for auth usa
 ```bash
 az identity federated-credential create --name KARPENTER_FID --identity-name karpentermsi --resource-group "${RG}" \
   --issuer "$(jq -r ".oidcIssuerProfile.issuerUrl" <<< "$AKS_JSON")" \
-  --subject system:serviceaccount:${SYSTEM_NAMESPACE}:karpenter-sa \
+  --subject system:serviceaccount:${KARPENTER_NAMESPACE}:karpenter-sa \
   --audience api://AzureADTokenExchange
 ```
 
@@ -139,7 +139,7 @@ export KARPENTER_VERSION=v0.3.0
 
 helm upgrade --install karpenter oci://mcr.microsoft.com/aks/karpenter/karpenter \
   --version "${KARPENTER_VERSION}" \
-  --namespace "${SYSTEM_NAMESPACE}" --create-namespace \
+  --namespace "${KARPENTER_NAMESPACE}" --create-namespace \
   --values karpenter-values.yaml \
   --set controller.resources.requests.cpu=1 \
   --set controller.resources.requests.memory=1Gi \
@@ -147,18 +147,18 @@ helm upgrade --install karpenter oci://mcr.microsoft.com/aks/karpenter/karpenter
   --set controller.resources.limits.memory=1Gi \
   --wait
 
-kubectl logs -f -n "${SYSTEM_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
+kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 Snapshot versions can be installed in a similar way for development:
 
 ```bash
-export SYSTEM_NAMESPACE=kube-system
+export KARPENTER_NAMESPACE=kube-system
 export KARPENTER_VERSION=0-f83fadf2c99ffc2b7429cb40a316fcefc0c4752a
 
 helm upgrade --install karpenter oci://ksnap.azurecr.io/karpenter/snapshot/karpenter \
   --version "${KARPENTER_VERSION}" \
-  --namespace "${SYSTEM_NAMESPACE}" --create-namespace \
+  --namespace "${KARPENTER_NAMESPACE}" --create-namespace \
   --values karpenter-values.yaml \
   --set controller.resources.requests.cpu=1 \
   --set controller.resources.requests.memory=1Gi \
@@ -166,7 +166,7 @@ helm upgrade --install karpenter oci://ksnap.azurecr.io/karpenter/snapshot/karpe
   --set controller.resources.limits.memory=1Gi \
   --wait
 
-kubectl logs -f -n "${SYSTEM_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
+kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 ### Create NodePool
@@ -252,7 +252,7 @@ spec:
 EOF
 
 kubectl scale deployment inflate --replicas 5
-kubectl logs -f -n "${SYSTEM_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
+kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 ### Scale down deployment
@@ -261,7 +261,7 @@ Now, delete the deployment. After a short amount of time, Karpenter should termi
 
 ```bash
 kubectl delete deployment inflate
-kubectl logs -f -n "${SYSTEM_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
+kubectl logs -f -n "${KARPENTER_NAMESPACE}" -l app.kubernetes.io/name=karpenter -c controller
 ```
 
 ### Delete Karpenter nodes manually
@@ -277,7 +277,7 @@ kubectl delete node $NODE_NAME
 To avoid additional charges, remove the demo infrastructure from your AKS account.
 
 ```bash
-helm uninstall karpenter --namespace "${SYSTEM_NAMESPACE}"
+helm uninstall karpenter --namespace "${KARPENTER_NAMESPACE}"
 az aks delete --name "${CLUSTER_NAME}" --resource-group "${RG}"
 ```
 

--- a/hack/deploy/create-cluster.sh
+++ b/hack/deploy/create-cluster.sh
@@ -8,7 +8,7 @@ fi
 
 CLUSTER_NAME=$1
 RG=$2
-SYSTEM_NAMESPACE=$3
+KARPENTER_NAMESPACE=$3
 
 echo "Creating the workload MSI for Karpenter use ..."
 LOCATION=$(az group show --name "${RG}" --query "location" -otsv)
@@ -26,7 +26,7 @@ az aks get-credentials --name "${CLUSTER_NAME}" --resource-group "${RG}" --overw
 echo "Creating federated credential linked to the Karpenter service account ..."
 az identity federated-credential create --name KARPENTER_FID --identity-name karpentermsi --resource-group "${RG}" \
   --issuer "$(jq -r ".oidcIssuerProfile.issuerUrl" <<< "$AKS_JSON")" \
-  --subject system:serviceaccount:${SYSTEM_NAMESPACE}:karpenter-sa \
+  --subject system:serviceaccount:${KARPENTER_NAMESPACE}:karpenter-sa \
   --audience api://AzureADTokenExchange
 
 echo "Creating role assignments to let Karpenter manage VMs and Network resources ..."

--- a/hack/deploy/create-cluster.sh
+++ b/hack/deploy/create-cluster.sh
@@ -8,7 +8,7 @@ fi
 
 CLUSTER_NAME=$1
 RG=$2
-KARPENTER_NAMESPACE=kube-system
+KARPENTER_NAMESPACE=karpenter
 
 echo "Creating the workload MSI for Karpenter use ..."
 LOCATION=$(az group show --name "${RG}" --query "location" -otsv)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
When testing `v0.4.0.rc.3` I noticed the service account federated credential not aligning correctly. The namespace within `create-cluster.sh` should be `karpenter`, so fixing.

**How was this change tested?**
tested this exact change with `v0.4.0.rc.3` on a different branch/code space and worked correctly.
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
