### PR TITLE
fix: Fix Gt and Lt for EphemerealOSMaxSize (Fixes #683)

### DIFF
--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -349,7 +349,7 @@ func (p *DefaultProvider) isConfidential(sku *skewer.SKU) bool {
 // For Ephemeral disk creation, CRP will use the larger of the two values to ensure we have enough space for the ephemeral disk.
 // Note that generally only older SKUs use the Temp Disk space for ephemeral disks, and newer SKUs use the Cached Disk in most cases.
 // The ephemeral OS disk is created with the free space of the larger of the two values in that place.
-func MaxEphemeralOSDiskSizeGB(sku *skewer.SKU) float64 {
+func MaxEphemeralOSDiskSizeGB(sku *skewer.SKU) int32 {
 	if sku == nil {
 		return 0
 	}
@@ -362,7 +362,7 @@ func MaxEphemeralOSDiskSizeGB(sku *skewer.SKU) float64 {
 		return 0
 	}
 	// convert bytes to GB
-	return maxDiskBytes / float64(units.Gigabyte)
+	return int32(maxDiskBytes / float64(units.Gigabyte))
 }
 
 var (

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -889,7 +889,7 @@ var _ = Describe("InstanceType Provider", func() {
 				v1alpha2.LabelSKUName:                      "Standard_NC24ads_A100_v4",
 				v1alpha2.LabelSKUFamily:                    "N",
 				v1alpha2.LabelSKUVersion:                   "4",
-				v1alpha2.LabelSKUStorageEphemeralOSMaxSize: "53.6870912",
+				v1alpha2.LabelSKUStorageEphemeralOSMaxSize: "54",
 				v1alpha2.LabelSKUAcceleratedNetworking:     "true",
 				v1alpha2.LabelSKUEncryptionAtHostSupported: "true",
 				v1alpha2.LabelSKUStoragePremiumCapable:     "true",


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #683 

**Description**

Context: https://github.com/Azure/karpenter-provider-azure/issues/683#issuecomment-2729583707

GT and LT operators do not work for `karpenter.azure.com/sku-storage-ephemeralos-maxsize`.
The reason is (or at least seems to be for me) that K8s parses the annotation's value as integer and that is a float. So, the GT and LT won't work...

> Gt and Lt operators will not work with non-integer values. If the given value doesn't parse as an integer, the pod will fail to get scheduled. Also, Gt and Lt are not available for podAffinity.

Issue request for float support in K8s core here: https://github.com/kubernetes/kubernetes/issues/44932

I guess that the annotation should be (at least for now) an integer, and not a float... Or this filtering won't work at all in current K8s versions!

This PR includes changes to write the annotation as integer. When reading the annotation, it is already parsed as int32!

This is my first PR in this repo. If needed I can provide an update to the docs!

**How was this change tested?**

* Updated the tests in order to make sure it reflects integers instead of floats.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
GT and LT operators are honored and do work for `karpenter.azure.com/sku-storage-ephemeralos-maxsize` annotation. This changes the type from float64 to int32 in the annotation.
```
