### PR TITLE
fix: don't use untagged on ksnap acr purge

### DIFF
--- a/hack/infra/ksnap-acr.bicep
+++ b/hack/infra/ksnap-acr.bicep
@@ -15,10 +15,11 @@ resource acr 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' = {
 
 var schedule = '0 1 * * Tue' // 1am UTC every Tuesday
 
+// --untagged appears to be broken: https://github.com/Azure/acr-cli/issues/131
 var purgeOldArtifacts = '''
 version: v1.1.0
 steps:
-- cmd: acr purge --filter 'karpenter/snapshot/.*:.*' --ago 30d --untagged
+- cmd: acr purge --filter 'karpenter/snapshot/.*:.*' --ago 30d
   disableWorkingDirectoryOverride: true
   timeout: 3600
 '''


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Don't use `--untagged` on ksnap acr purge, as it appears to be broken: https://github.com/Azure/acr-cli/issues/131

**How was this change tested?**

* (not tested yet)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
