### PR TITLE
[release-v0.6.x] fix: CVEs by bumping go from 1.22.10 -> 1.22.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/karpenter-provider-azure
 
-go 1.22
+go 1.22.11
 
 require (
 	github.com/Azure/azure-kusto-go v0.16.1


### PR DESCRIPTION
**Description**
same cves show up as https://github.com/Azure/karpenter-provider-azure/pull/665 in go 1.22.10 so bumping to 1.22.11
**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
