### PR TITLE
feat: duration for node auto repair should match aks customer promise

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -329,12 +329,12 @@ func (c *CloudProvider) RepairPolicies() []cloudprovider.RepairPolicy {
 		{
 			ConditionType:      corev1.NodeReady,
 			ConditionStatus:    corev1.ConditionFalse,
-			TolerationDuration: 30 * time.Minute,
+			TolerationDuration: 10 * time.Minute,
 		},
 		{
 			ConditionType:      corev1.NodeReady,
 			ConditionStatus:    corev1.ConditionUnknown,
-			TolerationDuration: 30 * time.Minute,
+			TolerationDuration: 10 * time.Minute,
 		},
 	}
 }


### PR DESCRIPTION
**Description**
See: https://learn.microsoft.com/en-us/azure/aks/node-auto-repair#how-aks-checks-for-notready-nodes for that repair SLO.

**How was this change tested?**
It wasn't

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
