### PR TITLE
dev: adding a command for creating a dev environment in codespaces from cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,20 @@ tidy: ## Recursively "go mod tidy" on all directories where go.mod exists
 download: ## Recursively "go mod download" on all directories where go.mod exists
 	$(foreach dir,$(MOD_DIRS),cd $(dir) && go mod download $(newline))
 
-.PHONY: help presubmit ci-test ci-non-test test deflake e2etests coverage verify vulncheck licenses codegen snapshot release toolchain tidy download
+
+codespace: 
+	@if [ -z "$(BRANCH)" ]; then \
+		echo "Usage: make codespace BRANCH=<branch_name>"; \
+		exit 1; \
+	fi
+	gh auth refresh -h github.com -s codespace 
+	@echo "Creating new branch '$(BRANCH)' locally..."
+	git checkout -b $(BRANCH)
+	git push -u origin $(BRANCH)
+	@echo "Creating a GitHub Codespace for branch '$(BRANCH)' with maximum machine size..."
+	gh codespace create --branch $(BRANCH) --machine premiumLinux
+
+.PHONY: help presubmit ci-test ci-non-test test deflake e2etests coverage verify vulncheck licenses codegen snapshot release toolchain tidy download codespace
 
 define newline
 


### PR DESCRIPTION
**Description**
I find that I end up creating a codespace after doing some code changes as it requires me to jump into the browser, so I run CI etc after creating a PR. 

This change adds a basic command to launch a codespace inside of vscode with codespace branch="branch-name" so that I have one setup and initialized from the moment I start working. 


**How was this change tested?**
make codespace BRANCH=feature-name

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
