### PR TITLE
fix(provisioning): add cilium taint and label

### DIFF
--- a/examples/v1beta1/general-purpose.yaml
+++ b/examples/v1beta1/general-purpose.yaml
@@ -10,10 +10,16 @@ spec:
   disruption:
     expireAfter: Never
   template:
+    metadata:
+      labels:
+        # required for Karpenter to predict overhead from cilium DaemonSet
+        kubernetes.azure.com/ebpf-dataplane: cilium
     spec:
       startupTaints:
+        # https://karpenter.sh/docs/concepts/nodepools/#cilium-startup-taint
         - key: node.cilium.io/agent-not-ready
-          effect: NoSchedule
+          effect: NoExecute
+          value: "true"
       requirements:
         - key: kubernetes.io/arch
           operator: In

--- a/examples/v1beta1/multi-arch.yaml
+++ b/examples/v1beta1/multi-arch.yaml
@@ -10,10 +10,16 @@ spec:
   disruption:
     expireAfter: Never
   template:
+    metadata:
+      labels:
+        # required for Karpenter to predict overhead from cilium DaemonSet
+        kubernetes.azure.com/ebpf-dataplane: cilium
     spec:
       startupTaints:
+        # https://karpenter.sh/docs/concepts/nodepools/#cilium-startup-taint
         - key: node.cilium.io/agent-not-ready
-          effect: NoSchedule
+          effect: NoExecute
+          value: "true"
       requirements:
         - key: kubernetes.io/arch
           operator: In

--- a/examples/v1beta1/system-surge.yaml
+++ b/examples/v1beta1/system-surge.yaml
@@ -11,13 +11,17 @@ spec:
     expireAfter: Never
   template:
     metadata:
-      labels: 
+      labels:
         kubernetes.azure.com/mode: "system"
+        # required for Karpenter to predict overhead from cilium DaemonSet
+        kubernetes.azure.com/ebpf-dataplane: cilium
     spec:
       startupTaints:
+        # https://karpenter.sh/docs/concepts/nodepools/#cilium-startup-taint
         - key: node.cilium.io/agent-not-ready
-          effect: NoSchedule
-      taints: 
+          effect: NoExecute
+          value: "true"
+      taints:
         - key: "CriticalAddonsOnly"
           value: "true"
           effect: "NoSchedule"


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Adds cilium startup taint (https://karpenter.sh/docs/concepts/nodepools/#cilium-startup-taint) and add cillium ebpf-dataplaine label (so that Karpenter can take the corresponding DaemonSet into account when computing the expected overhead), to example and default E2E NodePools.

**How was this change tested?**

* `make presubmit`
* E2E - https://github.com/Azure/karpenter-provider-azure/actions/runs/11261786845

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
