### PR TITLE
feat: update go-helper-image for go 1.24 / delve 1.24.1

### DIFF
--- a/hack/go-helper-image/Dockerfile
+++ b/hack/go-helper-image/Dockerfile
@@ -1,17 +1,17 @@
-ARG GOVERSION=1.21
+ARG GOVERSION=1.24
 FROM --platform=$BUILDPLATFORM golang:${GOVERSION} as delve
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG DELVE_VERSION=1.21.0
+ARG DELVE_VERSION=1.24.1
 
 # Patch delve to make defaults for --check-go-version and --only-same-user
 # to be set at build time.  We must install patch(1) to apply the patch.
 #
 # We default --check-go-version to false to support binaries compiled
 # with unsupported versions of Go.  Delve issues a prominent warning.
-# 
+#
 # We default --only-same-user to false as `kubectl port-forward`
 # to dlv port is refused otherwise.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/hack/go-helper-image/delve-as-options.patch
+++ b/hack/go-helper-image/delve-as-options.patch
@@ -1,32 +1,39 @@
 diff --git cmd/dlv/cmds/commands.go cmd/dlv/cmds/commands.go
-index 15df5f6..f145330 100644
+index 374b5451..ad1c6b69 100644
 --- cmd/dlv/cmds/commands.go
 +++ cmd/dlv/cmds/commands.go
-@@ -46,6 +46,10 @@ var (
- 	apiVersion int
- 	// acceptMulti allows multiple clients to connect to the same server
- 	acceptMulti bool
-+	// checkGoVersionDefault sets default for --check-go-version
-+	checkGoVersionDefault = "true"
+@@ -61,6 +61,8 @@ var (
+ 	// checkLocalConnUser is true if the debugger should check that local
+ 	// connections come from the same user that started the headless server
+ 	checkLocalConnUser bool
 +	// checkLocalConnUserDefault sets default for --only-same-user
 +	checkLocalConnUserDefault = "true"
- 	// addr is the debugging server listen address.
- 	addr string
- 	// initFile is the path to initialization file.
-@@ -139,8 +143,8 @@ func New(docCall bool) *cobra.Command {
- 	rootCommand.PersistentFlags().StringVar(&initFile, "init", "", "Init file, executed by the terminal client.")
- 	rootCommand.PersistentFlags().StringVar(&buildFlags, "build-flags", buildFlagsDefault, "Build flags, to be passed to the compiler. For example: --build-flags=\"-tags=integration -mod=vendor -cover -v\"")
+ 	// tty is used to provide an alternate TTY for the program you wish to debug.
+ 	tty string
+ 	// disableASLR is used to disable ASLR
+@@ -78,6 +80,8 @@ var (
+ 	// used to compile the executable and refuse to work on incompatible
+ 	// versions.
+ 	checkGoVersion bool
++	// checkGoVersionDefault sets default for --check-go-version
++	checkGoVersionDefault = "true"
+ 
+ 	// rootCommand is the root of the command tree.
+ 	rootCommand *cobra.Command
+@@ -158,8 +162,8 @@ func New(docCall bool) *cobra.Command {
+ 	must(rootCommand.RegisterFlagCompletionFunc("build-flags", cobra.NoFileCompletions))
  	rootCommand.PersistentFlags().StringVar(&workingDir, "wd", "", "Working directory for running the program.")
+ 	must(rootCommand.MarkPersistentFlagDirname("wd"))
 -	rootCommand.PersistentFlags().BoolVarP(&checkGoVersion, "check-go-version", "", true, "Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve.")
 -	rootCommand.PersistentFlags().BoolVarP(&checkLocalConnUser, "only-same-user", "", true, "Only connections from the same user that started this instance of Delve are allowed to connect.")
 +	rootCommand.PersistentFlags().BoolVarP(&checkGoVersion, "check-go-version", "", parseBool(checkGoVersionDefault), "Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve.")
 +	rootCommand.PersistentFlags().BoolVarP(&checkLocalConnUser, "only-same-user", "", parseBool(checkLocalConnUserDefault), "Only connections from the same user that started this instance of Delve are allowed to connect.")
  	rootCommand.PersistentFlags().StringVar(&backend, "backend", "default", `Backend selection (see 'dlv help backend').`)
+ 	must(rootCommand.RegisterFlagCompletionFunc("backend", cobra.FixedCompletions([]string{"default", "native", "lldb", "rr"}, cobra.ShellCompDirectiveNoFileComp)))
  	rootCommand.PersistentFlags().StringArrayVarP(&redirects, "redirect", "r", []string{}, "Specifies redirect rules for target process (see 'dlv help redirect')")
- 	rootCommand.PersistentFlags().BoolVar(&allowNonTerminalInteractive, "allow-non-terminal-interactive", false, "Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr")
-@@ -1020,3 +1024,14 @@ func parseRedirects(redirects []string) ([3]string, error) {
+@@ -1249,3 +1253,14 @@ func must(err error) {
+ 		log.Fatal(err)
  	}
- 	return r, nil
  }
 +
 +// parseBool parses a boolean value represented by a string, and panics if there is an error.


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Update go-helper-image for go 1.24 / delve 1.24.1 (until https://github.com/GoogleContainerTools/container-debug-support/pull/145 is merged)

**How was this change tested?**

* `skaffold debug` + debugging session

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
