### PR TITLE
fix: upgrading node image versions in drift e2e since we are deprecating older node image versions

### DIFF
--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -116,8 +116,9 @@ var _ = Describe("Drift", func() {
 		SetDefaultEventuallyTimeout(5 * time.Minute)
 	})
 	It("should upgrade nodes using drift based on node image version change", func() {
-		startingImageVersion := "202309.29.0"
-		upgradedImageVersion := "202310.01.0"
+		// TODO: Get these dynamically
+		startingImageVersion := "202404.09.0"
+		upgradedImageVersion := "202404.16.0"
 
 		nodeClass.Spec.ImageVersion = &startingImageVersion
 


### PR DESCRIPTION


<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Upgrading older node image versions to new ones to make sure e2e doesnt break during deprecation

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
