### PR TITLE
fix: reallowing nodeclaim zones to fix node/nodeclaim creations for workloads with zone affinity constraints

### DIFF
--- a/hack/validation/common.sh
+++ b/hack/validation/common.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# remove topology.kubernetes.io/zone from allowed labels and requirements
+# remove topology.kubernetes.io/zone from allowed labels and requirements for nodepools
 # until the continuous drift it causes is fixed
-sed -e 's|"topology.kubernetes.io/zone", ||g' -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
 sed -e 's|"topology.kubernetes.io/zone", ||g' -i pkg/apis/crds/karpenter.sh_nodepools.yaml

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -212,7 +212,7 @@ spec:
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
                         x-kubernetes-validations:
                           - message: label domain "kubernetes.io" is restricted
-                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
                           - message: label domain "k8s.io" is restricted
                             rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
                           - message: label domain "karpenter.sh" is restricted


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #339 

**Description**
See the issue.
This change should not undo the continuous drift issue that https://github.com/Azure/karpenter-provider-azure/pull/274 fixes, as adding zones requirements is still prohibited on the nodepool CRD, which is the (intentionally) user-facing interface.
Current drift logic also "ignore" requirements that exist in NodeClaims, but not NodePools.

**How was this change tested?**
* Manual inspection from reproduction
* NAP E2Es
* Check-ins here

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
- Fix the issue where Karpenter/NAP sometimes cannot create nodes/nodeclaims for workloads with zone affinity constraints
```
