### PR TITLE
fix configure-values.sh missing AZURE_SUBSCRIPTION_ID

### DIFF
--- a/hack/deploy/configure-values.sh
+++ b/hack/deploy/configure-values.sh
@@ -19,7 +19,7 @@ AZURE_KARPENTER_USER_ASSIGNED_IDENTITY_NAME=$4
 AKS_JSON=$(az aks show --name "$CLUSTER_NAME" --resource-group "$AZURE_RESOURCE_GROUP")
 AZURE_LOCATION=$(jq -r ".location" <<< "$AKS_JSON")
 AZURE_RESOURCE_GROUP_MC=$(jq -r ".nodeResourceGroup" <<< "$AKS_JSON")
-AZURE_SUBSCRIPTION_ID=$(jq -r ".nodeResourceGroup" <<< "$AKS_JSON" | cut -d'/' -f3)
+AZURE_SUBSCRIPTION_ID=$(az account show --query 'id' -otsv)
 
 CLUSTER_ENDPOINT=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

ottodeng@karpenter-client:~$ chmod +x ./configure-values.sh && ./configure-values.sh ${CLUSTER_NAME} ${RG} karpenter-sa karpentermsi
Configuring karpenter-values.yaml for cluster karpenter in resource group karpenter ...
Error: variable ${AZURE_SUBSCRIPTION_ID} not set

**How was this change tested?**

ottodeng@karpenter-client:~$ chmod +x ./configure-values.sh && ./configure-values.sh ${CLUSTER_NAME} ${RG} karpenter-sa karpentermsi
Configuring karpenter-values.yaml for cluster karpenter in resource group karpenter ...

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
