### PR TITLE
[release-v0.6.x] fix: Resolve errors for resource not found (#633)

### DIFF
--- a/pkg/providers/instance/armutils.go
+++ b/pkg/providers/instance/armutils.go
@@ -126,7 +126,8 @@ func deleteNicIfExists(ctx context.Context, client NetworkInterfacesAPI, rg, nic
 func deleteVirtualMachineIfExists(ctx context.Context, client VirtualMachinesAPI, rg, vmName string) error {
 	_, err := client.Get(ctx, rg, vmName, nil)
 	if err != nil {
-		if sdkerrors.IsNotFoundErr(err) {
+		azErr := sdkerrors.IsResponseError(err)
+		if azErr != nil && (azErr.ErrorCode == "NotFound" || azErr.ErrorCode == "ResourceNotFound") {
 			return nil
 		}
 		return err

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -148,7 +148,8 @@ func (p *Provider) Get(ctx context.Context, vmName string) (*armcompute.VirtualM
 	var err error
 
 	if vm, err = p.AZClient.virtualMachinesClient.Get(ctx, p.resourceGroup, vmName, nil); err != nil {
-		if sdkerrors.IsNotFoundErr(err) {
+		azErr := sdkerrors.IsResponseError(err)
+		if azErr != nil && (azErr.ErrorCode == "NotFound" || azErr.ErrorCode == "ResourceNotFound") {
 			return nil, corecloudprovider.NewNodeClaimNotFoundError(err)
 		}
 		return nil, fmt.Errorf("failed to get VM instance, %w", err)


### PR DESCRIPTION

**Description**

Cherry-picks #633 into release-v0.6.x branch

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
