### PR TITLE
chore(roles): update roles for self-hosted to support v1 webhook migrations

### DIFF
--- a/charts/karpenter/templates/clusterrole-core.yaml
+++ b/charts/karpenter/templates/clusterrole-core.yaml
@@ -70,6 +70,10 @@ rules:
     verbs: ["delete"]
   {{- if .Values.webhook.enabled }}
   - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions/status"]
+    resourceNames: ["aksnodeclasses.karpenter.azure.com", "nodepools.karpenter.sh", "nodeclaims.karpenter.sh"]
+    verbs: ["patch"]
+  - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["update"]
   {{- end }}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
As part of our plan to upgrade to v1.1.x which remove webhooks, the `.status.storedVersions` have to be handled correctly for existing v1beta1 instances in advance, which these updated roles will allow self-hosted to do.

**How was this change tested?**
- E2E: https://github.com/Azure/karpenter-provider-azure/actions/runs/14135341920
- make presubmit

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Updating roles for self-hosted to allow correct transition of `.status.storedVersions` as required for existing v1beta1 instances, required for future upcoming update to upstream v1.1.x core dependency change.
```
