### PR TITLE
fix: add required `MCR_REPOSITORY_BASE` to bootstrap

### DIFF
--- a/pkg/providers/imagefamily/bootstrap/cse_cmd.sh.gtpl
+++ b/pkg/providers/imagefamily/bootstrap/cse_cmd.sh.gtpl
@@ -144,6 +144,7 @@ AZURE_ENVIRONMENT_FILEPATH="{{.AzureEnvironmentFilepath}}"
 KUBE_CA_CRT="{{.KubeCACrt}}"
 CONTAINERD_CONFIG_CONTENT="{{.ContainerdConfigContent}}"
 IS_KATA="{{.IsKata}}"
+MCR_REPOSITORY_BASE="mcr.microsoft.com"
 ENABLE_IMDS_RESTRICTION=false
 INSERT_IMDS_RESTRICTION_RULE_TO_MANGLE_TABLE=false
 /usr/bin/nohup /bin/bash -c "/bin/bash /opt/azure/containers/provision_start.sh"


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #723

**Description**

This adds the `MCR_REPOSITORY_BASE` setting to bootstrap, which is apparently required by `v202503.02.0` VHD image

**How was this change tested?**

* manual scaleup
* `make presubmit`
* E2E: https://github.com/Azure/karpenter-provider-azure/actions/runs/13709312852 (pending)
* independent testing of snapshot image

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adds `MCR_REPOSITORY_BASE` setting to bootstrap script to fix bootstrap of `v202503.02.0` VHD image
```
