### PR TITLE
test: node auto repair doesn't remove our gpus

### DIFF
--- a/test/suites/gpu/suite_test.go
+++ b/test/suites/gpu/suite_test.go
@@ -55,11 +55,10 @@ var _ = Describe("GPU", func() {
 		func(nodeClass *v1alpha2.AKSNodeClass) {
 			// Enable NodeRepair feature gate if running in-cluster
 			if env.InClusterController {
-				// One scenario we want to test, is that our node-auto-repair isn't too aggressive.
-				// If a gpu vm joins the cluster at 3 minutes, and takes 10 minutes to get ready, we don't want
-				// to GC the vm for node auto repair.
-				// By enabling the controller, the below assertions that the gpu workload eventually gets scheduled
-				// and runs means we didnt remove the not-ready vm
+				// Have Node Repair enabled to validate it does not interfere with
+				// provisioning of GPU VMs, which can take longer to become Ready.
+				// The assertions on healthy workload and created node count
+				// already rule out node repair scenario.
 				env.ExpectSettingsOverridden(corev1.EnvVar{Name: "FEATURE_GATES", Value: "NodeRepair=True"})
 			}
 			nodePool := env.DefaultNodePool(nodeClass)

--- a/test/suites/gpu/suite_test.go
+++ b/test/suites/gpu/suite_test.go
@@ -51,7 +51,6 @@ var _ = AfterEach(func() { env.Cleanup() })
 var _ = AfterEach(func() { env.AfterEach() })
 
 var _ = Describe("GPU", func() {
-	// Table test for GPU provisioning
 	DescribeTable("should provision one GPU node and one GPU Pod",
 		func(nodeClass *v1alpha2.AKSNodeClass) {
 			// Enable NodeRepair feature gate if running in-cluster
@@ -63,10 +62,7 @@ var _ = Describe("GPU", func() {
 				// and runs means we didnt remove the not-ready vm
 				env.ExpectSettingsOverridden(corev1.EnvVar{Name: "FEATURE_GATES", Value: "NodeRepair=True"})
 			}
-
 			nodePool := env.DefaultNodePool(nodeClass)
-
-			// Relax SKU family selector to allow GPU SKUs
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 				NodeSelectorRequirement: corev1.NodeSelectorRequirement{
 					Key:      v1alpha2.LabelSKUFamily,
@@ -174,4 +170,3 @@ func createNVIDIADevicePluginDaemonSet() *appsv1.DaemonSet {
 		},
 	}
 }
-


### PR DESCRIPTION
**Description**
Validating that node auto repair is not deleting gpu nodes before they join the cluster and run workloads.
**How was this change tested?**
E2E Tests: https://github.com/Azure/karpenter-provider-azure/actions/runs/14809391794/job/41582237267

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
