### PR TITLE
test(Cilium): add CiliumAgentNotReadyTaint to prevent overprovisioning

### DIFF
--- a/examples/v1beta1/general-purpose.yaml
+++ b/examples/v1beta1/general-purpose.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     spec:
       startupTaints:
-        - key: node.kubernetes.io/network-unavailable
+        - key: node.cilium.io/agent-not-ready
           effect: NoSchedule
       requirements:
         - key: kubernetes.io/arch

--- a/examples/v1beta1/general-purpose.yaml
+++ b/examples/v1beta1/general-purpose.yaml
@@ -11,6 +11,9 @@ spec:
     expireAfter: Never
   template:
     spec:
+      startupTaints:
+        - key: node.kubernetes.io/network-unavailable
+          effect: NoSchedule
       requirements:
         - key: kubernetes.io/arch
           operator: In

--- a/examples/v1beta1/multi-arch.yaml
+++ b/examples/v1beta1/multi-arch.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     spec:
       startupTaints:
-        - key: node.kubernetes.io/network-unavailable
+        - key: node.cilium.io/agent-not-ready
           effect: NoSchedule
       requirements:
         - key: kubernetes.io/arch

--- a/examples/v1beta1/multi-arch.yaml
+++ b/examples/v1beta1/multi-arch.yaml
@@ -11,6 +11,9 @@ spec:
     expireAfter: Never
   template:
     spec:
+      startupTaints:
+        - key: node.kubernetes.io/network-unavailable
+          effect: NoSchedule
       requirements:
         - key: kubernetes.io/arch
           operator: In

--- a/examples/v1beta1/system-surge.yaml
+++ b/examples/v1beta1/system-surge.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.azure.com/mode: "system"
     spec:
       startupTaints:
-        - key: node.kubernetes.io/network-unavailable
+        - key: node.cilium.io/agent-not-ready
           effect: NoSchedule
       taints: 
         - key: "CriticalAddonsOnly"

--- a/examples/v1beta1/system-surge.yaml
+++ b/examples/v1beta1/system-surge.yaml
@@ -14,6 +14,9 @@ spec:
       labels: 
         kubernetes.azure.com/mode: "system"
     spec:
+      startupTaints:
+        - key: node.kubernetes.io/network-unavailable
+          effect: NoSchedule
       taints: 
         - key: "CriticalAddonsOnly"
           value: "true"

--- a/test/pkg/environment/azure/environment.go
+++ b/test/pkg/environment/azure/environment.go
@@ -38,8 +38,8 @@ func init() {
 }
 
 const (
-	WindowsDefaultImage               = "mcr.microsoft.com/oss/kubernetes/pause:3.9"
-	KubernetesNetworkUnavailableTaint = "node.kubernetes.io/network-unavailable"
+	WindowsDefaultImage      = "mcr.microsoft.com/oss/kubernetes/pause:3.9"
+	CiliumAgentNotReadyTaint = "node.cilium.io/agent-not-ready"
 )
 
 type Environment struct {
@@ -93,7 +93,7 @@ func (env *Environment) DefaultNodePool(nodeClass *v1alpha2.AKSNodeClass) *corev
 		v1.ResourceMemory: resource.MustParse("1000Gi"),
 	})
 	nodePool.Spec.Template.Spec.StartupTaints = append(nodePool.Spec.Template.Spec.StartupTaints, v1.Taint{
-		Key:    KubernetesNetworkUnavailableTaint,
+		Key:    CiliumAgentNotReadyTaint,
 		Effect: v1.TaintEffectNoSchedule,
 	})
 	return nodePool

--- a/test/pkg/environment/azure/environment.go
+++ b/test/pkg/environment/azure/environment.go
@@ -38,8 +38,8 @@ func init() {
 }
 
 const (
-	WindowsDefaultImage      = "mcr.microsoft.com/oss/kubernetes/pause:3.9"
-	CiliumAgentNotReadyTaint = "node.cilium.io/agent-not-ready"
+	WindowsDefaultImage               = "mcr.microsoft.com/oss/kubernetes/pause:3.9"
+	KubernetesNetworkUnavailableTaint = "node.kubernetes.io/network-unavailable"
 )
 
 type Environment struct {
@@ -93,7 +93,7 @@ func (env *Environment) DefaultNodePool(nodeClass *v1alpha2.AKSNodeClass) *corev
 		v1.ResourceMemory: resource.MustParse("1000Gi"),
 	})
 	nodePool.Spec.Template.Spec.StartupTaints = append(nodePool.Spec.Template.Spec.StartupTaints, v1.Taint{
-		Key:    CiliumAgentNotReadyTaint,
+		Key:    KubernetesNetworkUnavailableTaint,
 		Effect: v1.TaintEffectNoSchedule,
 	})
 	return nodePool

--- a/test/pkg/environment/azure/environment.go
+++ b/test/pkg/environment/azure/environment.go
@@ -37,7 +37,10 @@ func init() {
 	corev1beta1.NormalizedLabels = lo.Assign(corev1beta1.NormalizedLabels, map[string]string{"topology.disk.csi.azure.com/zone": v1.LabelTopologyZone})
 }
 
-const WindowsDefaultImage = "mcr.microsoft.com/oss/kubernetes/pause:3.9"
+const (
+	WindowsDefaultImage      = "mcr.microsoft.com/oss/kubernetes/pause:3.9"
+	CiliumAgentNotReadyTaint = "node.cilium.io/agent-not-ready"
+)
 
 type Environment struct {
 	*common.Environment
@@ -88,6 +91,10 @@ func (env *Environment) DefaultNodePool(nodeClass *v1alpha2.AKSNodeClass) *corev
 	nodePool.Spec.Limits = corev1beta1.Limits(v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("100"),
 		v1.ResourceMemory: resource.MustParse("1000Gi"),
+	})
+	nodePool.Spec.Template.Spec.StartupTaints = append(nodePool.Spec.Template.Spec.StartupTaints, v1.Taint{
+		Key:    CiliumAgentNotReadyTaint,
+		Effect: v1.TaintEffectNoSchedule,
 	})
 	return nodePool
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
See the following thread for why we need the given startupTaint:
- https://karpenter.sh/docs/faq/#why-do-i-see-extra-nodes-get-launched-to-schedule-pending-pods-that-remain-empty-and-are-later-removed

As our testing, and main example cases all use Cilium, adding this to all the areas.

**How was this change tested?**
Tested [general-purpose.yaml](https://github.com/Azure/karpenter-provider-azure/pull/508/files#diff-d76365775af789aed6414b86f28136204ea77b35ee25349d76eb590b9d7c03b9) in self-hosted codespace setup.

Also, ran E2E suite:
- https://github.com/Azure/karpenter-provider-azure/actions/runs/11149258534
- https://github.com/Azure/karpenter-provider-azure/actions/runs/11150952645

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
