### PR TITLE
test(make): update `az-run-sample` to v1

### DIFF
--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -171,7 +171,7 @@ az-run: ## Deploy the controller from the current state of your git repository i
 	skaffold run
 
 az-run-sample: ## Deploy sample Provisioner and workload (with 0 replicas, to be scaled manually)
-	kubectl apply -f examples/v1beta1/general-purpose.yaml
+	kubectl apply -f examples/v1/general-purpose.yaml
 	kubectl apply -f examples/workloads/inflate.yaml
 
 az-mc-show: ## show managed cluster

--- a/examples/v1/general-purpose.yaml
+++ b/examples/v1/general-purpose.yaml
@@ -9,8 +9,12 @@ metadata:
 spec:
   disruption:
     consolidateAfter: 0s
+    expireAfter: Never
     budgets:
     - nodes: 30%
+  # Optional: Uncomment if you want to put a cap on the max resources available for provisioning
+  # limits:
+  #   cpu: "30"
   template:
     metadata:
       labels:
@@ -40,6 +44,11 @@ spec:
       - key: karpenter.azure.com/sku-family
         operator: In
         values: [D]
+      # Optional: Uncomment if you want to add a restriction on max sku cpus.
+      #           Useful for ensuring karpneter provisions multiple nodes for feature testing.
+      # - key: karpenter.azure.com/sku-cpu
+      #   operator: Lt
+      #   values: ["3"]
 ---
 apiVersion: karpenter.azure.com/v1alpha2
 kind: AKSNodeClass

--- a/examples/v1/general-purpose.yaml
+++ b/examples/v1/general-purpose.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   disruption:
     consolidateAfter: 0s
-    expireAfter: Never
     budgets:
     - nodes: 30%
   # Optional: Uncomment if you want to put a cap on the max resources available for provisioning

--- a/examples/v1beta1/general-purpose.yaml
+++ b/examples/v1beta1/general-purpose.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   disruption:
     expireAfter: Never
+    budgets:
+    - nodes: 30%
   # Optional: Uncomment if you want to put a cap on the max resources available for provisioning
   # limits:
   #   cpu: "30"


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
I noticed that the `az-run-sample` make command was still using, 1vbeta, and updating it here, along with updating the `v1` file in accordance with recent optional settings.

**How was this change tested?**
`make az-run-sample`
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
