### PR TITLE
feat: adding wiring for --network-plugin-mode and vnet labels cleanup

### DIFF
--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -66,6 +66,7 @@ type Options struct {
 	SSHPublicKey                   string   // ssh.publicKeys.keyData => VM SSH public key // TODO: move to v1alpha2.AKSNodeClass?
 	NetworkPlugin                  string   // => NetworkPlugin in bootstrap
 	NetworkPolicy                  string   // => NetworkPolicy in bootstrap
+	NetworkPluginMode				string  // => Network Plugin mode is used to set AzureCNIs network plugin mode to overlay. Learn more about overlay networking here: https://learn.microsoft.com/en-us/azure/aks/azure-cni-overlay?tabs=kubectl#overview-of-overlay-networking
 	NodeIdentities                 []string // => Applied onto each VM
 
 	SubnetID string // => VnetSubnetID to use (for nodes in Azure CNI Overlay and Azure CNI + pod subnet; for for nodes and pods in Azure CNI), unless overridden via AKSNodeClass
@@ -80,6 +81,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.KubeletClientTLSBootstrapToken, "kubelet-bootstrap-token", env.WithDefaultString("KUBELET_BOOTSTRAP_TOKEN", ""), "[REQUIRED] The bootstrap token for new nodes to join the cluster.")
 	fs.StringVar(&o.SSHPublicKey, "ssh-public-key", env.WithDefaultString("SSH_PUBLIC_KEY", ""), "[REQUIRED] VM SSH public key.")
 	fs.StringVar(&o.NetworkPlugin, "network-plugin", env.WithDefaultString("NETWORK_PLUGIN", "azure"), "The network plugin used by the cluster.")
+	fs.StringVar(&o.NetworkPluginMode, "network-plugin-mode", env.WithDefaultString("NETWORK_PLUGIN_MODE", "overlay"), "[REQUIRED] network plugin mode of the cluster")
 	fs.StringVar(&o.NetworkPolicy, "network-policy", env.WithDefaultString("NETWORK_POLICY", ""), "The network policy used by the cluster.")
 	fs.StringVar(&o.SubnetID, "vnet-subnet-id", env.WithDefaultString("VNET_SUBNET_ID", ""), "The default subnet ID to use for new nodes. This must be a valid ARM resource ID for subnet that does not overlap with the service CIDR or the pod CIDR")
 	fs.Var(newNodeIdentitiesValue(env.WithDefaultString("NODE_IDENTITIES", ""), &o.NodeIdentities), "node-identities", "User assigned identities for nodes.")

--- a/pkg/operator/options/options_validation.go
+++ b/pkg/operator/options/options_validation.go
@@ -31,9 +31,19 @@ func (o Options) Validate() error {
 		o.validateRequiredFields(),
 		o.validateEndpoint(),
 		o.validateVMMemoryOverheadPercent(),
+		o.validateNetworkPluginMode(),
 		o.validateVnetSubnetID(),
 		validate.Struct(o),
 	)
+}
+
+func (o Options) validateNetworkPluginMode() error {
+	// TODO: Move overlay and none to shared constants in AgentBaker
+	// NOTE: Network Plugin Mode should be normalized on the AKS API Level, so if we are passing values in from the ManagedCluster, NetworkPluginMode will already be normalized.
+	if o.NetworkPluginMode != "overlay" && o.NetworkPluginMode != "" && o.NetworkPluginMode != "none" {
+		return fmt.Errorf("network-plugin-mode %v is invalid. network-plugin-mode must equal 'overlay', 'none' or ''.", o.NetworkPluginMode)
+	}
+	return nil
 }
 
 func (o Options) validateVnetSubnetID() error {

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -19,6 +19,7 @@ package options_test
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 
@@ -115,6 +116,21 @@ var _ = Describe("Options", func() {
 	})
 
 	Context("Validation", func() {
+		It("should fail validation when networkPluginMode is invalid", func() {
+			typo := "overlaay"
+			errMsg := fmt.Sprintf("network-plugin-mode %v is invalid. network-plugin-mode must equal 'overlay', 'none' or ''.", typo)
+
+			err := opts.Parse(
+				fs, 
+				"--cluster-name", "my-name",
+				"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+				"--kubelet-bootstrap-token", "flag-bootstrap-token",
+				"--ssh-public-key", "flag-ssh-public-key",
+				"--vm-memory-overhead-percent", "-0.01",
+				"--network-plugin-mode", typo,
+			)
+			Expect(err).To(MatchError(ContainSubstring(errMsg)))
+		})
 		It("should fail validation when clusterName not included", func() {
 			err := opts.Parse(
 				fs,

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -43,6 +43,7 @@ const (
 	vnetGUIDLabel           = "kubernetes.azure.com/nodenetwork-vnetguid"
 	vnetPodNetworkTypeLabel = "kubernetes.azure.com/podnetwork-type"
 
+	networkPluginAzure = "azure"
 	networkModeOverlay = "overlay"
 )
 
@@ -114,7 +115,7 @@ func (p *Provider) getStaticParameters(ctx context.Context, instanceType *cloudp
 		arch = corev1beta1.ArchitectureArm64
 	}
 
-	if options.FromContext(ctx).NetworkPluginMode == networkModeOverlay {
+	if options.FromContext(ctx).NetworkPlugin == networkPluginAzure && options.FromContext(ctx).NetworkPluginMode == networkModeOverlay {
 		// TODO: make conditional on pod subnet
 		vnetLabels, err := p.getVnetInfoLabels(ctx, nodeClass)
 		if err != nil {

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -32,6 +32,7 @@ type OptionsFields struct {
 	KubeletClientTLSBootstrapToken *string
 	SSHPublicKey                   *string
 	NetworkPlugin                  *string
+	NetworkPluginMode			   *string
 	NetworkPolicy                  *string
 	VMMemoryOverheadPercent        *float64
 	NodeIdentities                 []string
@@ -52,6 +53,7 @@ func Options(overrides ...OptionsFields) *azoptions.Options {
 		KubeletClientTLSBootstrapToken: lo.FromPtrOr(options.KubeletClientTLSBootstrapToken, "test-token"),
 		SSHPublicKey:                   lo.FromPtrOr(options.SSHPublicKey, "test-ssh-public-key"),
 		NetworkPlugin:                  lo.FromPtrOr(options.NetworkPlugin, "azure"),
+		NetworkPluginMode:				lo.FromPtrOr(options.NetworkPluginMode, "overlay"),
 		NetworkPolicy:                  lo.FromPtrOr(options.NetworkPolicy, "cilium"),
 		VMMemoryOverheadPercent:        lo.FromPtrOr(options.VMMemoryOverheadPercent, 0.075),
 		NodeIdentities:                 options.NodeIdentities,


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
We need to pass in the wiring of the `network-plugin-mode` for supporting azure cni without overlay. This is the first step for that support. It also includes some general cleanup. 

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
