### PR TITLE
chore(refactor): add Resolver interface in refactor of imagefamily package

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -100,7 +100,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		azConfig.SubscriptionID,
 		azClient.NodeImageVersionsClient,
 	)
-	imageResolver := imagefamily.NewResolver(
+	imageResolver := imagefamily.NewDefaultResolver(
 		operator.GetClient(),
 		imageProvider,
 	)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -65,7 +65,7 @@ type Operator struct {
 	UnavailableOfferingsCache *azurecache.UnavailableOfferings
 
 	ImageProvider          *imagefamily.Provider
-	ImageResolver          *imagefamily.Resolver
+	ImageResolver          imagefamily.Resolver
 	LaunchTemplateProvider *launchtemplate.Provider
 	PricingProvider        *pricing.Provider
 	InstanceTypesProvider  instancetype.Provider

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -100,7 +100,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		azConfig.SubscriptionID,
 		azClient.NodeImageVersionsClient,
 	)
-	imageResolver := imagefamily.New(
+	imageResolver := imagefamily.NewResolver(
 		operator.GetClient(),
 		imageProvider,
 	)

--- a/pkg/providers/imagefamily/resolver.go
+++ b/pkg/providers/imagefamily/resolver.go
@@ -77,14 +77,14 @@ type ImageFamily interface {
 }
 
 // New constructs a new launch template Resolver
-func NewResolver(_ client.Client, imageProvider *Provider) *Resolver {
+func NewResolver(_ client.Client, imageProvider *Provider) Resolver {
 	return &resolver{
 		imageProvider: imageProvider,
 	}
 }
 
 // Resolve fills in dynamic launch template parameters
-func (r resolver) Resolve(ctx context.Context, nodeClass *v1alpha2.AKSNodeClass, nodeClaim *karpv1.NodeClaim, instanceType *cloudprovider.InstanceType,
+func (r *resolver) Resolve(ctx context.Context, nodeClass *v1alpha2.AKSNodeClass, nodeClaim *karpv1.NodeClaim, instanceType *cloudprovider.InstanceType,
 	staticParameters *template.StaticParameters) (*template.Parameters, error) {
 	imageFamily := getImageFamily(nodeClass.Spec.ImageFamily, staticParameters)
 	imageDistro, imageID, err := r.imageProvider.Get(ctx, nodeClass, instanceType, imageFamily)

--- a/pkg/providers/imagefamily/resolver.go
+++ b/pkg/providers/imagefamily/resolver.go
@@ -47,7 +47,7 @@ type Resolver interface {
 }
 
 // assert that defaultResolver implements Resolver interface
-var _ Resolver = (*defaultResolver)(nil)
+var _ Resolver = &defaultResolver{}
 
 // defaultResolver is able to fill-in dynamic launch template parameters
 type defaultResolver struct {

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -58,7 +58,7 @@ type Template struct {
 }
 
 type Provider struct {
-	imageFamily             *imagefamily.Resolver
+	imageFamily             imagefamily.Resolver
 	imageProvider           *imagefamily.Provider
 	caBundle                *string
 	clusterEndpoint         string
@@ -74,7 +74,7 @@ type Provider struct {
 
 // TODO: add caching of launch templates
 
-func NewProvider(_ context.Context, imageFamily *imagefamily.Resolver, imageProvider *imagefamily.Provider, caBundle *string, clusterEndpoint string,
+func NewProvider(_ context.Context, imageFamily imagefamily.Resolver, imageProvider *imagefamily.Provider, caBundle *string, clusterEndpoint string,
 	tenantID, subscriptionID, clusterResourceGroup string, kubeletIdentityClientID, resourceGroup, location, vnetGUID, provisionMode string,
 ) *Provider {
 	return &Provider{

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -71,7 +71,7 @@ type Environment struct {
 	InstanceProvider       instance.Provider
 	PricingProvider        *pricing.Provider
 	ImageProvider          *imagefamily.Provider
-	ImageResolver          *imagefamily.Resolver
+	ImageResolver          imagefamily.Resolver
 	LaunchTemplateProvider *launchtemplate.Provider
 	LoadBalancerProvider   *loadbalancer.Provider
 

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -111,7 +111,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 	// Providers
 	pricingProvider := pricing.NewProvider(ctx, pricingAPI, region, make(chan struct{}))
 	imageFamilyProvider := imagefamily.NewProvider(env.KubernetesInterface, kubernetesVersionCache, communityImageVersionsAPI, region, subscription, nodeImageVersionsAPI)
-	imageFamilyResolver := imagefamily.New(env.Client, imageFamilyProvider)
+	imageFamilyResolver := imagefamily.NewDefaultResolver(env.Client, imageFamilyProvider)
 	instanceTypesProvider := instancetype.NewDefaultProvider(region, instanceTypeCache, skuClientSingleton, pricingProvider, unavailableOfferingsCache)
 	launchTemplateProvider := launchtemplate.NewProvider(
 		ctx,


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Currently working on a refactor of the `imagefamily` package to leverage the new status information on node images and kubernetes version for provisioning. Felt this refactor could be broken out into a clean, simple, and smaller PR.

**How was this change tested?**
Nothing additional (just normal check-in tests, and running E2E manually)
- E2E test: https://github.com/Azure/karpenter-provider-azure/actions/runs/13999763078


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
