### PR TITLE
feat: controller to add missing kubernetes.azure.com/azure-cni-overlay label

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
+	"github.com/Azure/karpenter-provider-azure/pkg/controllers/node/remediation"
 	nodeclaimgarbagecollection "github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclaim/garbagecollection"
 	nodeclasshash "github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclass/hash"
 	nodeclassstatus "github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclass/status"
@@ -51,6 +52,8 @@ func NewControllers(ctx context.Context, mgr manager.Manager, kubeClient client.
 		// TODO: nodeclaim tagging
 		inplaceupdate.NewController(kubeClient, instanceProvider),
 		status.NewController[*v1alpha2.AKSNodeClass](kubeClient, mgr.GetEventRecorderFor("karpenter")),
+
+		remediation.NewController(kubeClient),
 	}
 	return controllers
 }

--- a/pkg/controllers/node/remediation/controller.go
+++ b/pkg/controllers/node/remediation/controller.go
@@ -1,0 +1,95 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remediation
+
+import (
+	"context"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
+	"github.com/samber/lo"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+)
+
+const (
+	azureCNIOverlayLabelKey = "kubernetes.azure.com/azure-cni-overlay"
+)
+
+// Controller adds azure-cni-overlay label to managed nodes that don't have it.
+// It only runs (registers) when Azure CNI Overlay configuration is detected
+type Controller struct {
+	kubeClient client.Client
+}
+
+func NewController(kubeClient client.Client) *Controller {
+	return &Controller{
+		kubeClient: kubeClient,
+	}
+}
+
+func (c *Controller) Reconcile(ctx context.Context, node *corev1.Node) (reconcile.Result, error) {
+	if !isManagedWithoutLabel(node) { // extra guard and testability
+		return reconcile.Result{}, nil
+	}
+
+	ctx = injection.WithControllerName(ctx, c.Name())
+	stored := node.DeepCopy()
+	node.Labels = lo.Assign(node.Labels, map[string]string{azureCNIOverlayLabelKey: "true"})
+	if !equality.Semantic.DeepEqual(stored, node) {
+		if err := c.kubeClient.Patch(ctx, node, client.MergeFrom(stored)); err != nil {
+			return reconcile.Result{}, client.IgnoreNotFound(err)
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+func (c *Controller) Name() string {
+	return "node.remediation"
+}
+
+func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
+	if !isAzureCNIOverlay(ctx) {
+		return nil
+	}
+
+	return controllerruntime.NewControllerManagedBy(m).
+		Named(c.Name()).
+		For(&corev1.Node{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
+			return isManagedWithoutLabel(o)
+		}))).
+		Complete(reconcile.AsReconciler(m.GetClient(), c))
+}
+
+func isManagedWithoutLabel(o client.Object) bool {
+	return o.GetLabels()[v1.NodePoolLabelKey] != "" && o.GetLabels()[azureCNIOverlayLabelKey] == ""
+}
+
+func isAzureCNIOverlay(ctx context.Context) bool {
+	return options.FromContext(ctx).NetworkPlugin == consts.NetworkPluginAzure &&
+		options.FromContext(ctx).NetworkPluginMode == consts.NetworkPluginModeOverlay
+}

--- a/pkg/controllers/node/remediation/suite_test.go
+++ b/pkg/controllers/node/remediation/suite_test.go
@@ -1,0 +1,97 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remediation_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/controllers/node/remediation"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/karpenter/pkg/apis"
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+)
+
+var ctx context.Context
+var remediationController *remediation.Controller
+var env *test.Environment
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Remediation")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...))
+	ctx = options.ToContext(ctx, test.Options())
+
+	remediationController = remediation.NewController(env.Client)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+})
+
+var _ = Describe("Remediation", func() {
+	DescribeTable(
+		"Azure CNI Overlay Label",
+		func(isManaged bool, hadLabel bool) {
+
+			labels := map[string]string{}
+			if hadLabel {
+				labels["kubernetes.azure.com/azure-cni-overlay"] = "true"
+			}
+			if isManaged {
+				labels[v1.NodePoolLabelKey] = "default"
+			}
+
+			node := test.Node(test.NodeOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+			})
+
+			ExpectApplied(ctx, env.Client, node)
+			ExpectObjectReconciled(ctx, env.Client, remediationController, node)
+
+			node = ExpectExists(ctx, env.Client, node)
+			value, ok := node.Labels["kubernetes.azure.com/azure-cni-overlay"]
+
+			Expect(ok).To(Equal(isManaged || hadLabel))
+			if isManaged || hadLabel {
+				Expect(value).To(Equal("true"))
+			}
+		},
+		Entry("should add  label to   managed node without label", true, false),
+		Entry("should keep label on   managed node with    label", true, true),
+		Entry("should keep label on unmanaged node with    label", false, true),
+		Entry("should ignore        unmanaged node without label", false, false),
+	)
+})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Controller adds azure-cni-overlay label to existing managed nodes that don't have it.
It only runs (registers) when Azure CNI Overlay configuration is detected.

(Singleton controller is another option, can stop reconciling once successful)

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
