### PR TITLE
feat: add azure-cni-overlay label and set network plugin to none in some cases

### DIFF
--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -454,6 +454,7 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 	nbv.UserAssignedIdentityID = a.KubeletIdentityClientID
 
 	nbv.NetworkPlugin = a.NetworkPlugin
+
 	nbv.NetworkPolicy = a.NetworkPolicy
 	nbv.KubernetesVersion = a.KubernetesVersion
 

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -130,6 +130,8 @@ var _ = Describe("InstanceType Provider", func() {
 			},
 		})
 
+		ctx = options.ToContext(ctx, test.Options())
+
 		cluster.Reset()
 		clusterNonZonal.Reset()
 		azureEnv.Reset()
@@ -162,6 +164,7 @@ var _ = Describe("InstanceType Provider", func() {
 				ContainSubstring("kubernetes.azure.com/network-subnet=karpentersub"),
 				ContainSubstring("kubernetes.azure.com/nodenetwork-vnetguid=test-vnet-guid"),
 				ContainSubstring("kubernetes.azure.com/podnetwork-type=overlay"),
+				ContainSubstring("kubernetes.azure.com/azure-cni-overlay=true"),
 			))
 		})
 		It("should use the subnet specified in the nodeclass", func() {
@@ -1196,6 +1199,57 @@ var _ = Describe("InstanceType Provider", func() {
 			}
 		})
 	})
+
+	DescribeTable("Azure CNI node labels and agentbaker network plugin", func(
+		networkPlugin, networkPluginMode, networkDataplane, expectedAgentBakerNetPlugin string,
+		expectedNodeLabels sets.Set[string]) {
+		options := test.Options(test.OptionsFields{
+			NetworkPlugin:     lo.ToPtr(networkPlugin),
+			NetworkPluginMode: lo.ToPtr(networkPluginMode),
+			NetworkDataplane:  lo.ToPtr(networkDataplane),
+		})
+		ctx = options.ToContext(ctx)
+
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+		pod := coretest.UnschedulablePod()
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
+		ExpectScheduled(ctx, env.Client, pod)
+		customData := ExpectDecodedCustomData(azureEnv)
+
+		Expect(customData).To(ContainSubstring(fmt.Sprintf("NETWORK_PLUGIN=%s", expectedAgentBakerNetPlugin)))
+
+		for label := range expectedNodeLabels {
+			Expect(customData).To(ContainSubstring(label))
+		}
+	},
+		Entry("Azure CNI V1",
+			"azure", "", "",
+			"azure", sets.New[string]()),
+		Entry("Azure CNI w Overlay",
+			"azure", "overlay", "",
+			"none",
+			sets.New(
+				"kubernetes.azure.com/azure-cni-overlay=true",
+				"kubernetes.azure.com/network-subnet=karpentersub",
+				"kubernetes.azure.com/nodenetwork-vnetguid=test-vnet-guid",
+				"kubernetes.azure.com/podnetwork-type=overlay",
+			)),
+		Entry("Azure CNI w Overlay w Cilium",
+			"azure", "overlay", "cilium",
+			"none",
+			sets.New(
+				"kubernetes.azure.com/azure-cni-overlay=true",
+				"kubernetes.azure.com/network-subnet=karpentersub",
+				"kubernetes.azure.com/nodenetwork-vnetguid=test-vnet-guid",
+				"kubernetes.azure.com/podnetwork-type=overlay",
+				"kubernetes.azure.com/ebpf-dataplane=cilium",
+			)),
+		Entry("Cilium w feature flag Microsoft.ContainerService/EnableCiliumNodeSubnet",
+			"azure", "", "cilium",
+			"none",
+			sets.New("kubernetes.azure.com/ebpf-dataplane=cilium")),
+	)
+
 	Context("LoadBalancer", func() {
 		resourceGroup := "test-resourceGroup"
 


### PR DESCRIPTION
* fix: setting network plugin to none in the agentbaker contract if we are using overlay net plugin mode. This will delegate the installation of the cni to daemonsets (azure-cns) etc. This also introduces a label azure-cni-overlay which adds better consistency between karpenter provided nodes and nodes provided from aks. We also introduce tests to explicitly validate that if the network plugin mode on the cluster is azure and uses azure cni overlay, that we properly delegate that installation

* fix: ci

* refactor: renaming cni label var

* modifying comment

* style: renaming vars to not have vnet prefix

* test: adding tests for the different cni modes on labels

* refactor: renaming test

* feat: supporting cilium + nodesubnet case

