### PR TITLE
test(e2e): fix drift suite

### DIFF
--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -96,9 +96,9 @@ var _ = Describe("Drift", func() {
 			nodePool = coretest.ReplaceRequirements(nodePool,
 				karpv1.NodeSelectorRequirementWithMinValues{
 					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
-						Key:      corev1.LabelInstanceTypeStable,
+						Key:      v1alpha2.LabelSKUCPU,
 						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{"Standard_DS4_v2"},
+						Values:   []string{"8"},
 					},
 				},
 			)
@@ -118,7 +118,7 @@ var _ = Describe("Drift", func() {
 						},
 						Labels: map[string]string{"app": "large-app"},
 					},
-					// Each Standard_DS4_v2 has 8 cpu, so each node should fit 2 pods.
+					// Each node has 8 cpus, so should fit 2 pods.
 					ResourceRequirements: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("3"),
@@ -160,9 +160,9 @@ var _ = Describe("Drift", func() {
 			nodePool = coretest.ReplaceRequirements(nodePool,
 				karpv1.NodeSelectorRequirementWithMinValues{
 					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
-						Key:      corev1.LabelInstanceTypeStable,
+						Key:      v1alpha2.LabelSKUCPU,
 						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{"Standard_DS4_v2"},
+						Values:   []string{"8"},
 					},
 				},
 			)
@@ -182,7 +182,7 @@ var _ = Describe("Drift", func() {
 						},
 						Labels: map[string]string{"app": "large-app"},
 					},
-					// Each Standard_DS4_v2 has 8 cpu, so each node should fit no more than 3 pods.
+					// Each node has 8 cpu, so should fit no more than 3 pods.
 					ResourceRequirements: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("2100m"),
@@ -434,10 +434,10 @@ var _ = Describe("Drift", func() {
 		}),
 		Entry("NodeRequirements", karpv1.NodeClaimTemplate{
 			Spec: karpv1.NodeClaimTemplateSpec{
-				// since this will overwrite the default requirements, add instance category and family selectors back into requirements
+				// since this will overwrite the default requirements, add SKU family selector back into requirements
 				Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
 					{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: karpv1.CapacityTypeLabelKey, Operator: corev1.NodeSelectorOpIn, Values: []string{karpv1.CapacityTypeSpot}}},
-					{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"Standard_DS4_v2"}}},
+					{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: v1alpha2.LabelSKUFamily, Operator: corev1.NodeSelectorOpIn, Values: []string{"D"}}},
 				},
 			},
 		}),

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -103,8 +103,6 @@ var _ = Describe("Drift", func() {
 				},
 			)
 			// We're expecting to create 3 nodes, so normally one would expect to see 2 nodes deleting at one time.
-			// Due to synchronous nature of current implementation, only 1 node is expected to be disrupted/deleted at a time.
-			// The test is still written to expect maximum of 2 nodes disruped/deleted at a time.
 			nodePool.Spec.Disruption.Budgets = []karpv1.Budget{{
 				Nodes: "50%",
 			}}
@@ -167,8 +165,6 @@ var _ = Describe("Drift", func() {
 				},
 			)
 			// We're expecting to create 3 nodes, so we'll expect to see at most 2 nodes deleting at one time.
-			// Due to synchronous nature of current implementation, only 1 node is expected to be disrupted/deleted at a time.
-			// The test is still written to expect maximum of 2 nodes disruped/deleted at a time.
 			nodePool.Spec.Disruption.Budgets = []karpv1.Budget{{
 				Nodes: "50%",
 			}}
@@ -236,8 +232,6 @@ var _ = Describe("Drift", func() {
 			appLabels := map[string]string{"app": "large-app"}
 			nodePool.Labels = appLabels
 			// We're expecting to create 5 nodes, so we'll expect to see at most 3 nodes deleting at one time.
-			// Due to synchronous nature of current implementation, only 1 node is expected to be disrupted/deleted at a time.
-			// The test is still written to expect maximum of 3 nodes disruped/deleted at a time.
 			nodePool.Spec.Disruption.Budgets = []karpv1.Budget{{
 				Nodes: "3",
 			}}
@@ -268,7 +262,7 @@ var _ = Describe("Drift", func() {
 			// Check that all deployment pods are online
 			env.EventuallyExpectHealthyPodCount(selector, numPods)
 
-			By("cordoning and adding finalizer to the nodes")
+			By("adding finalizer to the nodes")
 			// Add a finalizer to each node so that we can stop termination disruptions
 			for _, node := range originalNodes {
 				Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), node)).To(Succeed())
@@ -279,8 +273,14 @@ var _ = Describe("Drift", func() {
 			By("drifting the nodepool")
 			nodePool.Spec.Template.Annotations = lo.Assign(nodePool.Spec.Template.Annotations, map[string]string{"test-annotation": "drift"})
 			env.ExpectUpdated(nodePool)
+
+			By("waiting for disruption to start")
+			env.EventuallyExpectTaintedNodeCount(">", 0)
+
+			By("checking max 3 out of 5 nodes to be disrupted at any time")
 			env.ConsistentlyExpectDisruptionsUntilNoneLeft(5, 3, 15*time.Minute)
 
+			By("removing testing finalizes on original nodes and nodeclaims")
 			for _, node := range originalNodes {
 				Expect(env.ExpectTestingFinalizerRemoved(node)).To(Succeed())
 			}
@@ -291,8 +291,10 @@ var _ = Describe("Drift", func() {
 			// Eventually expect all the nodes to be rolled and completely removed
 			// Since this completes the disruption operation, this also ensures that we aren't leaking nodes into subsequent
 			// tests since nodeclaims that are actively replacing but haven't brought-up nodes yet can register nodes later
+			By("checking all nodes are rolled and completely removed")
 			env.EventuallyExpectNotFound(lo.Map(originalNodes, func(n *corev1.Node, _ int) client.Object { return n })...)
 			env.EventuallyExpectNotFound(lo.Map(originalNodeClaims, func(n *karpv1.NodeClaim, _ int) client.Object { return n })...)
+			By("checking the final count of nodes and nodeclaims")
 			env.ExpectNodeClaimCount("==", 5)
 			env.ExpectNodeCount("==", 5)
 		})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Fix drift E2E suite failures and deflake. 
* Have VM SKU selection use CPU count instead of specific SKU (DSv2 series may no longer be available in some regions).
* Deflake non-empty replace drift test
* Remove outdated comments

**How was this change tested?**

* E2E: https://github.com/Azure/karpenter-provider-azure/actions/runs/14819482094 ✅

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
