### PR TITLE
chore(release): switch release workflow to have tag trigger

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -3,11 +3,6 @@
 
 name: Build and publish to MCR
 on:
-  workflow_dispatch:
-    inputs:
-      releaseTag:
-        description: 'Release tag to publish, defaults to the latest one'
-        type: string
   push:
     # Only release on supported semantic version tagging e.g. v0.0.1-rc.0
     tags:

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -8,42 +8,24 @@ on:
       releaseTag:
         description: 'Release tag to publish, defaults to the latest one'
         type: string
+  push:
+    # Only release on supported semantic version tagging e.g. v0.0.1-rc.0
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
 
 permissions:
   contents: read
 
 jobs:
-  prepare-variables:
-    runs-on:
-      labels: [self-hosted, "1ES.Pool=${{ vars.RELEASE_1ES_POOL }}"]
-    outputs:
-      release_tag: ${{ steps.vars.outputs.release_tag }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        with:
-          fetch-depth: 0
-      - name: 'Set output variables'
-        id: vars
-        run: |
-          RELEASE_TAG=${{ inputs.releaseTag }}
-          if [ -z "$RELEASE_TAG" ]; then
-            RELEASE_TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)")"
-            echo "The user input release tag is empty, will use the latest tag $RELEASE_TAG."
-          fi
-          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
-
   publish-images:
     permissions:
       contents: read
       id-token: write # This is required for requesting the JWT
     runs-on:
       labels: [self-hosted, "1ES.Pool=${{ vars.RELEASE_1ES_POOL }}"]
-    needs: prepare-variables
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
@@ -52,7 +34,7 @@ jobs:
 
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:
-        ref: ${{ needs.prepare-variables.outputs.release_tag }}
+        fetch-depth: 0
         
     - uses: ./.github/actions/install-deps
   


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Working towards a more automated release process. Removing the manual step of triggering with specified tag to automatic trigger based off tagging.

This is aligned behavior with the aws provider:
- https://github.com/aws/karpenter-provider-aws/blob/9e113aaca23bce17e99cd6f14447927e7c89e3d4/.github/workflows/release.yaml

**How was this change tested?**
Nothing additional
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
