### PR TITLE
fix: harden harden-runner egress policy

### DIFF
--- a/.github/workflows/approval-comment.yaml
+++ b/.github/workflows/approval-comment.yaml
@@ -14,7 +14,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
-          egress-policy: audit
+          disable-telemetry: true
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -21,12 +21,22 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
       with:
-        egress-policy: audit
+        disable-telemetry: true
+        egress-policy: block
+        allowed-endpoints: >
+          api.github.com:443
+          coveralls.io:443
+          github.com:443
+          objects.githubusercontent.com:443
+          proxy.golang.org:443
+          raw.githubusercontent.com:443
+          storage.googleapis.com:443
+          sum.golang.org:443
 
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - uses: ./.github/actions/install-deps
       with:
-        k8sVersion: ${{ matrix.k8sVersion }}    
+        k8sVersion: ${{ matrix.k8sVersion }}
     - run: K8S_VERSION=${{ matrix.k8sVersion }} make ci-test
     - name: Send coverage
       # should only send coverage once https://docs.coveralls.io/parallel-builds

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   workflow_dispatch:
 permissions:
-  contents: read    
+  contents: read
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -13,7 +13,17 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
       with:
-        egress-policy: audit
+        disable-telemetry: true
+        egress-policy: block
+        allowed-endpoints: >
+          api.github.com:443
+          github.com:443
+          objects.githubusercontent.com:443
+          proxy.golang.org:443
+          raw.githubusercontent.com:443
+          storage.googleapis.com:443
+          sum.golang.org:443
+          vuln.go.dev:443
 
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - uses: ./.github/actions/install-deps

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,20 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
-          egress-policy: audit
+          disable-telemetry: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            dc.services.visualstudio.com:443
+            github.com:443
+            login.microsoftonline.com:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            raw.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            uploads.github.com:443
+            vuln.go.dev:443
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: ./.github/actions/install-deps

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -16,7 +16,15 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
-          egress-policy: audit
+          disable-telemetry: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            storage.googleapis.com:443
+            sum.golang.org:443
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: ./.github/actions/install-deps

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,7 +19,14 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
-          egress-policy: audit
+          disable-telemetry: true
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.deps.dev:443
+            api.github.com:443
+            api.securityscorecards.dev:443
+            github.com:443
 
       - name: 'Checkout Repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -34,6 +34,7 @@ jobs:
           disable-telemetry: true
           disable-sudo: true
           egress-policy: block
+          # no allowed endpoints
           allowed-endpoints: >
 
       - id: generate-e2e-run-hash

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -21,7 +21,7 @@ on:
 
 permissions:
   contents: read
-        
+
 jobs:
   initialize-generative-params:
     runs-on: ubuntu-latest
@@ -31,7 +31,10 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
-          egress-policy: audit
+          disable-telemetry: true
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
 
       - id: generate-e2e-run-hash
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,6 +49,9 @@ jobs:
         with:
           disable-telemetry: true
           egress-policy: block
+          # - wildcards to allow for variation in targeted clusters
+          # - clients3.google.com:80 and firebaselogging-pa.googleapis.com:443 - confirmed Skaffol
+          #   likely telemetry, likely can be avoided/blocked with/after "skaffold config set --global collect-metrics false"
           allowed-endpoints: >
             *.azmk8s.io:443
             *.azurecr.io:443

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,7 +47,33 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
-          egress-policy: audit
+          disable-telemetry: true
+          egress-policy: block
+          allowed-endpoints: >
+            *.azmk8s.io:443
+            *.azurecr.io:443
+            *.data.mcr.microsoft.com:443
+            aka.ms:443
+            api.github.com:443
+            app.aladdin.microsoft.com:443
+            auth.docker.io:443
+            azcliextensionsync.blob.core.windows.net:443
+            clients3.google.com:80
+            dc.services.visualstudio.com:443
+            distroless.dev:443
+            firebaselogging-pa.googleapis.com:443
+            gist.githubusercontent.com:443
+            github.com:443
+            graph.microsoft.com:443
+            index.docker.io:443
+            login.microsoftonline.com:443
+            management.azure.com:443
+            mcr.microsoft.com:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            raw.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,7 +50,7 @@ jobs:
           disable-telemetry: true
           egress-policy: block
           # - wildcards to allow for variation in targeted clusters
-          # - clients3.google.com:80 and firebaselogging-pa.googleapis.com:443 - confirmed Skaffol
+          # - clients3.google.com:80 and firebaselogging-pa.googleapis.com:443 - confirmed Skaffold,
           #   likely telemetry, likely can be avoided/blocked with/after "skaffold config set --global collect-metrics false"
           allowed-endpoints: >
             *.azmk8s.io:443

--- a/.github/workflows/release-trigger.yaml
+++ b/.github/workflows/release-trigger.yaml
@@ -19,7 +19,13 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
-          egress-policy: audit
+          disable-telemetry: true
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
+
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0

--- a/.github/workflows/resolve-args.yaml
+++ b/.github/workflows/resolve-args.yaml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: read
-  
+
 jobs:
   resolve:
     runs-on: ubuntu-latest
@@ -18,7 +18,12 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
-          egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - if: github.event_name == 'workflow_run'

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -33,7 +33,26 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
-          egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.deps.dev:443
+            api.github.com:443
+            api.osv.dev:443
+            api.scorecard.dev:443
+            api.securityscorecards.dev:443
+            auth.docker.io:443
+            bestpractices.coreinfrastructure.org:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            index.docker.io:443
+            mcr.microsoft.com:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
+            rekor.sigstore.dev:443
+            sigstore-tuf-root.storage.googleapis.com:443
+            tuf-repo-cdn.sigstore.dev:443
+            www.bestpractices.dev:443
 
       - name: "Checkout code"
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Switch to Harden Runner `egress-policy: block`, add selected `allowed-endpoints`. Also `disable-telemetry: true` for now.

The endpoints come from StepSecurity insights for corresponding runs (such as [this one](https://app.stepsecurity.io/github/Azure/karpenter-provider-azure/actions/runs/10379526294?jobid=28737859970&tab=recommendations); "Recommendations" tab as base, "Networks Events" for further drill down), with some selected wildcarding (to accommodate variations) and removals (mostly things that are no longer used, but might still be reported in the cumulative insights). Notes and outliers:
* The largest set of endpoints is (naturally) used by E2E tests, which use az CLI, create AKS clusters, and run tests. The only one using wildcards.
* Historically observed but removed: `9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com` - [blob storage for cgr.dev](https://edu.chainguard.dev/chainguard/administration/network-requirements/#chainguard-images-third-party-hosts), and we no longer use Chainguard for base images
* `clients3.google.com:80` and `firebaselogging-pa.googleapis.com:443` - confirmed Skaffold, likely [telemetry](https://skaffold.dev/docs/resources/telemetry/), likely can be avoided/blocked with/after `skaffold config set --global collect-metrics false`
* There are no changes to "Build and publish to MCR" workflow, as it runs on self-hosted 1ES pool. (Use of Harden Runner in that context needs to be reviewed separately.)

**How was this change tested?**

* Selected checks (using the updated workflows) [passed](https://github.com/Azure/karpenter-provider-azure/pull/477/checks)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
