### PR TITLE
fix: set `DisableKubeletCloudCredentialProviders=false` for versions without OOT credential provider (1.29)

### DIFF
--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -438,7 +438,7 @@ func CredentialProviderURL(kubernetesVersion, arch string) string {
 	case 30:
 		credentialProviderVersion = "1.30.0"
 
-	case 31: 
+	case 31:
 		credentialProviderVersion = "1.31.0"
 	}
 
@@ -487,7 +487,7 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 	nbv.KubeletNodeLabels = strings.Join(lo.MapToSlice(kubeletLabels, func(k, v string) string {
 		return fmt.Sprintf("%s=%s", k, v)
 	}), ",")
-		
+
 	// Assign Per K8s version kubelet flags
 	credentialProviderURL := CredentialProviderURL(a.KubernetesVersion, a.Arch)
 	if credentialProviderURL != "" { // use OOT credential provider
@@ -495,8 +495,8 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 		kubeletFlagsBase["--image-credential-provider-config"] = "/var/lib/kubelet/credential-provider-config.yaml"
 		kubeletFlagsBase["--image-credential-provider-bin-dir"] = "/var/lib/kubelet/credential-provider"
 	} else { // Versions Less than 1.30
-		// we can make this logic smarter later when we have more than one 
-		// for now just adding here. 
+		// we can make this logic smarter later when we have more than one
+		// for now just adding here.
 		kubeletFlagsBase["--feature-gates"] = "DisableKubeletCloudCredentialProviders=false"
 		kubeletFlagsBase["--azure-container-registry-config"] = "/etc/kubernetes/azure.json"
 	}

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -437,6 +437,9 @@ func CredentialProviderURL(kubernetesVersion, arch string) string {
 		credentialProviderVersion = "1.29.2"
 	case 30:
 		credentialProviderVersion = "1.30.0"
+
+	case 31: 
+		credentialProviderVersion = "1.31.0"
 	}
 
 	return fmt.Sprintf("%s/cloud-provider-azure/v%s/binaries/azure-acr-credential-provider-linux-%s-v%s.tar.gz", globalAKSMirror, credentialProviderVersion, arch, credentialProviderVersion)

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -484,7 +484,7 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 	nbv.KubeletNodeLabels = strings.Join(lo.MapToSlice(kubeletLabels, func(k, v string) string {
 		return fmt.Sprintf("%s=%s", k, v)
 	}), ",")
-
+		
 	// Assign Per K8s version kubelet flags
 	credentialProviderURL := CredentialProviderURL(a.KubernetesVersion, a.Arch)
 	if credentialProviderURL != "" { // use OOT credential provider
@@ -492,6 +492,9 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 		kubeletFlagsBase["--image-credential-provider-config"] = "/var/lib/kubelet/credential-provider-config.yaml"
 		kubeletFlagsBase["--image-credential-provider-bin-dir"] = "/var/lib/kubelet/credential-provider"
 	} else { // Versions Less than 1.30
+		// we can make this logic smarter later when we have more than one 
+		// for now just adding here. 
+		kubeletFlagsBase["--feature-gates"] = "DisableKubeletCloudCredentialProviders=false"
 		kubeletFlagsBase["--azure-container-registry-config"] = "/etc/kubernetes/azure.json"
 	}
 	// merge and stringify taints

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
@@ -67,7 +67,7 @@ func TestGetCredentialProviderURL(t *testing.T) {
 	}{
 		{
 			version: "1.31.0",
-			arch:	 "amd64",
+			arch:    "amd64",
 			url:     fmt.Sprintf("%s/cloud-provider-azure/v1.31.0/binaries/azure-acr-credential-provider-linux-amd64-v1.31.0.tar.gz", globalAKSMirror),
 		},
 		{

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
@@ -66,6 +66,11 @@ func TestGetCredentialProviderURL(t *testing.T) {
 		url     string
 	}{
 		{
+			version: "1.31.0",
+			arch:	 "amd64",
+			url:     fmt.Sprintf("%s/cloud-provider-azure/v1.31.0/binaries/azure-acr-credential-provider-linux-amd64-v1.31.0.tar.gz", globalAKSMirror),
+		},
+		{
 			version: "1.30.2",
 			arch:    "amd64",
 			url:     fmt.Sprintf("%s/cloud-provider-azure/v1.30.0/binaries/azure-acr-credential-provider-linux-amd64-v1.30.0.tar.gz", globalAKSMirror),


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #411

**Description**
https://github.com/Azure/karpenter-provider-azure/blob/main/pkg/providers/imagefamily/bootstrap/aksbootstrap.go#L425
```
// CredentialProviderURL returns the URL for OOT credential provider,
// or an empty string if OOT provider is not to be used
func CredentialProviderURL(kubernetesVersion, arch string) string {
  minorVersion := semver.MustParse(kubernetesVersion).Minor
  if minorVersion < 30 { 
    return ""
  }
```

Looks like from this code for out of tree provider we default to not including the settings for out of tree provider if CredentialProviderURL is empty. 


DisableKubeletCloudCredentialProviders | false | Alpha | 1.23 | 1.28
-- | -- | -- | -- | --
DisableKubeletCloudCredentialProviders | true | Beta | 1.29 | –

We don't have the logic conditionally enabled for 1.29, so auth pull will not work for that specific kubernetes version. 

This can be easily fixed by 

A) Switching 1.29 to use out of tree credential provider.(Have karpenter pass in the rest of the required OOT Provider kubelet flags.)
B) Adding the default to false for the feature gate for 1.29 clusters. 

To have consistency with the provisioning of the AKS Resource Provider nodes, we will choose option B. 

**How was this change tested?**
- make az-all 
- make presubmit 
- az e2etest acr

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
fixes acr pull on 1.29
```
