### PR TITLE
feat: switch CloudProvider Create to be (mostly) non-blocking

### DIFF
--- a/pkg/cloudprovider/events/events.go
+++ b/pkg/cloudprovider/events/events.go
@@ -26,13 +26,15 @@ import (
 )
 
 const (
-	AsyncProvisioningReason = "AsyncProvisioningError"
+	AsyncProvisioningReason   = "AsyncProvisioningError"
+	NodeClassResolutionReason = "NodeClassResolutionError"
 )
 
 func NodePoolFailedToResolveNodeClass(nodePool *v1.NodePool) events.Event {
 	return events.Event{
 		InvolvedObject: nodePool,
 		Type:           corev1.EventTypeWarning,
+		Reason:         NodeClassResolutionReason,
 		Message:        "Failed resolving NodeClass",
 		DedupeValues:   []string{string(nodePool.UID)},
 	}
@@ -42,6 +44,7 @@ func NodeClaimFailedToResolveNodeClass(nodeClaim *v1.NodeClaim) events.Event {
 	return events.Event{
 		InvolvedObject: nodeClaim,
 		Type:           corev1.EventTypeWarning,
+		Reason:         NodeClassResolutionReason,
 		Message:        "Failed resolving NodeClass",
 		DedupeValues:   []string{string(nodeClaim.UID)},
 	}
@@ -51,8 +54,8 @@ func NodeClaimFailedToRegister(nodeClaim *v1.NodeClaim, err error) events.Event 
 	return events.Event{
 		InvolvedObject: nodeClaim,
 		Type:           corev1.EventTypeWarning,
-		Reason:         AsyncProvisioningReason, // TODO: our other events don't set reason... is it an oversight?
-		Message:        fmt.Sprintf("NodeClaim %s failed to register: %s", nodeClaim.Name, truncateMessage(err.Error())),
+		Reason:         AsyncProvisioningReason,
+		Message:        fmt.Sprintf("Failed to register: %s", truncateMessage(err.Error())),
 		DedupeValues:   []string{string(nodeClaim.UID)},
 	}
 }

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	sdkerrors "github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/samber/lo"
@@ -69,8 +70,13 @@ var (
 
 type Resource = map[string]interface{}
 
+type VirtualMachinePromise struct {
+	VM   *armcompute.VirtualMachine
+	Wait func() error
+}
+
 type Provider interface {
-	Create(context.Context, *v1alpha2.AKSNodeClass, *karpv1.NodeClaim, []*corecloudprovider.InstanceType) (*armcompute.VirtualMachine, error)
+	BeginCreate(context.Context, *v1alpha2.AKSNodeClass, *karpv1.NodeClaim, []*corecloudprovider.InstanceType) (*VirtualMachinePromise, error)
 	Get(context.Context, string) (*armcompute.VirtualMachine, error)
 	List(context.Context) ([]*armcompute.VirtualMachine, error)
 	Delete(context.Context, string) error
@@ -125,23 +131,25 @@ func NewDefaultProvider(
 	}
 }
 
-// Create an instance given the constraints.
+// BeginCreate creates an instance given the constraints.
 // instanceTypes should be sorted by priority for spot capacity type.
-func (p *DefaultProvider) Create(
+// Note that the returned instance may not be finished provisioning yet.
+func (p *DefaultProvider) BeginCreate(
 	ctx context.Context,
 	nodeClass *v1alpha2.AKSNodeClass,
 	nodeClaim *karpv1.NodeClaim,
 	instanceTypes []*corecloudprovider.InstanceType,
-) (*armcompute.VirtualMachine, error) {
+) (*VirtualMachinePromise, error) {
 	instanceTypes = orderInstanceTypesByPrice(instanceTypes, scheduling.NewNodeSelectorRequirementsWithMinValues(nodeClaim.Spec.Requirements...))
-	vm, err := p.launchInstance(ctx, nodeClass, nodeClaim, instanceTypes)
+	vmPromise, err := p.beginLaunchInstance(ctx, nodeClass, nodeClaim, instanceTypes)
 	if err != nil {
-		// Currently, CSE errors will lead to here
+		// There may be orphan NICs
 		if cleanupErr := p.cleanupAzureResources(ctx, GenerateResourceName(nodeClaim.Name)); cleanupErr != nil {
 			log.FromContext(ctx).Error(cleanupErr, fmt.Sprintf("failed to cleanup resources for node claim %s", nodeClaim.Name))
 		}
 		return nil, err
 	}
+	vm := vmPromise.VM
 	zone, err := utils.GetZone(vm)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "")
@@ -154,7 +162,7 @@ func (p *DefaultProvider) Create(
 		"zone", zone,
 		"capacity-type", GetCapacityType(vm)).Info("launched new instance")
 
-	return vm, nil
+	return vmPromise, nil
 }
 
 func (p *DefaultProvider) Update(ctx context.Context, vmName string, update armcompute.VirtualMachineUpdate) error {
@@ -256,7 +264,7 @@ func (p *DefaultProvider) createAKSIdentifyingExtension(ctx context.Context, vmN
 	return nil
 }
 
-func (p *DefaultProvider) createCSExtension(ctx context.Context, vmName string, cse string, isWindows bool) (err error) {
+func (p *DefaultProvider) createCSExtension(ctx context.Context, vmName string, cse string, isWindows bool) error {
 	vmExt := p.getCSExtension(cse, isWindows)
 	vmExtName := *vmExt.Name
 	log.FromContext(ctx).V(1).Info(fmt.Sprintf("Creating virtual machine CSE for %s", vmName))
@@ -364,12 +372,13 @@ type createVMOptions struct {
 }
 
 // newVMObject creates a new armcompute.VirtualMachine from the provided options
-func newVMObject(opts *createVMOptions) armcompute.VirtualMachine {
+func newVMObject(opts *createVMOptions) *armcompute.VirtualMachine {
 	if opts.LaunchTemplate.IsWindows {
-		return armcompute.VirtualMachine{} // TODO(Windows)
+		return &armcompute.VirtualMachine{} // TODO(Windows)
 	}
 
-	vm := armcompute.VirtualMachine{
+	vm := &armcompute.VirtualMachine{
+		Name:     lo.ToPtr(opts.VMName), // TODO: I think it's safe to set this, even though it's read only
 		Location: lo.ToPtr(opts.Location),
 		Identity: ConvertToVirtualMachineIdentity(opts.NodeIdentities),
 		Properties: &armcompute.VirtualMachineProperties{
@@ -474,8 +483,13 @@ func setNodePoolNameTag(tags map[string]*string, nodeClaim *karpv1.NodeClaim) {
 	}
 }
 
+type createResult struct {
+	Poller *runtime.Poller[armcompute.VirtualMachinesClientCreateOrUpdateResponse]
+	VM     *armcompute.VirtualMachine
+}
+
 // createVirtualMachine creates a new VM using the provided options or skips the creation of a vm if it already exists, which means opts is not guaranteed except VMName
-func (p *DefaultProvider) createVirtualMachine(ctx context.Context, opts *createVMOptions) (*armcompute.VirtualMachine, error) {
+func (p *DefaultProvider) createVirtualMachine(ctx context.Context, opts *createVMOptions) (*createResult, error) {
 	// We assume that if a vm exists, we successfully created it with the right parameters from the nodeclaims during another run before a restart.
 	// there are some non-deterministic properties that may change.
 	// Zones: zones are non-detrminsitic as we do a random pick out of zones on the nodeclaim that satisfy the workload requirements.
@@ -490,7 +504,7 @@ func (p *DefaultProvider) createVirtualMachine(ctx context.Context, opts *create
 	resp, err := p.azClient.virtualMachinesClient.Get(ctx, p.resourceGroup, opts.VMName, nil)
 	// If status == ok, we want to return the existing vmm
 	if err == nil {
-		return &resp.VirtualMachine, nil
+		return &createResult{VM: &resp.VirtualMachine}, nil
 	}
 	// if status != ok, and for a reason other than we did not find the vm
 	azErr := sdkerrors.IsResponseError(err)
@@ -500,21 +514,23 @@ func (p *DefaultProvider) createVirtualMachine(ctx context.Context, opts *create
 	vm := newVMObject(opts)
 	log.FromContext(ctx).V(1).Info(fmt.Sprintf("Creating virtual machine %s (%s)", opts.VMName, opts.InstanceType.Name))
 
-	result, err := CreateVirtualMachine(ctx, p.azClient.virtualMachinesClient, p.resourceGroup, opts.VMName, vm)
+	poller, err := p.azClient.virtualMachinesClient.BeginCreateOrUpdate(ctx, p.resourceGroup, opts.VMName, *vm, nil)
 	if err != nil {
+		log.FromContext(ctx).Error(err, fmt.Sprintf("Creating virtual machine %q failed", opts.VMName))
 		return nil, fmt.Errorf("virtualMachine.BeginCreateOrUpdate for VM %q failed: %w", opts.VMName, err)
 	}
-
-	log.FromContext(ctx).V(1).Info(fmt.Sprintf("Created virtual machine %s", *result.ID))
-	return result, nil
+	return &createResult{Poller: poller, VM: vm}, nil
 }
 
-func (p *DefaultProvider) launchInstance(
+// beginLaunchInstance starts the launch of a VM instance.
+// The returned VirtualMachinePromise must be called to gather any errors
+// that are retrieved during async provisioning, as well as to complete the provisioning process.
+func (p *DefaultProvider) beginLaunchInstance(
 	ctx context.Context,
 	nodeClass *v1alpha2.AKSNodeClass,
 	nodeClaim *karpv1.NodeClaim,
 	instanceTypes []*corecloudprovider.InstanceType,
-) (*armcompute.VirtualMachine, error) {
+) (*VirtualMachinePromise, error) {
 	instanceType, capacityType, zone := p.pickSkuSizePriorityAndZone(ctx, nodeClaim, instanceTypes)
 	if instanceType == nil {
 		return nil, corecloudprovider.NewInsufficientCapacityError(fmt.Errorf("no instance types available"))
@@ -536,6 +552,10 @@ func (p *DefaultProvider) launchInstance(
 	}
 	networkPlugin := options.FromContext(ctx).NetworkPlugin
 	networkPluginMode := options.FromContext(ctx).NetworkPluginMode
+	// TODO: Not returning after launching this LRO because
+	// TODO: doing so would bypass the capacity and other errors that are currently handled by
+	// TODO: core pkg/controllers/nodeclaim/lifecycle/controller.go - in particular, there are metrics/events
+	// TODO: emitted in capacity failure cases that we probably want.
 	nicReference, err := p.createNetworkInterface(
 		ctx,
 		&createNICOptions{
@@ -552,7 +572,7 @@ func (p *DefaultProvider) launchInstance(
 		return nil, err
 	}
 
-	vm, err := p.createVirtualMachine(ctx, &createVMOptions{
+	result, err := p.createVirtualMachine(ctx, &createVMOptions{
 		VMName:         resourceName,
 		NicReference:   nicReference,
 		Zone:           zone,
@@ -571,19 +591,44 @@ func (p *DefaultProvider) launchInstance(
 		return nil, azErr
 	}
 
-	if p.provisionMode == consts.ProvisionModeBootstrappingClient {
-		err = p.createCSExtension(ctx, resourceName, launchTemplate.CustomScriptsCSE, launchTemplate.IsWindows)
-		if err != nil {
-			// This should fall back to cleanupAzureResources
-			return nil, err
-		}
-	}
+	// Patch the VM object to fill out a few fields that are needed later.
+	// This is a bit of a hack that saves us doing a GET now.
+	// The reason to avoid a GET is that it can fail, and if it does the future above will be lost,
+	// which we don't want.
+	result.VM.ID = lo.ToPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s", p.subscriptionID, p.resourceGroup, resourceName))
+	result.VM.Properties.TimeCreated = lo.ToPtr(time.Now())
 
-	err = p.createAKSIdentifyingExtension(ctx, resourceName)
-	if err != nil {
-		return nil, err
-	}
-	return vm, nil
+	return &VirtualMachinePromise{
+		Wait: func() error {
+			if result.Poller == nil {
+				// Poller is nil means the VM existed already and we're done
+				return nil
+			}
+
+			_, err = result.Poller.PollUntilDone(ctx, nil)
+			if err != nil {
+				azErr := p.handleResponseErrors(ctx, instanceType, zone, capacityType, err)
+				return azErr
+			}
+
+			if p.provisionMode == consts.ProvisionModeBootstrappingClient {
+				err = p.createCSExtension(ctx, resourceName, launchTemplate.CustomScriptsCSE, launchTemplate.IsWindows)
+				if err != nil {
+					// This should fall back to cleanupAzureResources
+					// TODO: Confirm this
+					return err
+				}
+			}
+
+			err = p.createAKSIdentifyingExtension(ctx, resourceName)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		VM: result.VM,
+	}, nil
 }
 
 // nolint:gocyclo
@@ -729,7 +774,7 @@ func (p *DefaultProvider) pickSkuSizePriorityAndZone(
 	return nil, "", ""
 }
 
-func (p *DefaultProvider) cleanupAzureResources(ctx context.Context, resourceName string) (err error) {
+func (p *DefaultProvider) cleanupAzureResources(ctx context.Context, resourceName string) error {
 	vmErr := deleteVirtualMachineIfExists(ctx, p.azClient.virtualMachinesClient, p.resourceGroup, resourceName)
 	if vmErr != nil {
 		log.FromContext(ctx).Error(vmErr, fmt.Sprintf("virtualMachine.Delete for %s failed", resourceName))

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -29,6 +29,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clock "k8s.io/utils/clock/testing"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
 	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
@@ -37,7 +39,6 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
 	. "github.com/Azure/karpenter-provider-azure/pkg/test/expectations"
-	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
@@ -156,7 +157,7 @@ var _ = Describe("InstanceProvider", func() {
 			instanceTypes = lo.Filter(instanceTypes, func(i *corecloudprovider.InstanceType, _ int) bool { return i.Name == "Standard_D2_v2" })
 
 			// Since all the offerings are unavailable, this should return back an ICE error
-			instance, err := azEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, instanceTypes)
+			instance, err := azEnv.InstanceProvider.BeginCreate(ctx, nodeClass, nodeClaim, instanceTypes)
 			Expect(corecloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
 			Expect(instance).To(BeNil())
 		},

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -34,13 +34,16 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/karpenter/pkg/metrics"
 	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
@@ -52,11 +55,13 @@ import (
 
 	sdkerrors "github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/bootstrap"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
+
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
 	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
@@ -211,7 +216,7 @@ var _ = Describe("InstanceType Provider", func() {
 			ErrMsg := "test error"
 			ErrCode := fmt.Sprint(http.StatusNotFound)
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-			azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.Error.Set(
+			azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(
 				&azcore.ResponseError{
 					ErrorCode: ErrCode,
 					RawResponse: &http.Response{
@@ -247,7 +252,7 @@ var _ = Describe("InstanceType Provider", func() {
 				}})
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			// Set the LowPriorityCoresQuota error to be returned when creating the vm
-			azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.Error.Set(
+			azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(
 				&azcore.ResponseError{
 					ErrorCode: sdkerrors.OperationNotAllowed,
 					RawResponse: &http.Response{
@@ -273,7 +278,7 @@ var _ = Describe("InstanceType Provider", func() {
 		It("should fail to provision when VM SKU family vCPU quota exceeded error is returned, and succeed when it is gone", func() {
 			familyVCPUQuotaExceededErrorMessage := "Operation could not be completed as it results in exceeding approved standardDLSv5Family Cores quota. Additional details - Deployment Model: Resource Manager, Location: westus2, Current Limit: 100, Current Usage: 96, Additional Required: 32, (Minimum) New Limit Required: 128. Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%(redacted)%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22westus2%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22standardDLSv5Family%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:128,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22standardDLSv5Family%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests"
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-			azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.Error.Set(
+			azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(
 				&azcore.ResponseError{
 					ErrorCode: sdkerrors.OperationNotAllowed,
 					RawResponse: &http.Response{
@@ -301,7 +306,7 @@ var _ = Describe("InstanceType Provider", func() {
 		It("should fail to provision when VM SKU family vCPU quota limit is zero, and succeed when its gone", func() {
 			familyVCPUQuotaIsZeroErrorMessage := "Operation could not be completed as it results in exceeding approved standardDLSv5Family Cores quota. Additional details - Deployment Model: Resource Manager, Location: westus2, Current Limit: 0, Current Usage: 0, Additional Required: 32, (Minimum) New Limit Required: 32. Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%(redacted)%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22westus2%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22standardDLSv5Family%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:128,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22standardDLSv5Family%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests"
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-			azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.Error.Set(
+			azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(
 				&azcore.ResponseError{
 					ErrorCode: sdkerrors.OperationNotAllowed,
 					RawResponse: &http.Response{
@@ -328,7 +333,7 @@ var _ = Describe("InstanceType Provider", func() {
 
 		It("should return ICE if Total Regional Cores Quota errors are hit", func() {
 			regionalVCPUQuotaExceededErrorMessage := "Operation could not be completed as it results in exceeding approved Total Regional Cores quota. Additional details - Deployment Model: Resource Manager, Location: uksouth, Current Limit: 100, Current Usage: 100, Additional Required: 64, (Minimum) New Limit Required: 164. Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%(redacted)%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22uksouth%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22cores%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:164,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22cores%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/regional-quota-requests"
-			azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.Error.Set(
+			azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(
 				&azcore.ResponseError{
 					ErrorCode: sdkerrors.OperationNotAllowed,
 					RawResponse: &http.Response{
@@ -638,8 +643,10 @@ var _ = Describe("InstanceType Provider", func() {
 
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			pod := coretest.UnschedulablePod()
-			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
+			ExpectLaunched(ctx, env.Client, cloudProvider, coreProvisioner, pod)
 			ExpectNotScheduled(ctx, env.Client, pod)
+
+			Eventually(func() []*karpv1.NodeClaim { return ExpectNodeClaims(ctx, env.Client) }).To(HaveLen(0))
 
 			By("marking whatever zone was picked as unavailable - for both spot and on-demand")
 			zone, err := utils.GetZone(&azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Pop().VM)
@@ -690,8 +697,8 @@ var _ = Describe("InstanceType Provider", func() {
 			pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
 				{
 					Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
-						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{fakeZone1}},
-					}},
+					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{fakeZone1}},
+				}},
 				},
 			}}}
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
@@ -757,7 +764,7 @@ var _ = Describe("InstanceType Provider", func() {
 		Context("SkuNotAvailable", func() {
 			AssertUnavailable := func(sku string, capacityType string) {
 				// fake a SKU not available error
-				azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.Error.Set(
+				azureEnv.VirtualMachinesAPI.VirtualMachinesBehavior.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(
 					&azcore.ResponseError{ErrorCode: sdkerrors.SKUNotAvailableErrorCode},
 				)
 				coretest.ReplaceRequirements(nodePool,
@@ -1501,5 +1508,25 @@ func ExpectCapacityPodsToMatchMaxPods(instanceTypes []*corecloudprovider.Instanc
 		podsCount, ok := pods.AsInt64()
 		Expect(ok).To(BeTrue(), "failed to convert pods capacity to int64")
 		Expect(podsCount).To(Equal(expected), "pods capacity does not match expected value")
+	}
+}
+
+// TODO: Upstream this?
+func ExpectLaunched(ctx context.Context, c client.Client, cloudProvider corecloudprovider.CloudProvider, provisioner *provisioning.Provisioner, pods ...*v1.Pod) {
+	GinkgoHelper()
+	// Persist objects
+	for _, pod := range pods {
+		ExpectApplied(ctx, c, pod)
+	}
+	results, err := provisioner.Schedule(ctx)
+	Expect(err).ToNot(HaveOccurred())
+	for _, m := range results.NewNodeClaims {
+		var nodeClaimName string
+		nodeClaimName, err = provisioner.Create(ctx, m, provisioning.WithReason(metrics.ProvisionedReason))
+		Expect(err).ToNot(HaveOccurred())
+		nodeClaim := &karpv1.NodeClaim{}
+		Expect(c.Get(ctx, types.NamespacedName{Name: nodeClaimName}, nodeClaim)).To(Succeed())
+		_, err = ExpectNodeClaimDeployedNoNode(ctx, c, cloudProvider, nodeClaim)
+		Expect(err).ToNot(HaveOccurred())
 	}
 }

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -694,13 +694,22 @@ var _ = Describe("InstanceType Provider", func() {
 			pod := coretest.UnschedulablePod(coretest.PodOptions{
 				NodeSelector: map[string]string{v1.LabelInstanceTypeStable: "Standard_D2_v2"},
 			})
-			pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
-				{
-					Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
-					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{fakeZone1}},
-				}},
+			pod.Spec.Affinity = &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+						{
+							Weight: 1,
+							Preference: v1.NodeSelectorTerm{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{fakeZone1},
+									},
+								},
+							},
+						},
+					},
 				},
-			}}}
+			}
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels[v1alpha2.AlternativeLabelTopologyZone]).ToNot(Equal(fakeZone1))


### PR DESCRIPTION
 * NIC creation is still blocking, but that may change in the future if we roll NIC creation into VM creation.
 * instance provider now returns a VMFuture, which CloudProvider polls in a separate goroutine. If an error is encountered, the NodeClaim is deleted and the pending pods will trigger another NodeClaim to be created.

This improves disruption speed significantly, but there is still slowness in disruption (caused by core as far as I can tell).

Fixes #600

**How was this change tested?**

* Unit tests
* E2E tests (pass 1): https://github.com/Azure/karpenter-provider-azure/actions/runs/14605092382 - this had some flakes but I re-ran them locally and they passed.
* E2E tests (pass 2): https://github.com/Azure/karpenter-provider-azure/actions/runs/14673602666 - running a second pass because there were a few changes from pass 1 and want to make sure things are OK.
* E2E tests (pass 3): after rebase, passed: https://github.com/Azure/karpenter-provider-azure/actions/runs/14740596543

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Updated provider node create to be non-blocking, which significantly increases the throughput of disruption. Disruption is now more likely to actually utilize the full disruption budget.
```
