### PR TITLE
fix: Support custom DNS service IP in kubelet config

### DIFF
--- a/hack/deploy/configure-values.sh
+++ b/hack/deploy/configure-values.sh
@@ -63,13 +63,15 @@ NETWORK_PLUGIN=$(jq -r ".networkProfile.networkPlugin // empty | if . == \"none\
 NETWORK_PLUGIN_MODE=$(jq -r ".networkProfile.networkPluginMode // empty | if . == \"none\" then \"\" else . end" <<< "$AKS_JSON")
 NETWORK_POLICY=$(jq -r ".networkProfile.networkPolicy // empty | if . == \"none\" then \"\" else . end" <<< "$AKS_JSON")
 
+DNS_SERVICE_IP=$(jq -r ".networkProfile.dnsServiceIp // empty | if . == \"none\" then \"\" else . end" <<< "$AKS_JSON")
+
 NODE_IDENTITIES=$(jq -r ".identityProfile.kubeletidentity.resourceId" <<< "$AKS_JSON")
 
 KARPENTER_USER_ASSIGNED_CLIENT_ID=$(az identity show --resource-group "${AZURE_RESOURCE_GROUP}" --name "${AZURE_KARPENTER_USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -otsv)
 
 export CLUSTER_NAME AZURE_LOCATION AZURE_RESOURCE_GROUP_MC KARPENTER_SERVICE_ACCOUNT_NAME \
     CLUSTER_ENDPOINT BOOTSTRAP_TOKEN SSH_PUBLIC_KEY VNET_SUBNET_ID KARPENTER_USER_ASSIGNED_CLIENT_ID NODE_IDENTITIES AZURE_SUBSCRIPTION_ID NETWORK_PLUGIN NETWORK_PLUGIN_MODE NETWORK_POLICY \
-    LOG_LEVEL VNET_GUID
+    DNS_SERVICE_IP LOG_LEVEL VNET_GUID
 
 # get karpenter-values-template.yaml, if not already present (e.g. outside of repo context)
 if [ ! -f karpenter-values-template.yaml ]; then

--- a/karpenter-values-template.yaml
+++ b/karpenter-values-template.yaml
@@ -29,6 +29,8 @@ controller:
       value: ${VNET_GUID}
     - name: NODE_IDENTITIES
       value: ${NODE_IDENTITIES}
+    - name: DNS_SERVICE_IP
+      value: ${DNS_SERVICE_IP}
 
     # Azure client settings
     - name: ARM_SUBSCRIPTION_ID

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -71,6 +71,7 @@ type Options struct {
 	NetworkPolicy     string // => NetworkPolicy in bootstrap
 	NetworkPluginMode string // => Network Plugin Mode is used to control the mode the network plugin should operate in. For example, "overlay" used with --network-plugin=azure will use an overlay network (non-VNET IPs) for pods in the cluster. Learn more about overlay networking here: https://learn.microsoft.com/en-us/azure/aks/azure-cni-overlay?tabs=kubectl#overview-of-overlay-networking
 	NetworkDataplane  string
+	DNSServiceIP      string
 
 	NodeIdentities []string // => Applied onto each VM
 	VnetGUID       string   // resource guid used by azure cni for identifying the right vnet
@@ -92,6 +93,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.KubeletClientTLSBootstrapToken, "kubelet-bootstrap-token", env.WithDefaultString("KUBELET_BOOTSTRAP_TOKEN", ""), "[REQUIRED] The bootstrap token for new nodes to join the cluster.")
 	fs.StringVar(&o.SSHPublicKey, "ssh-public-key", env.WithDefaultString("SSH_PUBLIC_KEY", ""), "[REQUIRED] VM SSH public key.")
 	fs.StringVar(&o.NetworkPlugin, "network-plugin", env.WithDefaultString("NETWORK_PLUGIN", consts.NetworkPluginAzure), "The network plugin used by the cluster.")
+	fs.StringVar(&o.DNSServiceIP, "dns-service-ip", env.WithDefaultString("DNS_SERVICE_IP", "10.0.0.10"), "The IP address of cluster DNS service.")
 	fs.StringVar(&o.NetworkPluginMode, "network-plugin-mode", env.WithDefaultString("NETWORK_PLUGIN_MODE", consts.NetworkPluginModeOverlay), "network plugin mode of the cluster.")
 	fs.StringVar(&o.NetworkPolicy, "network-policy", env.WithDefaultString("NETWORK_POLICY", ""), "The network policy used by the cluster.")
 	fs.StringVar(&o.NetworkDataplane, "network-dataplane", env.WithDefaultString("NETWORK_DATAPLANE", "cilium"), "The network dataplane used by the cluster.")

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -96,6 +96,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("NETWORK_PLUGIN", "none") // Testing with none to make sure the default isn't overriding or something like that with "azure"
 			os.Setenv("NETWORK_PLUGIN_MODE", "")
 			os.Setenv("NETWORK_POLICY", "env-network-policy")
+			os.Setenv("DNS_SERVICE_IP", "10.244.0.1")
 			os.Setenv("NODE_IDENTITIES", "/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/envid1,/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/envid2")
 			os.Setenv("VNET_SUBNET_ID", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub")
 			os.Setenv("PROVISION_MODE", "bootstrappingclient")
@@ -121,6 +122,7 @@ var _ = Describe("Options", func() {
 				ProvisionMode:                  lo.ToPtr("bootstrappingclient"),
 				NodeBootstrappingServerURL:     lo.ToPtr("https://nodebootstrapping-server-url"),
 				VnetGUID:                       lo.ToPtr("a519e60a-cac0-40b2-b883-084477fe6f5c"),
+				DNSServiceIP:                   lo.ToPtr("10.244.0.1"),
 			}))
 		})
 	})

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -420,6 +420,9 @@ func KubeletConfigToMap(kubeletConfig *KubeletConfiguration) map[string]string {
 	if kubeletConfig.CPUCFSQuota != nil {
 		args["--cpu-cfs-quota"] = fmt.Sprintf("%t", lo.FromPtr(kubeletConfig.CPUCFSQuota))
 	}
+	if kubeletConfig.DNSServiceIP != "" {
+		args["--cluster-dns"] = kubeletConfig.DNSServiceIP
+	}
 
 	return args
 }

--- a/pkg/providers/imagefamily/bootstrap/bootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/bootstrap.go
@@ -26,7 +26,8 @@ type KubeletConfiguration struct {
 	v1alpha2.KubeletConfiguration
 
 	// MaxPods is the maximum number of pods that can run on a worker node instance.
-	MaxPods int32
+	MaxPods      int32
+	DNSServiceIP string
 
 	SystemReserved map[string]string
 	// KubeReserved contains resources reserved for Kubernetes system components.

--- a/pkg/providers/imagefamily/resolver.go
+++ b/pkg/providers/imagefamily/resolver.go
@@ -153,6 +153,7 @@ func prepareKubeletConfiguration(ctx context.Context, instanceType *cloudprovide
 	}
 
 	kubeletConfig.MaxPods = utils.GetMaxPods(nodeClass, options.FromContext(ctx).NetworkPlugin, options.FromContext(ctx).NetworkPluginMode)
+	kubeletConfig.DNSServiceIP = options.FromContext(ctx).DNSServiceIP
 
 	// TODO: revisit computeResources implementation
 	kubeletConfig.KubeReserved = utils.StringMap(instanceType.Overhead.KubeReserved)

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -42,7 +42,8 @@ type OptionsFields struct {
 	ProvisionMode                  *string
 	NodeBootstrappingServerURL     *string
 	VnetGUID                       *string
-
+	DNSServiceIP                   *string
+	
 	// UseSIG Flags not required by the self hosted offering
 	UseSIG            *bool
 	SIGSubscriptionID *string


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #335

**Description**
This PR enables customisation of `--dns-service-ip` kubelet parameter with controller environment variable.

**How was this change tested?**
Ran make az-all, created an AKS with customised DNS service IP, and verified that name resolution works fine from worker nodes.

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
fix: Support custom DNS service IP in kubelet config
```
