### PR TITLE
test: removing NoError in favor of consistent Expect(err).ToNot(HaveOccurred()) throughout the codebase

### DIFF
--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclaim/garbagecollection"
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
-	. "github.com/Azure/karpenter-provider-azure/pkg/test/expectations"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -86,6 +85,7 @@ var _ = BeforeSuite(func() {
 	fakeClock = &clock.FakeClock{}
 	cluster = state.NewCluster(fakeClock, env.Client)
 	prov = provisioning.NewProvisioner(env.Client, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, fakeClock)
+
 })
 
 var _ = AfterSuite(func() {
@@ -331,7 +331,7 @@ var _ = Describe("NetworkInterface Garbage Collection", func() {
 		azureEnv.NetworkInterfacesAPI.NetworkInterfaces.Store(lo.FromPtr(nic.ID), *nic)
 
 		nicsBeforeGC, err := azureEnv.InstanceProvider.ListNics(ctx)
-		ExpectNoError(err)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(len(nicsBeforeGC)).To(Equal(1))
 
 		// Run garbage collection
@@ -339,7 +339,7 @@ var _ = Describe("NetworkInterface Garbage Collection", func() {
 
 		// Verify NIC still exists after GC
 		nicsAfterGC, err := azureEnv.InstanceProvider.ListNics(ctx)
-		ExpectNoError(err)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(len(nicsAfterGC)).To(Equal(1))
 	})
 	It("should delete a NIC if there is no associated VM", func() {
@@ -352,13 +352,13 @@ var _ = Describe("NetworkInterface Garbage Collection", func() {
 		azureEnv.NetworkInterfacesAPI.NetworkInterfaces.Store(lo.FromPtr(nic.ID), *nic)
 		azureEnv.NetworkInterfacesAPI.NetworkInterfaces.Store(lo.FromPtr(nic2.ID), *nic2)
 		nicsBeforeGC, err := azureEnv.InstanceProvider.ListNics(ctx)
-		ExpectNoError(err)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(len(nicsBeforeGC)).To(Equal(2))
 		// add a nic to azure env, and call reconcile. It should show up in the list before reconcile
 		// then it should not showup after
 		ExpectSingletonReconciled(ctx, networkInterfaceGCController)
 		nicsAfterGC, err := azureEnv.InstanceProvider.ListNics(ctx)
-		ExpectNoError(err)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(len(nicsAfterGC)).To(Equal(0))
 	})
 	It("should not delete a NIC if there is an associated VM", func() {
@@ -371,7 +371,7 @@ var _ = Describe("NetworkInterface Garbage Collection", func() {
 		ExpectSingletonReconciled(ctx, networkInterfaceGCController)
 		// We should still have a network interface here
 		nicsAfterGC, err := azureEnv.InstanceProvider.ListNics(ctx)
-		ExpectNoError(err)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(len(nicsAfterGC)).To(Equal(1))
 
 	})
@@ -391,12 +391,12 @@ var _ = Describe("NetworkInterface Garbage Collection", func() {
 		ExpectSingletonReconciled(ctx, networkInterfaceGCController)
 		// We should still have a network interface here
 		nicsAfterGC, err := azureEnv.InstanceProvider.ListNics(ctx)
-		ExpectNoError(err)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(len(nicsAfterGC)).To(Equal(1))
 
 		ExpectSingletonReconciled(ctx, virtualMachineGCController)
 		nicsAfterVMReconciliation, err := azureEnv.InstanceProvider.ListNics(ctx)
-		ExpectNoError(err)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(len(nicsAfterVMReconciliation)).To(Equal(0))
 
 	})

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -46,7 +46,6 @@ import (
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
 
-	. "github.com/Azure/karpenter-provider-azure/pkg/test/expectations"
 	. "knative.dev/pkg/logging/testing"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
@@ -232,7 +231,7 @@ var _ = Describe("InstanceProvider", func() {
 		azureEnv.NetworkInterfacesAPI.NetworkInterfaces.Store(lo.FromPtr(managedNic.ID), *managedNic)
 		azureEnv.NetworkInterfacesAPI.NetworkInterfaces.Store(lo.FromPtr(unmanagedNic.ID), *unmanagedNic)
 		interfaces, err := azureEnv.InstanceProvider.ListNics(ctx)
-		ExpectNoError(err)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(len(interfaces)).To(Equal(1))
 		Expect(interfaces[0].Name).To(Equal(managedNic.Name))
 	})

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -53,8 +53,3 @@ func ExpectDecodedCustomData(env *test.Environment) string {
 
 	return decodedString
 }
-
-func ExpectNoError(err error) {
-	GinkgoHelper()
-	Expect(err).To(BeNil())
-}


### PR DESCRIPTION
**Description**
One of the cleanup items from the network interface garbage collection pr was to remove this minor helper I added. This pr does that.
**How was this change tested?**
- make test

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
