### PR TITLE
test: making startup taints and annotations for cilium conditional on the cilium ds being present

### DIFF
--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -1035,3 +1035,19 @@ func (env *Environment) GetDaemonSetOverhead(np *karpv1.NodePool) corev1.Resourc
 		return p, true
 	})...)
 }
+
+func (env *Environment) IsCilium() bool {
+	GinkgoHelper()
+
+	dsList := &appsv1.DaemonSetList{}
+	Expect(env.Client.List(env.Context, dsList,
+		client.InNamespace("kube-system"),
+	)).To(Succeed())
+
+	for _, ds := range dsList.Items {
+		if strings.HasPrefix(ds.Name, "cilium") {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**Description**
When running our test suite against other cni configurations, it will fail. This change makes the configurations dynamic

**How was this change tested?**
- make az-all-cniv1 
- make az-e2etest

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
