### PR TITLE
chore(release): add new semantic-release workflow

### DIFF
--- a/.github/workflows/release-trigger.yaml
+++ b/.github/workflows/release-trigger.yaml
@@ -1,0 +1,28 @@
+# This Github action is the release trigger for Azure/karpenter-provider-azure
+# It will auto-generate the next semantic release version and tag the git ref
+
+name: Release Trigger
+on:
+    workflow_dispatch:
+
+jobs:
+  generate-sem-ver:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x' # semantic-release requires Node version 20.8.1 or higher
+      - name: semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npx semantic-release@18

--- a/.github/workflows/release-trigger.yaml
+++ b/.github/workflows/release-trigger.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: '20.x' # semantic-release requires Node version 20.8.1 or higher
       - name: semantic-release

--- a/.github/workflows/release-trigger.yaml
+++ b/.github/workflows/release-trigger.yaml
@@ -22,7 +22,5 @@ jobs:
         with:
           node-version: '20.x' # semantic-release requires Node version 20.8.1 or higher
       - name: semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npx semantic-release@18

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,8 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/git"
+  ]
+}

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,5 +1,6 @@
 {
   "branches": ["main"],
+  "dryRun": true,
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
We currently have to create the github release, and its release notes manually.

The repo `aws` is using is no longer maintained:
 - https://github.com/aws/karpenter-provider-aws/blob/2e907f90b82ea04ff76da13c5a486c71a421e827/.github/workflows/release.yaml
![image](https://github.com/Azure/karpenter-provider-azure/assets/33269602/e487c38d-9825-4b12-8f7a-451744b9d0df)

Because of this there are two approaches I'm looking at for our more automated release process.

I looked over the recommended substitutes and found that I think the [action-gh-release](https://github.com/softprops/action-gh-release) might match our current desires the best. Its closest to the old action. However, the [semantic-release](https://github.com/semantic-release/semantic-release) action could also be useful with some of its additional feature sets, so want to explore that option as well, even though more complex. This PR is exploring the [semantic-release](https://github.com/semantic-release/semantic-release) option more. 

I'm only giving the workflow the following perms, even though its known to now be enough:
- contents: read
This is a safeguard from the workflow actually doing a release for now. I'm wanting to complete this since I want to run the workflow to test semantic-release. However, can't run the workflow without it having the file in existence in main. I'm curious if we can maybe leverage it, and if the components are correcting up correctly within the workflow.

**How was this change tested?**
Sadly there isn't a great way to test this until we have it in main.
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
