### PR TITLE
fix: pin skaffold version (and have e2e match dev)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -74,6 +74,6 @@
 		"ghcr.io/devcontainers/features/azure-cli:1": {},
 		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
 		"ghcr.io/marcozac/devcontainer-features/shellcheck:1": {},
-		"ghcr.io/rio/features/skaffold:2": {}
+		"ghcr.io/rio/features/skaffold:2": { "version": "v2.14.2" }
 	}
 }

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -98,7 +98,7 @@ jobs:
         run: az account set --subscription ${{ secrets.E2E_SUBSCRIPTION_ID }}
       - name: install skaffold
         run: |
-          curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.13.0/skaffold-linux-amd64
+          curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.14.2/skaffold-linux-amd64
           install skaffold /usr/local/bin/
       - name: generate rg name
         run: |


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->


**Description**

Pin skaffold version in devcontainer to 2.14.2 (latest = 2.15.0 appears to have broken helm overrides) and make e2e match dev


**How was this change tested?**

* `make presubmit`
* `make az-run`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
