### PR TITLE
fix: adding InClusterController check to validate if we are using nap or self-hosted setup in our e2e tests

### DIFF
--- a/test/pkg/environment/azure/expectations.go
+++ b/test/pkg/environment/azure/expectations.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"

--- a/test/pkg/environment/azure/setup.go
+++ b/test/pkg/environment/azure/setup.go
@@ -45,6 +45,10 @@ func (env *Environment) Cleanup() {
 }
 
 func (env *Environment) AfterEach() {
+	if !env.InClusterController() {
+		return
+	}
+
 	fmt.Println("##[group]    E2E SUITE: LOG DUMP")
 	defer fmt.Println("##[endgroup]")
 	env.Environment.AfterEach()

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -49,6 +49,20 @@ import (
 	coreresources "sigs.k8s.io/karpenter/pkg/utils/resources"
 )
 
+const (
+	DefaultControllerNamespace = "kube-system"
+	DefaultDeploymentName      = "karpenter"
+)
+
+// InClusterController returns a boolean if the karpenter controller is hosted in the cluster rather than some managed
+// controlplane.
+func (env *Environment) InClusterController() bool {
+	GinkgoHelper()
+	d := &appsv1.Deployment{}
+	err := env.Client.Get(env.Context, types.NamespacedName{Namespace: DefaultControllerNamespace, Name: DefaultDeploymentName}, d)
+	return err == nil
+}
+
 func (env *Environment) ExpectCreated(objects ...client.Object) {
 	GinkgoHelper()
 	for _, object := range objects {
@@ -146,9 +160,12 @@ func (env *Environment) ExpectCreatedOrUpdated(objects ...client.Object) {
 
 func (env *Environment) ExpectSettings() (res []corev1.EnvVar) {
 	GinkgoHelper()
-
+	// we cannot run tests for now on karpenter if the controller isn't in cluster
+	if !env.InClusterController() {
+		return
+	}
 	d := &appsv1.Deployment{}
-	Expect(env.Client.Get(env.Context, types.NamespacedName{Namespace: "kube-system", Name: "karpenter"}, d)).To(Succeed())
+	Expect(env.Client.Get(env.Context, types.NamespacedName{Namespace: DefaultControllerNamespace, Name: DefaultDeploymentName}, d)).To(Succeed())
 	Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
 	return lo.Map(d.Spec.Template.Spec.Containers[0].Env, func(v corev1.EnvVar, _ int) corev1.EnvVar {
 		return *v.DeepCopy()
@@ -157,9 +174,12 @@ func (env *Environment) ExpectSettings() (res []corev1.EnvVar) {
 
 func (env *Environment) ExpectSettingsReplaced(vars ...corev1.EnvVar) {
 	GinkgoHelper()
-
+	// we cannot run tests for now on karpenter if the controller isn't in cluster
+	if !env.InClusterController() {
+		return
+	}
 	d := &appsv1.Deployment{}
-	Expect(env.Client.Get(env.Context, types.NamespacedName{Namespace: "kube-system", Name: "karpenter"}, d)).To(Succeed())
+	Expect(env.Client.Get(env.Context, types.NamespacedName{Namespace: DefaultControllerNamespace, Name: DefaultDeploymentName}, d)).To(Succeed())
 	Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
 
 	stored := d.DeepCopy()
@@ -174,9 +194,12 @@ func (env *Environment) ExpectSettingsReplaced(vars ...corev1.EnvVar) {
 
 func (env *Environment) ExpectSettingsOverridden(vars ...corev1.EnvVar) {
 	GinkgoHelper()
-
+	// we cannot run tests for now on karpenter if the controller isn't in cluster
+	if !env.InClusterController() {
+		return
+	}
 	d := &appsv1.Deployment{}
-	Expect(env.Client.Get(env.Context, types.NamespacedName{Namespace: "kube-system", Name: "karpenter"}, d)).To(Succeed())
+	Expect(env.Client.Get(env.Context, types.NamespacedName{Namespace: DefaultControllerNamespace, Name: "karpenter"}, d)).To(Succeed())
 	Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
 
 	stored := d.DeepCopy()
@@ -198,11 +221,14 @@ func (env *Environment) ExpectSettingsOverridden(vars ...corev1.EnvVar) {
 
 func (env *Environment) ExpectSettingsRemoved(vars ...corev1.EnvVar) {
 	GinkgoHelper()
-
+	// we cannot run tests for now on karpenter if the controller isn't in cluster
+	if !env.InClusterController() {
+		return
+	}
 	varNames := sets.New(lo.Map(vars, func(v corev1.EnvVar, _ int) string { return v.Name })...)
 
 	d := &appsv1.Deployment{}
-	Expect(env.Client.Get(env.Context, types.NamespacedName{Namespace: "kube-system", Name: "karpenter"}, d)).To(Succeed())
+	Expect(env.Client.Get(env.Context, types.NamespacedName{Namespace: DefaultControllerNamespace, Name: "karpenter"}, d)).To(Succeed())
 	Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
 
 	stored := d.DeepCopy()
@@ -364,8 +390,12 @@ func (env *Environment) ConsistentlyExpectHealthyPods(duration time.Duration, po
 
 func (env *Environment) EventuallyExpectKarpenterRestarted() {
 	GinkgoHelper()
+	// we cannot run tests for now on karpenter if the controller isn't in cluster
+	if !env.InClusterController() {
+		return
+	}
 	By("rolling out the new karpenter deployment")
-	env.EventuallyExpectRollout("karpenter", "kube-system")
+	env.EventuallyExpectRollout("karpenter", DefaultControllerNamespace)
 
 	if !lo.ContainsBy(env.ExpectSettings(), func(v corev1.EnvVar) bool {
 		return v.Name == "DISABLE_LEADER_ELECTION" && v.Value == "true"
@@ -376,7 +406,10 @@ func (env *Environment) EventuallyExpectKarpenterRestarted() {
 
 func (env *Environment) ExpectKarpenterLeaseOwnerChanged() {
 	GinkgoHelper()
-
+	// we cannot run tests for now on karpenter if the controller isn't in cluster
+	if !env.InClusterController() {
+		return
+	}
 	By("waiting for a new karpenter pod to hold the lease")
 	pods := env.ExpectKarpenterPods()
 	Eventually(func(g Gomega) {
@@ -389,6 +422,10 @@ func (env *Environment) ExpectKarpenterLeaseOwnerChanged() {
 
 func (env *Environment) EventuallyExpectRollout(name, namespace string) {
 	GinkgoHelper()
+	// we cannot run tests for now on karpenter if the controller isn't in cluster
+	if !env.InClusterController() {
+		return
+	}
 	By("restarting the deployment")
 	deploy := &appsv1.Deployment{}
 	Expect(env.Client.Get(env.Context, types.NamespacedName{Name: name, Namespace: namespace}, deploy)).To(Succeed())
@@ -430,7 +467,7 @@ func (env *Environment) ExpectKarpenterPods() []*corev1.Pod {
 func (env *Environment) ExpectActiveKarpenterPodName() string {
 	GinkgoHelper()
 	lease := &coordinationv1.Lease{}
-	Expect(env.Client.Get(env.Context, types.NamespacedName{Name: "karpenter-leader-election", Namespace: "kube-system"}, lease)).To(Succeed())
+	Expect(env.Client.Get(env.Context, types.NamespacedName{Name: "karpenter-leader-election", Namespace: DefaultControllerNamespace}, lease)).To(Succeed())
 
 	// Holder identity for lease is always in the format "<pod-name>_<pseudo-random-value>
 	holderArr := strings.Split(lo.FromPtr(lease.Spec.HolderIdentity), "_")
@@ -444,7 +481,7 @@ func (env *Environment) ExpectActiveKarpenterPod() *corev1.Pod {
 	podName := env.ExpectActiveKarpenterPodName()
 
 	pod := &corev1.Pod{}
-	Expect(env.Client.Get(env.Context, types.NamespacedName{Name: podName, Namespace: "kube-system"}, pod)).To(Succeed())
+	Expect(env.Client.Get(env.Context, types.NamespacedName{Name: podName, Namespace: DefaultControllerNamespace}, pod)).To(Succeed())
 	return pod
 }
 
@@ -828,7 +865,7 @@ func (env *Environment) GetNode(nodeName string) corev1.Node {
 
 func (env *Environment) ExpectNoCrashes() {
 	GinkgoHelper()
-	for k, v := range env.Monitor.RestartCount("kube-system") {
+	for k, v := range env.Monitor.RestartCount(DefaultControllerNamespace) {
 		if strings.Contains(k, "karpenter") && v > 0 {
 			Fail("expected karpenter containers to not crash")
 		}
@@ -856,7 +893,7 @@ func (env *Environment) printControllerLogs(options *corev1.PodLogOptions) {
 			fmt.Printf("[PREVIOUS CONTAINER LOGS]\n")
 			temp.Previous = true
 		}
-		stream, err := env.KubeClient.CoreV1().Pods("kube-system").GetLogs(pod.Name, temp).Stream(env.Context)
+		stream, err := env.KubeClient.CoreV1().Pods(DefaultControllerNamespace).GetLogs(pod.Name, temp).Stream(env.Context)
 		if err != nil {
 			log.FromContext(env.Context).Error(err, "failed fetching controller logs")
 			return

--- a/test/pkg/environment/common/setup.go
+++ b/test/pkg/environment/common/setup.go
@@ -75,6 +75,15 @@ func (env *Environment) BeforeEach() {
 }
 
 func (env *Environment) ExpectCleanCluster() {
+	env.ExpectSystemNodesTainted()
+	env.ExpectNoPodsInDefaultNamespace()
+	env.ExpectNoProvisionablePods()
+
+	// This assumes the cluster is created without managed pools
+	env.ExpectNoNodePoolOrAKSNodeClass()
+}
+
+func (env *Environment) ExpectSystemNodesTainted() {
 	var nodes corev1.NodeList
 	Expect(env.Client.List(env.Context, &nodes)).To(Succeed())
 	for _, node := range nodes.Items {
@@ -82,26 +91,36 @@ func (env *Environment) ExpectCleanCluster() {
 			Fail(fmt.Sprintf("expected system pool node %s to be tainted", node.Name))
 		}
 	}
+}
+
+func (env *Environment) ExpectNoPodsInDefaultNamespace() {
 	var pods corev1.PodList
 	Expect(env.Client.List(env.Context, &pods)).To(Succeed())
-	for i := range pods.Items {
-		Expect(pods.Items[i].Namespace).ToNot(Equal("default"),
-			fmt.Sprintf("expected no pods in the `default` namespace, found %s/%s", pods.Items[i].Namespace, pods.Items[i].Name))
+	for _, pod := range pods.Items {
+		Expect(pod.Namespace).ToNot(Equal("default"),
+			fmt.Sprintf("expected no pods in the `default` namespace, found %s/%s", pod.Namespace, pod.Name))
 	}
+}
+
+func (env *Environment) ExpectNoProvisionablePods() {
 	Eventually(func(g Gomega) {
 		var pods corev1.PodList
 		g.Expect(env.Client.List(env.Context, &pods)).To(Succeed())
-		for i := range pods.Items {
-			g.Expect(pod.IsProvisionable(&pods.Items[i])).To(BeFalse(),
-				fmt.Sprintf("expected to have no provisionable pods, found %s/%s", pods.Items[i].Namespace, pods.Items[i].Name))
+		for _, p := range pods.Items {
+			g.Expect(pod.IsProvisionable(&p)).To(BeFalse(),
+				fmt.Sprintf("expected to have no provisionable pods, found %s/%s", p.Namespace, p.Name))
 		}
 	}).WithPolling(10 * time.Second).WithTimeout(5 * time.Minute).Should(Succeed())
+}
+
+func (env *Environment) ExpectNoNodePoolOrAKSNodeClass() {
 	for _, obj := range []client.Object{&karpv1.NodePool{}, &v1alpha2.AKSNodeClass{}} {
 		metaList := &metav1.PartialObjectMetadataList{}
 		gvk := lo.Must(apiutil.GVKForObject(obj, env.Client.Scheme()))
 		metaList.SetGroupVersionKind(gvk)
 		Expect(env.Client.List(env.Context, metaList, client.Limit(1))).To(Succeed())
-		Expect(metaList.Items).To(HaveLen(0), fmt.Sprintf("expected no %s to exist", gvk.Kind))
+		Expect(metaList.Items).To(HaveLen(0),
+			fmt.Sprintf("expected no %s to exist", gvk.Kind))
 	}
 }
 


### PR DESCRIPTION
… 

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
This PR Introduces the 2a testing changes in a cleaner implementation, and relies on the default pools not being deployed by nap. 
**How was this change tested?**
- in progress

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
