### PR TITLE
fix: Updated instanceTypeZones logic to handle non-zonal SKUs in zonal regions

### DIFF
--- a/examples/v1beta1/nodeclaim/manual-nodeclaim.yaml
+++ b/examples/v1beta1/nodeclaim/manual-nodeclaim.yaml
@@ -1,0 +1,23 @@
+apiVersion: karpenter.sh/v1beta1
+kind: NodeClaim
+metadata:
+  name: manual-kaito
+  labels:
+    karpenter.sh/nodepool: kaito
+  annotations:
+    karpenter.sh/do-not-disrupt: "true"
+spec:
+  nodeClassRef:
+    name: default
+    kind: AKSNodeClass
+  taints:
+    - key: "sku"
+      value: "gpu"
+      effect: NoSchedule
+  requirements:
+    - key: "karpenter.sh/nodepool"
+      operator: In
+      values: ["kaito"]
+    - key:  karpenter.azure.com/sku-name
+      operator: In
+      values: ["Standard_NC12s_v3"]

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -145,7 +145,8 @@ func instanceTypeZones(sku *skewer.SKU, region string) sets.Set[string] {
 	// skewer returns numerical zones, like "1" (as keys in the map);
 	// prefix each zone with "<region>-", to have them match the labels placed on Node (e.g. "westus2-1")
 	// Note this data comes from LocationInfo, then skewer is used to get the SKU info
-	if hasZonalSupport(region) {
+	// If an offering is non-zonal, the availability zones will be empty.
+	if hasZonalSupport(region) && sku.AvailabilityZones(region) != nil {
 		return sets.New(lo.Map(lo.Keys(sku.AvailabilityZones(region)), func(zone string, _ int) string {
 			return fmt.Sprintf("%s-%s", region, zone)
 		})...)


### PR DESCRIPTION
Fixes # <!-- issue number -->

**Description**
I'm working with the Kaito team to integrate with Karpenter Azure Provider. They noticed that they were unable to use some GPU skus due to "insufficient capacity", but were able to confirm that the capacity was available and that this wasn't happening when provisioning nodes directly using AKS APIs.  

It turns out that this was due to a small bug in retrieving availability zones for SKUs. We properly handle the case for non-zonal regions, but do not properly handle non-zonal offerings within zonal regions. I've updated the condition to handle this scenario.

I also have included the `manual-nodeclaim.yaml` that I use to test this. I think it will be helpful for future validations with Kaito, but I can remove it if needed.

**How was this change tested?**
* manually by applying the manual nodeclaim
* added another unit test to account for this

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
