### PR TITLE
test(e2e): switch to westus3 for e2e

### DIFF
--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -5,7 +5,7 @@ on:
       location:
         type: string
         description: "the azure location to run the e2e test in"
-        default: "southcentralus"
+        default: "westus3"
   push:
     branches: [main]
   workflow_run:
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/e2e-matrix.yaml
     with:
       git_ref: ${{ needs.resolve.outputs.GIT_REF }}
-      location: ${{ inputs.location || 'eastus' }}
+      location: ${{ inputs.location || 'westus3' }}
     secrets:
       E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}
       E2E_TENANT_ID: ${{ secrets.E2E_TENANT_ID }}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
We've been experiencing some allocation issues within the current testing regions. 

Did some testing to find a new region, which `westus3` seems to be rather well suited for our needs, so switching the testing pipeline there.

**How was this change tested?**
Ran the E2E pipeline for `westus3`:
https://github.com/Azure/karpenter-provider-azure/actions/runs/9964029669/job/27531436071

While not all successful, did a sanity check within the subscription on quota, and public doc support for multi-zone region, and this appears to be a good region change:
https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
