### PR TITLE
chore: update versions of credential provider (and add 1.32)

### DIFF
--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -257,15 +257,18 @@ func CredentialProviderURL(kubernetesVersion, arch string) string {
 	// credential provider has its own release outside of k8s version, and there'll be one credential provider binary for each k8s release,
 	// as credential provider release goes with cloud-provider-azure, not every credential provider release will be picked up unless
 	// there are CVE or bug fixes.
-	credentialProviderVersion := "1.29.2"
+	var credentialProviderVersion string
 	switch minorVersion {
 	case 29:
-		credentialProviderVersion = "1.29.2"
+		credentialProviderVersion = "1.29.13"
 	case 30:
-		credentialProviderVersion = "1.30.0"
-
+		credentialProviderVersion = "1.30.10"
 	case 31:
-		credentialProviderVersion = "1.31.0"
+		credentialProviderVersion = "1.31.4"
+	case 32:
+		fallthrough // to default, which is same as latest
+	default:
+		credentialProviderVersion = "1.32.3"
 	}
 
 	return fmt.Sprintf("%s/cloud-provider-azure/v%s/binaries/azure-acr-credential-provider-linux-%s-v%s.tar.gz", globalAKSMirror, credentialProviderVersion, arch, credentialProviderVersion)

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
@@ -66,24 +66,29 @@ func TestGetCredentialProviderURL(t *testing.T) {
 		url     string
 	}{
 		{
+			version: "1.32.0",
+			arch:    "amd64",
+			url:     fmt.Sprintf("%s/cloud-provider-azure/v1.32.3/binaries/azure-acr-credential-provider-linux-amd64-v1.32.3.tar.gz", globalAKSMirror),
+		},
+		{
 			version: "1.31.0",
 			arch:    "amd64",
-			url:     fmt.Sprintf("%s/cloud-provider-azure/v1.31.0/binaries/azure-acr-credential-provider-linux-amd64-v1.31.0.tar.gz", globalAKSMirror),
+			url:     fmt.Sprintf("%s/cloud-provider-azure/v1.31.4/binaries/azure-acr-credential-provider-linux-amd64-v1.31.4.tar.gz", globalAKSMirror),
 		},
 		{
 			version: "1.30.2",
 			arch:    "amd64",
-			url:     fmt.Sprintf("%s/cloud-provider-azure/v1.30.0/binaries/azure-acr-credential-provider-linux-amd64-v1.30.0.tar.gz", globalAKSMirror),
+			url:     fmt.Sprintf("%s/cloud-provider-azure/v1.30.10/binaries/azure-acr-credential-provider-linux-amd64-v1.30.10.tar.gz", globalAKSMirror),
 		},
 		{
 			version: "1.30.0",
 			arch:    "amd64",
-			url:     fmt.Sprintf("%s/cloud-provider-azure/v1.30.0/binaries/azure-acr-credential-provider-linux-amd64-v1.30.0.tar.gz", globalAKSMirror),
+			url:     fmt.Sprintf("%s/cloud-provider-azure/v1.30.10/binaries/azure-acr-credential-provider-linux-amd64-v1.30.10.tar.gz", globalAKSMirror),
 		},
 		{
 			version: "1.30.0",
 			arch:    "arm64",
-			url:     fmt.Sprintf("%s/cloud-provider-azure/v1.30.0/binaries/azure-acr-credential-provider-linux-arm64-v1.30.0.tar.gz", globalAKSMirror),
+			url:     fmt.Sprintf("%s/cloud-provider-azure/v1.30.10/binaries/azure-acr-credential-provider-linux-arm64-v1.30.10.tar.gz", globalAKSMirror),
 		},
 		{
 			version: "1.29.2",


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Update credential provider versions (and add 1.32); follow-up to #808 

**How was this change tested?**

* `make presubmit`
* E2E: https://github.com/Azure/karpenter-provider-azure/actions/runs/14545424719 ✅

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
