### PR TITLE
fix: use defaults for SDK retry options

### DIFF
--- a/pkg/utils/opts/armopts.go
+++ b/pkg/utils/opts/armopts.go
@@ -19,7 +19,6 @@ package opts
 import (
 	"net/http"
 	"os"
-	"time"
 
 	"log/slog"
 
@@ -47,9 +46,6 @@ func DefaultNICClientOpts() *arm.ClientOptions {
 
 func DefaultRetryOpts() policy.RetryOptions {
 	return policy.RetryOptions{
-		MaxRetries: 20,
-		// Note the default retry behavior is exponential backoff
-		RetryDelay: time.Second * 5,
 		// TODO: bsoghigian: Investigate if we want to leverage some of the status codes other than the defaults.
 		// the defaults are // StatusCodes specifies the HTTP status codes that indicate the operation should be retried.
 		// A nil slice will use the following values.


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Use defaults for SDK retry options, reducing retries to 3 from 20, and initial delay to 4s from 5s

**How was this change tested?**

* E2E: https://github.com/Azure/karpenter-provider-azure/actions/runs/14849391618 (pending)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
