### PR TITLE
fix: drop support for accelerator and gpu-name labels

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
@@ -138,7 +138,7 @@ spec:
                           - message: label "kubernetes.io/hostname" is restricted
                             rule: self != "kubernetes.io/hostname"
                           - message: label domain "karpenter.azure.com" is restricted
-                            rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-accelerator", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-encryptionathost-capable", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                            rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-encryptionathost-capable", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
                       minValues:
                         description: |-
                           This field is ALPHA and can be dropped or replaced at any time

--- a/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -207,7 +207,7 @@ spec:
                             - message: label "kubernetes.io/hostname" is restricted
                               rule: self.all(x, x != "kubernetes.io/hostname")
                             - message: label domain "karpenter.azure.com" is restricted
-                              rule: self.all(x, x in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-accelerator", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-encryptionathost-capable", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !x.find("^([^/]+)").endsWith("karpenter.azure.com"))
+                              rule: self.all(x, x in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-encryptionathost-capable", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !x.find("^([^/]+)").endsWith("karpenter.azure.com"))
                       type: object
                     spec:
                       description: |-
@@ -280,7 +280,7 @@ spec:
                                   - message: label "kubernetes.io/hostname" is restricted
                                     rule: self != "kubernetes.io/hostname"
                                   - message: label domain "karpenter.azure.com" is restricted
-                                    rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-accelerator", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-encryptionathost-capable", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                                    rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-encryptionathost-capable", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
                               minValues:
                                 description: |-
                                   This field is ALPHA and can be dropped or replaced at any time

--- a/designs/gpu-selection-and-bootstrap.md
+++ b/designs/gpu-selection-and-bootstrap.md
@@ -1,5 +1,5 @@
 # Overview
-This document outlines all of the functional requirements for the preview AKS API for karpenter GPU Support. 
+This document outlines all of the functional requirements for the preview AKS API for karpenter GPU Support.
 
 ## GPU Provisioning Requirements for Preview
 
@@ -40,7 +40,7 @@ spec:
   limits:
     resources:
       cpu: 100
-      nvidia.com/gpu: 2 
+      nvidia.com/gpu: 2
 ```
 **Workload Example**
 ```
@@ -74,28 +74,28 @@ The way we determine these drivers is via trial and error, and there is not a gr
 For Converged drivers they are a mix of multiple drivers installing vanilla cuda drivers will fail to install with opaque errors.
 nvidia-bug-report.sh may be helpful, but usually it tells you the pci card id is incompatible.
 
-So manual trial and error, or leveraging other peoples manual trial and error, and published gpu drivers seems to be the preferred method for approaching this. 
+So manual trial and error, or leveraging other peoples manual trial and error, and published gpu drivers seems to be the preferred method for approaching this.
 see https://github.com/Azure/azhpc-extensions/blob/daaefd78df6f27012caf30f3b54c3bd6dc437652/NvidiaGPU/resources.json for the HPC list of skus and converged drivers, and the driver matrix used by HPC
 
-**Ownership:** Node SIG is responsible for ensuring successful and functional installation. Our goal is to share a bootstrap contract, and the oblication of a functional successfully bootstrapped vhd relies on the node sig. 
+**Ownership:** Node SIG is responsible for ensuring successful and functional installation. Our goal is to share a bootstrap contract, and the oblication of a functional successfully bootstrapped vhd relies on the node sig.
 Sharing between agentbaker and karpenter is an additional goal, as to which drivers are supported, and for which skus. As well as extending skewer for better GPU Support is also a goal.
 
-#### 4a. GPU Driver installation 
-The bootstrap parameter `DRIVER_VERSION` will select the driver version and `ConfigGPUDriverIfNeeded` serves the purpose of telling the VHD to install all gpu helpers such as nvidia-smi etc. 
-### 5. containerd configuration 
+#### 4a. GPU Driver installation
+The bootstrap parameter `DRIVER_VERSION` will select the driver version and `ConfigGPUDriverIfNeeded` serves the purpose of telling the VHD to install all gpu helpers such as nvidia-smi etc.
+### 5. containerd configuration
 GPU's also use a different container runtime, so we need to be able to dynamically modify the containerd configuration we pass into karpenter's bootstrapping contract to include the proper configuration of the gpu settings
 
 [plugins."io.containerd.grpc.v1.cri".containerd]
 Needs to be able to alternate between normal containerd configuration of "io.containerd.runc" and "nvidia-container-runtime" in order to properly connect with device plugin and add the capacity for "nvidia.com/gpu" to our nodes to allow for scheduling of GPU Nodes.
 
-**Note** We also need to ensure that containerd, and kubelet are using the same cgroup driver. So when leveraging cgroupsv2, we need to make sure we are setting the kubelet flag, we need to update the containerd con 
+**Note** We also need to ensure that containerd, and kubelet are using the same cgroup driver. So when leveraging cgroupsv2, we need to make sure we are setting the kubelet flag, we need to update the containerd con
 
 ### 6. Nvidia Device Plugin
 The NVIDIA device plugin for Kubernetes is designed to enable GPU support within Kubernetes clusters. Kubernetes, by default, doesn’t recognize GPUs as a native resource. However, using device plugins, one can extend Kubernetes to manage other types of hardware resources, such as GPUs from NVIDIA.
 
 We will require the customer to install the nvidia device plugin daemonset to enable GPU support through karpenter.
 
-When a node with Nvidia GPUS joins the cluster, the device plugin detects available gpus and notifies the k8s scheduler that we have a new Allocatable Resource type of `nvidia.com/gpu` along with a resource quantity that can be considered for scheduling. 
+When a node with Nvidia GPUS joins the cluster, the device plugin detects available gpus and notifies the k8s scheduler that we have a new Allocatable Resource type of `nvidia.com/gpu` along with a resource quantity that can be considered for scheduling.
 
 Note the device plugin is also responsible for the allocation of that resource and reporting that other pods can not use that resource and marking it as used by changing the allocatable capacity on the node.
 
@@ -111,7 +111,6 @@ Here are some relevant labels:
 |---------------------------------------|-------------------------------------------|
 | `karpenter.azure.com/sku-family`       | Family of the SKU (N) for GPU          |
 | `karpenter.azure.com/sku-cpu`          | Number of virtual CPUs                    |
-| `karpenter.azure.com/sku-accelerator`  | Type of accelerator (e.g., Nvidia)        |
 
 **Note:** GPU SKUs usually support only a single hypervisor generation. Explicit image selection is moot in most cases, though there are some exceptions.
 
@@ -193,4 +192,3 @@ This table will outline for each SKU, the supported OS and the driver we commit 
 | standard_nv72ads_a10_v5 | Ubuntu       | Nvidia535GridDriver   |
 | standard_nd96ams_v4     | Ubuntu       | Nvidia525CudaDriver   |
 | standard_nd96ams_a100_v4| Ubuntu       | Nvidia525CudaDriver   |
-

--- a/hack/validation/labels.sh
+++ b/hack/validation/labels.sh
@@ -12,12 +12,10 @@ rule=$'self.all(x, x in
         "karpenter.azure.com/sku-version",
         "karpenter.azure.com/sku-cpu",
         "karpenter.azure.com/sku-memory",
-        "karpenter.azure.com/sku-accelerator",
         "karpenter.azure.com/sku-networking-accelerated",
         "karpenter.azure.com/sku-storage-premium-capable",
         "karpenter.azure.com/sku-storage-ephemeralos-maxsize",
         "karpenter.azure.com/sku-encryptionathost-capable",
-        "karpenter.azure.com/sku-gpu-name",
         "karpenter.azure.com/sku-gpu-manufacturer",
         "karpenter.azure.com/sku-gpu-count"
     ]

--- a/hack/validation/requirements.sh
+++ b/hack/validation/requirements.sh
@@ -12,12 +12,10 @@ rule=$'self in
         "karpenter.azure.com/sku-version",
         "karpenter.azure.com/sku-cpu",
         "karpenter.azure.com/sku-memory",
-        "karpenter.azure.com/sku-accelerator",
         "karpenter.azure.com/sku-networking-accelerated",
         "karpenter.azure.com/sku-storage-premium-capable",
         "karpenter.azure.com/sku-storage-ephemeralos-maxsize",
         "karpenter.azure.com/sku-encryptionathost-capable",
-        "karpenter.azure.com/sku-gpu-name",
         "karpenter.azure.com/sku-gpu-manufacturer",
         "karpenter.azure.com/sku-gpu-count"
     ]

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -138,7 +138,7 @@ spec:
                           - message: label "kubernetes.io/hostname" is restricted
                             rule: self != "kubernetes.io/hostname"
                           - message: label domain "karpenter.azure.com" is restricted
-                            rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-accelerator", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-encryptionathost-capable", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                            rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-encryptionathost-capable", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
                       minValues:
                         description: |-
                           This field is ALPHA and can be dropped or replaced at any time

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -207,7 +207,7 @@ spec:
                             - message: label "kubernetes.io/hostname" is restricted
                               rule: self.all(x, x != "kubernetes.io/hostname")
                             - message: label domain "karpenter.azure.com" is restricted
-                              rule: self.all(x, x in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-accelerator", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-encryptionathost-capable", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !x.find("^([^/]+)").endsWith("karpenter.azure.com"))
+                              rule: self.all(x, x in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-encryptionathost-capable", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !x.find("^([^/]+)").endsWith("karpenter.azure.com"))
                       type: object
                     spec:
                       description: |-
@@ -280,7 +280,7 @@ spec:
                                   - message: label "kubernetes.io/hostname" is restricted
                                     rule: self != "kubernetes.io/hostname"
                                   - message: label domain "karpenter.azure.com" is restricted
-                                    rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-accelerator", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-encryptionathost-capable", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                                    rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-encryptionathost-capable", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
                               minValues:
                                 description: |-
                                   This field is ALPHA and can be dropped or replaced at any time

--- a/pkg/apis/v1alpha2/labels.go
+++ b/pkg/apis/v1alpha2/labels.go
@@ -33,7 +33,6 @@ func init() {
 
 		LabelSKUCPU,
 		LabelSKUMemory,
-		LabelSKUAccelerator,
 
 		LabelSKUAcceleratedNetworking,
 
@@ -42,7 +41,6 @@ func init() {
 
 		LabelSKUEncryptionAtHostSupported,
 
-		LabelSKUGPUName,
 		LabelSKUGPUManufacturer,
 		LabelSKUGPUCount,
 
@@ -80,9 +78,8 @@ var (
 	LabelSKUFamily  = Group + "/sku-family"  // A
 	LabelSKUVersion = Group + "/sku-version" // numerical (without v), with 1 backfilled
 
-	LabelSKUCPU         = Group + "/sku-cpu"    // sku.vCPUs
-	LabelSKUMemory      = Group + "/sku-memory" // sku.MemoryGB
-	LabelSKUAccelerator = Group + "/sku-accelerator"
+	LabelSKUCPU    = Group + "/sku-cpu"    // sku.vCPUs
+	LabelSKUMemory = Group + "/sku-memory" // sku.MemoryGB
 
 	// selected capabilities (from additive features in VM size name, or from SKU capabilities)
 	LabelSKUAcceleratedNetworking = Group + "/sku-networking-accelerated" // sku.AcceleratedNetworkingEnabled
@@ -93,7 +90,6 @@ var (
 	LabelSKUEncryptionAtHostSupported = Group + "/sku-encryptionathost-capable" // sku.EncryptionAtHostSupported
 
 	// GPU labels
-	LabelSKUGPUName         = Group + "/sku-gpu-name"         // ie GPU Accelerator type we parse from vmSize
 	LabelSKUGPUManufacturer = Group + "/sku-gpu-manufacturer" // ie NVIDIA, AMD, etc
 	LabelSKUGPUCount        = Group + "/sku-gpu-count"        // ie 16, 32, etc
 

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -155,14 +155,12 @@ func computeRequirements(sku *skewer.SKU, vmsize *skewer.VMSizeType, architectur
 		scheduling.NewRequirement(v1alpha2.LabelSKUMemory, corev1.NodeSelectorOpIn, fmt.Sprint((memoryMiB(sku)))), // in MiB
 		scheduling.NewRequirement(v1alpha2.LabelSKUGPUCount, corev1.NodeSelectorOpIn, fmt.Sprint(gpuNvidiaCount(sku).Value())),
 		scheduling.NewRequirement(v1alpha2.LabelSKUGPUManufacturer, corev1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha2.LabelSKUGPUName, corev1.NodeSelectorOpDoesNotExist),
 
 		// composites
 		scheduling.NewRequirement(v1alpha2.LabelSKUName, corev1.NodeSelectorOpDoesNotExist),
 
 		// size parts
 		scheduling.NewRequirement(v1alpha2.LabelSKUFamily, corev1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha2.LabelSKUAccelerator, corev1.NodeSelectorOpDoesNotExist),
 		scheduling.NewRequirement(v1alpha2.LabelSKUVersion, corev1.NodeSelectorOpDoesNotExist),
 
 		// SKU capabilities
@@ -185,8 +183,7 @@ func computeRequirements(sku *skewer.SKU, vmsize *skewer.VMSizeType, architectur
 	setRequirementsEphemeralOSDiskSupported(requirements, sku, vmsize)
 	setRequirementsAcceleratedNetworking(requirements, sku)
 	setRequirementsHyperVGeneration(requirements, sku)
-	setRequirementsGPU(requirements, sku, vmsize)
-	setRequirementsAccelerator(requirements, vmsize)
+	setRequirementsGPU(requirements, sku)
 	setRequirementsVersion(requirements, vmsize)
 
 	return requirements
@@ -225,18 +222,9 @@ func setRequirementsHyperVGeneration(requirements scheduling.Requirements, sku *
 	}
 }
 
-func setRequirementsGPU(requirements scheduling.Requirements, sku *skewer.SKU, vmsize *skewer.VMSizeType) {
+func setRequirementsGPU(requirements scheduling.Requirements, sku *skewer.SKU) {
 	if utils.IsNvidiaEnabledSKU(sku.GetName()) {
 		requirements[v1alpha2.LabelSKUGPUManufacturer].Insert(v1alpha2.ManufacturerNvidia)
-		if vmsize.AcceleratorType != nil {
-			requirements[v1alpha2.LabelSKUGPUName].Insert(*vmsize.AcceleratorType)
-		}
-	}
-}
-
-func setRequirementsAccelerator(requirements scheduling.Requirements, vmsize *skewer.VMSizeType) {
-	if vmsize.AcceleratorType != nil {
-		requirements[v1alpha2.LabelSKUAccelerator].Insert(*vmsize.AcceleratorType)
 	}
 }
 

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -884,12 +884,10 @@ var _ = Describe("InstanceType Provider", func() {
 				v1alpha2.LabelSKUAcceleratedNetworking:     "true",
 				v1alpha2.LabelSKUEncryptionAtHostSupported: "true",
 				v1alpha2.LabelSKUStoragePremiumCapable:     "true",
-				v1alpha2.LabelSKUGPUName:                   "A100",
 				v1alpha2.LabelSKUGPUManufacturer:           "nvidia",
 				v1alpha2.LabelSKUGPUCount:                  "1",
 				v1alpha2.LabelSKUCPU:                       "24",
 				v1alpha2.LabelSKUMemory:                    "8192",
-				v1alpha2.LabelSKUAccelerator:               "A100",
 				// Deprecated Labels
 				v1.LabelFailureDomainBetaRegion:    fake.Region,
 				v1.LabelFailureDomainBetaZone:      fakeZone1,
@@ -935,8 +933,6 @@ var _ = Describe("InstanceType Provider", func() {
 
 			Expect(normalNode.Requirements.Get(v1alpha2.LabelSKUHyperVGeneration).Values()).To(ConsistOf(v1alpha2.HyperVGenerationV1))
 			Expect(gpuNode.Requirements.Get(v1alpha2.LabelSKUHyperVGeneration).Values()).To(ConsistOf(v1alpha2.HyperVGenerationV2))
-
-			Expect(gpuNode.Requirements.Get(v1alpha2.LabelSKUAccelerator).Values()).To(ConsistOf("A100"))
 
 			Expect(normalNode.Requirements.Get(v1alpha2.LabelSKUVersion).Values()).To(ConsistOf("2"))
 			Expect(gpuNode.Requirements.Get(v1alpha2.LabelSKUVersion).Values()).To(ConsistOf("4"))
@@ -1222,7 +1218,6 @@ var _ = Describe("InstanceType Provider", func() {
 
 			// Verify that the node the pod was scheduled on has GPU resource and labels set
 			Expect(node.Status.Allocatable).To(HaveKeyWithValue(v1.ResourceName("nvidia.com/gpu"), resource.MustParse("1")))
-			Expect(node.Labels).To(HaveKeyWithValue("karpenter.azure.com/sku-gpu-name", "T4"))
 			Expect(node.Labels).To(HaveKeyWithValue("karpenter.azure.com/sku-gpu-manufacturer", v1alpha2.ManufacturerNvidia))
 			Expect(node.Labels).To(HaveKeyWithValue("karpenter.azure.com/sku-gpu-count", "1"))
 		})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Remove support for `sku-accelerator` and `sku-gpu-name`. For one thing, they are redundant, set from the same source. For another, that source is parsed VM SKU name, which is not reliable. If we decide we have to support something like sku-gpu-name, we will have to find (or engineer) another source for this info.

This would be a breaking change.

**How was this change tested?**

* `make presubmit`
* E2E: pending

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
