### PR TITLE
test(integration): mark "drain pods in order" as pending

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   hooks:
   - id: gitleaks
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.61.0
+  rev: v1.64.8
   hooks:
   - id: golangci-lint
 - repo: https://github.com/jumanjihouse/pre-commit-hooks

--- a/charts/karpenter-crd/templates/karpenter.azure.com_aksnodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.azure.com_aksnodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: aksnodeclasses.karpenter.azure.com
 spec:
   group: karpenter.azure.com

--- a/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: aksnodeclasses.karpenter.azure.com
 spec:
   group: karpenter.azure.com

--- a/test/suites/integration/termination_test.go
+++ b/test/suites/integration/termination_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Termination", func() {
 	//   3. Critical Non-Daemonset pods
 	//   4. Critical Daemonset pods
 	// Pods in one group are expected to be fully removed before the next group is executed
-	It("should drain pods on a node in order", func() {
+	PIt("should drain pods on a node in order", func() {
 		daemonSet := test.DaemonSet(test.DaemonSetOptions{
 			Selector: map[string]string{"app": "non-critical-daemonset"},
 			PodOptions: test.PodOptions{


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Fix termination tests under Integration suite by marking the prematurely added "drain pods on a node in order" test as pending, until update of `sigs.k8s.io/karpenter` to 1.1.x which ensures the order (and fixes a bug in `test.DaemonSet` that does not propagate labels from `options.PodOptions`)

**How was this change tested?**

* `make az-e2etest` with focused test
* E2E: https://github.com/Azure/karpenter-provider-azure/actions/runs/14238150138 (https://github.com/Azure/karpenter-provider-azure/pull/766/commits/35af93566d28bf5c1d1324d5fa6f1e3443661fa7)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
