### PR TITLE
chore: using lo.FromPtr is safer than directly accessing the pointer

### DIFF
--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -307,7 +307,7 @@ func memory(ctx context.Context, sku *skewer.SKU) *resource.Quantity {
 }
 
 func ephemeralStorage(nodeClass *v1alpha2.AKSNodeClass) *resource.Quantity {
-	return resource.NewScaledQuantity(int64(*nodeClass.Spec.OSDiskSizeGB), resource.Giga)
+	return resource.NewScaledQuantity(int64(lo.FromPtr(nodeClass.Spec.OSDiskSizeGB)), resource.Giga)
 }
 
 func pods(sku *skewer.SKU, kc *corev1beta1.KubeletConfiguration) *resource.Quantity {


### PR DESCRIPTION
The nodeClass.Spec.OSDiskSizeGB dereference actually crashes when being called from the cloudprovider GetInstanceTypes if the nodepool is nil.

Fixes #315 

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!-- issue number -->

**Description**

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
