### PR TITLE
Attach Agent Pool network security group to karpenter node nics..

### DIFF
--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -128,7 +128,7 @@ func (o *Options) Parse(fs *coreoptions.FlagSet, args ...string) error {
 	}
 
 	// ClusterID is generated from cluster endpoint
-	o.ClusterID = getAKSClusterID(o.GetAPIServerName())
+	o.ClusterID = getAKSClusterID(o.ClusterName)
 
 	return nil
 }
@@ -153,7 +153,7 @@ func FromContext(ctx context.Context) *Options {
 // The logic comes from AgentBaker and other places, originally from aks-engine
 // with the additional assumption of DNS prefix being the first 33 chars of FQDN
 func getAKSClusterID(apiServerFQDN string) string {
-	dnsPrefix := apiServerFQDN[:33]
+	dnsPrefix := apiServerFQDN
 	h := fnv.New64a()
 	h.Write([]byte(dnsPrefix))
 	r := rand.New(rand.NewSource(int64(h.Sum64()))) //nolint:gosec


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # [<!-- issue number -->](https://github.com/Azure/karpenter-provider-azure/issues/562)

**Description**

Your logic for determining the cluster id seems to be wrong, and through experimentation it seems like it was just based on the name of the cluster.  In addition, while you add some code to generate the name of the agent pool security group, you didn't actually attach it anywhere.  I added the code to attach the security group to the NIC.

**How was this change tested?**

I tested it on one of my clusters, you should probably do some more thorough testing.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
