### PR TITLE
fix: make presubmit

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.azure.com_aksnodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.azure.com_aksnodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: aksnodeclasses.karpenter.azure.com
 spec:
   group: karpenter.azure.com

--- a/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: aksnodeclasses.karpenter.azure.com
 spec:
   group: karpenter.azure.com


### PR DESCRIPTION
**Description**
Seems make presubmit somehow was bypassed, this updates that. If you run make presubmit on main, it generates content. 

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
