### PR TITLE
Utilizing SH Logging Policy for ARM Track 2 SDK Calls

### DIFF
--- a/pkg/utils/opts/armopts.go
+++ b/pkg/utils/opts/armopts.go
@@ -18,8 +18,12 @@ package opts
 
 import (
 	"net/http"
+	"os"
 	"time"
 
+	"log/slog"
+
+	shPolicy "github.com/Azure/aks-middleware/http/client/azuresdk/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/karpenter-provider-azure/pkg/auth"
@@ -30,6 +34,9 @@ func DefaultArmOpts() *arm.ClientOptions {
 	opts.Telemetry = DefaultTelemetryOpts()
 	opts.Retry = DefaultRetryOpts()
 	opts.Transport = defaultHTTPClient
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	opts.PerCallPolicies = append(opts.PerCallPolicies, shPolicy.NewLoggingPolicy(logger))
 	return opts
 }
 

--- a/pkg/utils/opts/armopts.go
+++ b/pkg/utils/opts/armopts.go
@@ -36,7 +36,7 @@ func DefaultArmOpts() *arm.ClientOptions {
 	opts.Transport = defaultHTTPClient
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	opts.PerCallPolicies = append(opts.PerCallPolicies, shPolicy.NewLoggingPolicy(logger))
+	opts.PerCallPolicies = append(opts.PerCallPolicies, shPolicy.NewLoggingPolicy(*logger))
 	return opts
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**
This change utilizes Service Hub [logging policy](https://github.com/Azure/aks-middleware/blob/main/http/client/azuresdk/policy/policy.go) to instrument the pipeline used to send requests to ARM in order to log out responses for logging/monitoring purposes.

Example logs generated during E2E testing

![image](https://github.com/user-attachments/assets/5139a25a-43b7-4116-acfa-2cdaa4719cb7)


**How was this change tested?**
E2E tests
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
