### PR TITLE
fix: https://pkg.go.dev/vuln/GO-2025-3420 by upgrading from go 1.23.0 -> 1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/karpenter-provider-azure
 
-go 1.23.0
+go 1.23.5
 
 require (
 	github.com/Azure/azure-kusto-go v0.16.1


### PR DESCRIPTION
**Description**
The CI is failing due to vulncheck. We get the following two cves 

[242](https://github.com/Azure/karpenter-provider-azure/actions/runs/13001878487/job/36261959788?pr=642#step:6:243)Vulnerability #1: GO-2025-3420
[243](https://github.com/Azure/karpenter-provider-azure/actions/runs/13001878487/job/36261959788?pr=642#step:6:244)    Sensitive headers incorrectly sent after cross-domain redirect in net/http
[244](https://github.com/Azure/karpenter-provider-azure/actions/runs/13001878487/job/36261959788?pr=642#step:6:245)  More info: https://pkg.go.dev/vuln/GO-2025-3420
[245](https://github.com/Azure/karpenter-provider-azure/actions/runs/13001878487/job/36261959788?pr=642#step:6:246)  Standard library
[246](https://github.com/Azure/karpenter-provider-azure/actions/runs/13001878487/job/36261959788?pr=642#step:6:247)    Found in: net/http@go1.23
[247](https://github.com/Azure/karpenter-provider-azure/actions/runs/13001878487/job/36261959788?pr=642#step:6:248)    Fixed in: net/http@go1.23.5
and 
[253](https://github.com/Azure/karpenter-provider-azure/actions/runs/13001878487/job/36261959788?pr=642#step:6:254)Vulnerability #2: GO-2025-3373
[254](https://github.com/Azure/karpenter-provider-azure/actions/runs/13001878487/job/36261959788?pr=642#step:6:255)    Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509
[255](https://github.com/Azure/karpenter-provider-azure/actions/runs/13001878487/job/36261959788?pr=642#step:6:256)  More info: https://pkg.go.dev/vuln/GO-2025-3373
[256](https://github.com/Azure/karpenter-provider-azure/actions/runs/13001878487/job/36261959788?pr=642#step:6:257)  Standard library
[257](https://github.com/Azure/karpenter-provider-azure/actions/runs/13001878487/job/36261959788?pr=642#step:6:258)    Found in: crypto/x509@go1.23
[258](https://github.com/Azure/karpenter-provider-azure/actions/runs/13001878487/job/36261959788?pr=642#step:6:259)    Fixed in: crypto/x509@go1.23.5


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
fix cve  https://pkg.go.dev/vuln/GO-2025-3420 and https://pkg.go.dev/vuln/GO-2025-3373 by upgrading from go 1.23.0 -> 1.23.5
```
