### PR TITLE
fix: is network plugin none case for agentbaker networkplugin

### DIFF
--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -172,10 +172,14 @@ func (p *Provider) getStaticParameters(ctx context.Context, instanceType *cloudp
 }
 
 func getAgentbakerNetworkPlugin(ctx context.Context) string {
-	if isAzureCNIOverlay(ctx) || isCiliumNodeSubnet(ctx) {
+	if isAzureCNIOverlay(ctx) || isCiliumNodeSubnet(ctx) || isNetworkPluginNone(ctx) {
 		return consts.NetworkPluginNone
 	}
 	return consts.NetworkPluginAzure
+}
+
+func isNetworkPluginNone(ctx context.Context) bool {
+	return options.FromContext(ctx).NetworkPlugin == consts.NetworkPluginNone
 }
 
 func isCiliumNodeSubnet(ctx context.Context) bool {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #733 

**Description**
In a pr we stopped setting network plugin to none for agentbaker network plugin by mistake. This pr fixes that.

**How was this change tested?**
- make presubmit


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
