### PR TITLE
feat: supporting 1.30 bootstrap via enabling out of tree credential provider

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8sVersion: ["1.25.x", "1.26.x", "1.27.x", "1.28.x", "1.29.x"]
+        k8sVersion: ["1.25.x", "1.26.x", "1.27.x", "1.28.x", "1.29.x", "1.30.x"]
     env:
       K8S_VERSION: ${{ matrix.k8sVersion }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/Azure/skewer v0.0.19
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
+	github.com/blang/semver/v4 v4.0.0
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/go-playground/validator/v10 v10.19.0
@@ -66,7 +67,6 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-K8S_VERSION="${K8S_VERSION:="1.29.x"}"
+K8S_VERSION="${K8S_VERSION:="1.30.x"}"
 KUBEBUILDER_ASSETS="/usr/local/kubebuilder/bin"
 
 main() {

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-K8S_VERSION="${K8S_VERSION:="1.30.x"}"
+K8S_VERSION="${K8S_VERSION:="1.29.x"}"
 KUBEBUILDER_ASSETS="/usr/local/kubebuilder/bin"
 
 main() {

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -386,7 +386,7 @@ var (
 		KubenetTemplate:                 base64.StdEncoding.EncodeToString(kubenetTemplate),                  // s
 		ContainerdConfigContent:         "",                                                                  // kd
 		IsKata:                          false,                                                               // n
-
+		NeedsCgroupV2:                   true,                                                                // s only static for karpenter
 	}
 )
 

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -438,7 +438,6 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 	nbv.KubeBinaryURL = kubeBinaryURL(a.KubernetesVersion, a.Arch)
 	nbv.VNETCNILinuxPluginsURL = fmt.Sprintf("%s/azure-cni/v1.4.32/binaries/azure-vnet-cni-linux-%s-v1.4.32.tgz", globalAKSMirror, a.Arch)
 	nbv.CNIPluginsURL = fmt.Sprintf("%s/cni-plugins/v1.1.1/binaries/cni-plugins-linux-%s-v1.1.1.tgz", globalAKSMirror, a.Arch)
-
 	nbv.CredentialProviderDownloadURL = fmt.Sprintf("https://acs-mirror.azureedge.net/cloud-provider-azure/%s/binaries/azure-acr-credential-provider-linux-amd64-v%s.tar.gz", nbv.KubernetesVersion, nbv.KubernetesVersion)
 	// calculated values
 	nbv.EnsureNoDupePromiscuousBridge = nbv.NeedsContainerd && nbv.NetworkPlugin == "kubenet" && nbv.NetworkPolicy != "calico"
@@ -488,7 +487,6 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 	nbv.KubeletFlags = strings.Join(lo.MapToSlice(kubeletFlags, func(k, v string) string {
 		return fmt.Sprintf("%s=%s", k, v)
 	}), " ")
-
 }
 
 func containerdConfigFromNodeBootstrapVars(nbv *NodeBootstrapVariables) (string, error) {

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -452,7 +452,6 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 		nbv.GPUImageSHA = a.GPUImageSHA
 	}
 
-	
 	// merge and stringify labels
 	kubeletLabels := lo.Assign(kubeletNodeLabelsBase, a.Labels)
 	getAgentbakerGeneratedLabels(a.ResourceGroup, kubeletLabels)
@@ -465,7 +464,7 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 	nbv.KubeletNodeLabels = strings.Join(lo.MapToSlice(kubeletLabels, func(k, v string) string {
 		return fmt.Sprintf("%s=%s", k, v)
 	}), ",")
-	
+
 	// Assign Per K8s version kubelet flags
 	minorVersion := semver.MustParse(a.KubernetesVersion).Minor
 	if minorVersion < 30 {
@@ -484,12 +483,12 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 
 	nodeclaimKubeletConfig := KubeletConfigToMap(a.KubeletConfig)
 	kubeletFlags = lo.Assign(kubeletFlags, nodeclaimKubeletConfig)
-	
+
 	// striginify kubelet flags (including taints)
 	nbv.KubeletFlags = strings.Join(lo.MapToSlice(kubeletFlags, func(k, v string) string {
 		return fmt.Sprintf("%s=%s", k, v)
 	}), " ")
-	
+
 }
 
 func containerdConfigFromNodeBootstrapVars(nbv *NodeBootstrapVariables) (string, error) {

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -240,12 +240,12 @@ var (
 	// source note: unique per nodepool. partially user-specified, static, and RP-generated
 	// removed --image-pull-progress-deadline=30m  (not in 1.24?)
 	// removed --network-plugin=cni (not in 1.24?)
+	// removed --azure-container-registry-config (not in 1.30)
 	kubeletFlagsBase = map[string]string{
 		"--address":                           "0.0.0.0",
 		"--anonymous-auth":                    "false",
 		"--authentication-token-webhook":      "true",
 		"--authorization-mode":                "Webhook",
-		"--azure-container-registry-config":   "/etc/kubernetes/azure.json",
 		"--cgroups-per-qos":                   "true",
 		"--client-ca-file":                    "/etc/kubernetes/certs/ca.crt",
 		"--cloud-config":                      "/etc/kubernetes/azure.json",

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -466,11 +466,11 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 
 	// Assign Per K8s version kubelet flags
 	minorVersion := semver.MustParse(a.KubernetesVersion).Minor
-	if minorVersion < 30 {
-		kubeletFlagsBase["--azure-container-registry-config"] = "/etc/kubernetes/azure.json"
-	} else { // minorVersion >= 30
+	if utils.UseOOTCredential(minorVersion) {
 		kubeletFlagsBase["--image-credential-provider-config"] = "/var/lib/kubelet/credential-provider-config.yaml"
 		kubeletFlagsBase["--image-credential-provider-bin-dir"] = "/var/lib/kubelet/credential-provider"
+	} else { // Versions Less than 1.30
+		kubeletFlagsBase["--azure-container-registry-config"] = "/etc/kubernetes/azure.json"
 	}
 	// merge and stringify taints
 	kubeletFlags := lo.Assign(kubeletFlagsBase)

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -438,7 +438,6 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 	nbv.KubeBinaryURL = kubeBinaryURL(a.KubernetesVersion, a.Arch)
 	nbv.VNETCNILinuxPluginsURL = fmt.Sprintf("%s/azure-cni/v1.4.32/binaries/azure-vnet-cni-linux-%s-v1.4.32.tgz", globalAKSMirror, a.Arch)
 	nbv.CNIPluginsURL = fmt.Sprintf("%s/cni-plugins/v1.1.1/binaries/cni-plugins-linux-%s-v1.1.1.tgz", globalAKSMirror, a.Arch)
-	nbv.CredentialProviderDownloadURL = fmt.Sprintf("https://acs-mirror.azureedge.net/cloud-provider-azure/%s/binaries/azure-acr-credential-provider-linux-amd64-v%s.tar.gz", nbv.KubernetesVersion, nbv.KubernetesVersion)
 	// calculated values
 	nbv.EnsureNoDupePromiscuousBridge = nbv.NeedsContainerd && nbv.NetworkPlugin == "kubenet" && nbv.NetworkPolicy != "calico"
 	nbv.NetworkSecurityGroup = fmt.Sprintf("aks-agentpool-%s-nsg", a.ClusterID)
@@ -467,6 +466,7 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 	// Assign Per K8s version kubelet flags
 	minorVersion := semver.MustParse(a.KubernetesVersion).Minor
 	if utils.UseOOTCredential(minorVersion) {
+		nbv.CredentialProviderDownloadURL = fmt.Sprintf("https://acs-mirror.azureedge.net/cloud-provider-azure/%s/binaries/azure-acr-credential-provider-linux-amd64-v%s.tar.gz", nbv.KubernetesVersion, nbv.KubernetesVersion)
 		kubeletFlagsBase["--image-credential-provider-config"] = "/var/lib/kubelet/credential-provider-config.yaml"
 		kubeletFlagsBase["--image-credential-provider-bin-dir"] = "/var/lib/kubelet/credential-provider"
 	} else { // Versions Less than 1.30

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -468,8 +468,7 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 	minorVersion := semver.MustParse(a.KubernetesVersion).Minor
 	if minorVersion < 30 {
 		kubeletFlagsBase["--azure-container-registry-config"] = "/etc/kubernetes/azure.json"
-	}
-	if minorVersion >= 30 {
+	} else { // minorVersion >= 30
 		kubeletFlagsBase["--image-credential-provider-config"] = "/var/lib/kubelet/credential-provider-config.yaml"
 		kubeletFlagsBase["--image-credential-provider-bin-dir"] = "/var/lib/kubelet/credential-provider"
 	}

--- a/pkg/providers/imagefamily/bootstrap/cse_cmd.sh.gtpl
+++ b/pkg/providers/imagefamily/bootstrap/cse_cmd.sh.gtpl
@@ -24,6 +24,7 @@ KUBERNETES_VERSION={{.KubernetesVersion}}
 HYPERKUBE_URL={{.HyperkubeURL}}
 KUBE_BINARY_URL={{.KubeBinaryURL}}
 CUSTOM_KUBE_BINARY_URL={{.CustomKubeBinaryURL}}
+CREDENTIAL_PROVIDER_DOWNLOAD_URL={{.CredentialProviderDownloadURL}}
 KUBEPROXY_URL={{.KubeproxyURL}}
 APISERVER_PUBLIC_KEY={{.APIServerPublicKey}}
 SUBSCRIPTION_ID={{.SubscriptionID}}

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1091,6 +1091,33 @@ var _ = Describe("InstanceType Provider", func() {
 		})
 	})
 
+	Context("Bootstrap", func() {
+		It("should gate kubelet flags that are dependent on kubelet version", func() {
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+			pod := coretest.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
+			ExpectScheduled(ctx, env.Client, pod)
+
+			Expect(azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			vm := azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Pop().VM
+			customData := *vm.Properties.OSProfile.CustomData
+			Expect(customData).ToNot(BeNil())
+			decodedBytes, err := base64.StdEncoding.DecodeString(customData)
+			Expect(err).To(Succeed())
+			decodedString := string(decodedBytes[:])
+			kubeletFlags := decodedString[strings.Index(decodedString, "KUBELET_FLAGS=")+len("KUBELET_FLAGS="):]
+			if env.Version.Minor() < 30 {
+				Expect(kubeletFlags).To(
+					ContainSubstring("--azure-container-registry-config"),
+				)
+			} else {
+				Expect(kubeletFlags).To(Not(
+					ContainSubstring("--azure-container-registry-config"),
+				))
+			}
+		})
+	})
+
 	Context("LoadBalancer", func() {
 		resourceGroup := "test-resourceGroup"
 

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1117,7 +1117,7 @@ var _ = Describe("InstanceType Provider", func() {
 				}
 				return flagMap
 			}
-			
+
 			// TODO: (bsoghigian) leverage the helpers from the azure cni pr once they get in instead for testing kubelet flags
 			flagMap := parseKubeletFlags(kubeletFlags)
 			if env.Version.Minor() < 30 {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1131,16 +1131,14 @@ var _ = Describe("InstanceType Provider", func() {
 				fmt.Sprintf("https://acs-mirror.azureedge.net/cloud-provider-azure/%s/binaries/azure-acr-credential-provider-linux-amd64-v%s.tar.gz", parsed.String(), parsed.String()),
 			))
 
-			if parsed.Minor < 30 {
-				fmt.Println("K8s Version for env client: ")
-				Expect(flagMap).To(HaveKey("--azure-container-registry-config"))
-				Expect(flagMap).ToNot(HaveKey("--image-credential-provider-config"))
-				Expect(flagMap).ToNot(HaveKey("--image-credential-provider-bin-dir"))
-
-			} else {
+			if utils.UseOOTCredential(parsed.Minor) {
 				Expect(flagMap).ToNot(HaveKey("--azure-container-registry-config"))
 				Expect(flagMap).To(HaveKeyWithValue("--image-credential-provider-config", "/var/lib/kubelet/credential-provider-config.yaml"))
 				Expect(flagMap).To(HaveKeyWithValue("--image-credential-provider-bin-dir", "/var/lib/kubelet/credential-provider"))
+			} else {
+				Expect(flagMap).To(HaveKey("--azure-container-registry-config"))
+				Expect(flagMap).ToNot(HaveKey("--image-credential-provider-config"))
+				Expect(flagMap).ToNot(HaveKey("--image-credential-provider-bin-dir"))
 			}
 		})
 	})

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1107,10 +1107,6 @@ var _ = Describe("InstanceType Provider", func() {
 			Expect(err).To(Succeed())
 			decodedString := string(decodedBytes[:])
 			Expect(decodedString).To(ContainSubstring("CREDENTIAL_PROVIDER_DOWNLOAD_URL"))
-			Expect(decodedString).To(ContainSubstring(
-				fmt.Sprintf("https://acs-mirror.azureedge.net/cloud-provider-azure/%s/binaries/azure-acr-credential-provider-linux-amd64-v%s.tar.gz", env.Version.String(), env.Version.String()),
-			))
-
 			kubeletFlags := decodedString[strings.Index(decodedString, "KUBELET_FLAGS=")+len("KUBELET_FLAGS="):]
 			parseKubeletFlags := func(flags string) map[string]string {
 				flagMap := make(map[string]string)
@@ -1130,6 +1126,12 @@ var _ = Describe("InstanceType Provider", func() {
 			k8sVersion, err := azureEnv.ImageProvider.KubeServerVersion(ctx)
 			Expect(err).To(BeNil())
 			parsed := semver.MustParse(k8sVersion)
+
+			Expect(decodedString).To(ContainSubstring(
+				fmt.Sprintf("https://acs-mirror.azureedge.net/cloud-provider-azure/%s/binaries/azure-acr-credential-provider-linux-amd64-v%s.tar.gz", parsed.String(), parsed.String()),
+			))
+
+
 			if parsed.Minor < 30 {
 				fmt.Println("K8s Version for env client: ")
 				Expect(flagMap).To(HaveKey("--azure-container-registry-config"))

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1110,10 +1110,25 @@ var _ = Describe("InstanceType Provider", func() {
 				Expect(kubeletFlags).To(
 					ContainSubstring("--azure-container-registry-config"),
 				)
-			} else {
+				// The credential provider is not gated by k8s version in the vhd itself only by the flags which should only be passed in
+				// for 1.30+ so lets explicitly test for this
+				Expect(kubeletFlags).To(Not(
+					ContainSubstring("--image-credential-provider-config"),
+				))
+				Expect(kubeletFlags).To(Not(
+					ContainSubstring("--image-credential-provider-bin-dir"),
+				))
+			}
+
+			if env.Version.Minor() >= 30 {
 				Expect(kubeletFlags).To(Not(
 					ContainSubstring("--azure-container-registry-config"),
 				))
+				Expect(kubeletFlags).To(
+					ContainSubstring("--azure-container-registry-config"),
+					ContainSubstring("--image-credential-provider-config"),
+				)
+
 			}
 		})
 	})

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1127,14 +1127,14 @@ var _ = Describe("InstanceType Provider", func() {
 			Expect(err).To(BeNil())
 			parsed := semver.MustParse(k8sVersion)
 
-			Expect(decodedString).To(ContainSubstring(
-				fmt.Sprintf("https://acs-mirror.azureedge.net/cloud-provider-azure/%s/binaries/azure-acr-credential-provider-linux-amd64-v%s.tar.gz", parsed.String(), parsed.String()),
-			))
-
 			if utils.UseOOTCredential(parsed.Minor) {
 				Expect(flagMap).ToNot(HaveKey("--azure-container-registry-config"))
 				Expect(flagMap).To(HaveKeyWithValue("--image-credential-provider-config", "/var/lib/kubelet/credential-provider-config.yaml"))
 				Expect(flagMap).To(HaveKeyWithValue("--image-credential-provider-bin-dir", "/var/lib/kubelet/credential-provider"))
+				Expect(decodedString).To(ContainSubstring(
+					fmt.Sprintf("https://acs-mirror.azureedge.net/cloud-provider-azure/%s/binaries/azure-acr-credential-provider-linux-amd64-v%s.tar.gz", parsed.String(), parsed.String()),
+				))
+
 			} else {
 				Expect(flagMap).To(HaveKey("--azure-container-registry-config"))
 				Expect(flagMap).ToNot(HaveKey("--image-credential-provider-config"))

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1131,7 +1131,6 @@ var _ = Describe("InstanceType Provider", func() {
 				fmt.Sprintf("https://acs-mirror.azureedge.net/cloud-provider-azure/%s/binaries/azure-acr-credential-provider-linux-amd64-v%s.tar.gz", parsed.String(), parsed.String()),
 			))
 
-
 			if parsed.Minor < 30 {
 				fmt.Println("K8s Version for env client: ")
 				Expect(flagMap).To(HaveKey("--azure-container-registry-config"))

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1105,6 +1105,13 @@ var _ = Describe("InstanceType Provider", func() {
 			decodedBytes, err := base64.StdEncoding.DecodeString(customData)
 			Expect(err).To(Succeed())
 			decodedString := string(decodedBytes[:])
+
+			fmt.Println(env.Version)
+			Expect(decodedString).To(ContainSubstring("CREDENTIAL_PROVIDER_DOWNLOAD_URL"))
+			Expect(decodedString).To(ContainSubstring(
+				fmt.Sprintf("https://acs-mirror.azureedge.net/cloud-provider-azure/%s/binaries/azure-acr-credential-provider-linux-amd64-v%s.tar.gz", env.Version.String(), env.Version.String()),
+			))
+
 			kubeletFlags := decodedString[strings.Index(decodedString, "KUBELET_FLAGS=")+len("KUBELET_FLAGS="):]
 			parseKubeletFlags := func(flags string) map[string]string {
 				flagMap := make(map[string]string)
@@ -1124,6 +1131,7 @@ var _ = Describe("InstanceType Provider", func() {
 				Expect(flagMap).To(HaveKey("--azure-container-registry-config"))
 				Expect(flagMap).ToNot(HaveKey("--image-credential-provider-config"))
 				Expect(flagMap).ToNot(HaveKey("--image-credential-provider-bin-dir"))
+
 			} else {
 				Expect(flagMap).ToNot(HaveKey("--azure-container-registry-config"))
 				Expect(flagMap).To(HaveKeyWithValue("--image-credential-provider-config", "/var/lib/kubelet/credential-provider-config.yaml"))

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -58,3 +58,7 @@ func MkVMID(resourceGroupName string, vmName string) string {
 	const idFormat = "/subscriptions/subscriptionID/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s"
 	return fmt.Sprintf(idFormat, resourceGroupName, vmName)
 }
+
+func UseOOTCredential(minorK8sVersion uint64) bool {
+	return minorK8sVersion >= 30
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # NA

**Description**
Bootstrap for 1.30 will fail if we have the --azure-container-registry-config flag specified. 

```
azureuser@aks-general-purpose-78r6l:~$ journalctl -u kubelet.service
---
May 10 08:31:26 aks-general-purpose-78r6l kubelet[10604]: E0510 08:29:13.285779   10604 run.go:74]"command failed" err="failed to parse kubelet flag: unknown flag: --azure-container-registry-config"
May 10 08:31:26 aks-general-purpose-78r6l kubelet[13211]: E0510 08:31:26.037146   13211 run.go:74] "command failed" err="failed to parse kubelet flag: unknown flag: --azure-container-registry-config"
May 10 08:31:26 aks-general-purpose-78r6l systemd[1]: kubelet.service: Main process exited, code=exited, status=1/FAILURE
May 10 08:31:26 aks-general-purpose-78r6l systemd[1]: kubelet.service: Failed with result 'exit-code'.
```

By removing this flag we get nodes for k8s version 1.30 to bootstrap successfully. 
 
**How was this change tested?**
- make az-all
- acr pull e2e test: https://github.com/Azure/karpenter-provider-azure/pull/369

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
support for 1.30 node bootstrapping with karpenter
```
