### PR TITLE
feat: wait for CRDs

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -28,8 +28,6 @@ import (
 	"github.com/go-logr/zapr"
 	"github.com/samber/lo"
 
-	"k8s.io/client-go/kubernetes"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/metrics"
@@ -44,8 +42,7 @@ import (
 func main() {
 	ctx := injection.WithOptionsOrDie(context.Background(), options.Injectables...)
 	logger := zapr.NewLogger(logging.NewLogger(ctx, "controller"))
-	client := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())
-	lo.Must0(operator.WaitForCRDs(ctx, client.DiscoveryClient, 2*time.Minute, logger), "failed waiting for CRDs")
+	lo.Must0(operator.WaitForCRDs(ctx, 2*time.Minute, ctrl.GetConfigOrDie(), logger), "failed waiting for CRDs")
 
 	ctx, op := operator.NewOperator(coreoperator.NewOperator())
 	aksCloudProvider := cloudprovider.New(

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -56,6 +56,8 @@ func main() {
 		op.ImageProvider,
 	)
 
+	lo.Must0(op.AddHealthzCheck("cloud-provider", aksCloudProvider.LivenessProbe))
+
 	cloudProvider := metrics.Decorate(aksCloudProvider)
 	clusterState := state.NewCluster(op.Clock, op.GetClient(), cloudProvider)
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -19,19 +19,34 @@ limitations under the License.
 package main
 
 import (
-	"github.com/samber/lo"
+	"context"
+	"time"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers"
 	"github.com/Azure/karpenter-provider-azure/pkg/operator"
+	"github.com/go-logr/zapr"
+	"github.com/samber/lo"
+
+	"k8s.io/client-go/kubernetes"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/metrics"
 	corecontrollers "sigs.k8s.io/karpenter/pkg/controllers"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	coreoperator "sigs.k8s.io/karpenter/pkg/operator"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/operator/logging"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 )
 
 func main() {
+	ctx := injection.WithOptionsOrDie(context.Background(), options.Injectables...)
+	logger := zapr.NewLogger(logging.NewLogger(ctx, "controller"))
+	client := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())
+	lo.Must0(operator.WaitForCRDs(ctx, client.DiscoveryClient, 2*time.Minute, logger), "failed waiting for CRDs")
+
 	ctx, op := operator.NewOperator(coreoperator.NewOperator())
 	aksCloudProvider := cloudprovider.New(
 		op.InstanceTypesProvider,
@@ -41,7 +56,6 @@ func main() {
 		op.ImageProvider,
 	)
 
-	lo.Must0(op.AddHealthzCheck("cloud-provider", aksCloudProvider.LivenessProbe))
 	cloudProvider := metrics.Decorate(aksCloudProvider)
 	clusterState := state.NewCluster(op.Clock, op.GetClient(), cloudProvider)
 

--- a/cmd/controller/main_ccp.go
+++ b/cmd/controller/main_ccp.go
@@ -28,8 +28,6 @@ import (
 	"github.com/go-logr/zapr"
 	"github.com/samber/lo"
 
-	"k8s.io/client-go/kubernetes"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/metrics"
@@ -44,8 +42,7 @@ import (
 func main() {
 	ctx := injection.WithOptionsOrDie(context.Background(), options.Injectables...)
 	logger := zapr.NewLogger(logging.NewLogger(ctx, "controller"))
-	client := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())
-	lo.Must0(operator.WaitForCRDs(ctx, client.DiscoveryClient, 2*time.Minute, logger), "failed waiting for CRDs")
+	lo.Must0(operator.WaitForCRDs(ctx, 2*time.Minute, ctrl.GetConfigOrDie(), logger), "failed waiting for CRDs")
 
 	ctx, op := operator.NewOperator(coreoperator.NewOperator())
 	aksCloudProvider := cloudprovider.New(

--- a/cmd/controller/main_ccp.go
+++ b/cmd/controller/main_ccp.go
@@ -56,6 +56,8 @@ func main() {
 		op.ImageProvider,
 	)
 
+	lo.Must0(op.AddHealthzCheck("cloud-provider", aksCloudProvider.LivenessProbe))
+
 	cloudProvider := metrics.Decorate(aksCloudProvider)
 	clusterState := state.NewCluster(op.Clock, op.GetClient(), cloudProvider)
 

--- a/cmd/controller/main_ccp.go
+++ b/cmd/controller/main_ccp.go
@@ -19,19 +19,34 @@ limitations under the License.
 package main
 
 import (
-	"github.com/samber/lo"
+	"context"
+	"time"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers"
 	"github.com/Azure/karpenter-provider-azure/pkg/operator"
+	"github.com/go-logr/zapr"
+	"github.com/samber/lo"
+
+	"k8s.io/client-go/kubernetes"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/metrics"
 	corecontrollers "sigs.k8s.io/karpenter/pkg/controllers"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	coreoperator "sigs.k8s.io/karpenter/pkg/operator"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/operator/logging"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 )
 
 func main() {
+	ctx := injection.WithOptionsOrDie(context.Background(), options.Injectables...)
+	logger := zapr.NewLogger(logging.NewLogger(ctx, "controller"))
+	client := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())
+	lo.Must0(operator.WaitForCRDs(ctx, client.DiscoveryClient, 2*time.Minute, logger), "failed waiting for CRDs")
+
 	ctx, op := operator.NewOperator(coreoperator.NewOperator())
 	aksCloudProvider := cloudprovider.New(
 		op.InstanceTypesProvider,
@@ -41,7 +56,6 @@ func main() {
 		op.ImageProvider,
 	)
 
-	lo.Must0(op.AddHealthzCheck("cloud-provider", aksCloudProvider.LivenessProbe))
 	cloudProvider := metrics.Decorate(aksCloudProvider)
 	clusterState := state.NewCluster(op.Clock, op.GetClient(), cloudProvider)
 
@@ -62,6 +76,7 @@ func main() {
 			op.EventRecorder,
 			aksCloudProvider,
 			op.InstanceProvider,
+			// TODO: refactor so we are passing in kubernetesVersionProvider and nodeImageProvider. Currently ImageProvider just implements both.
 			op.ImageProvider,
 			op.ImageProvider,
 		)...).

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,8 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/awslabs/operatorpkg v0.0.0-20250320000002-b05af0f15c68
 	github.com/blang/semver/v4 v4.0.0
+	github.com/go-logr/logr v1.4.2
+	github.com/go-logr/zapr v1.3.0
 	github.com/go-openapi/errors v0.22.1
 	github.com/go-openapi/runtime v0.28.0
 	github.com/go-openapi/strfmt v0.23.0
@@ -84,9 +86,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -26,17 +26,21 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/flowcontrol"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/operator"
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/auth"
 	azurecache "github.com/Azure/karpenter-provider-azure/pkg/cache"
@@ -221,36 +225,46 @@ func getVnetGUID(cfg *auth.Config, subnetID string) (string, error) {
 }
 
 // WaitForCRDs waits for the required CRDs to be available with a timeout
-func WaitForCRDs(ctx context.Context, client *discovery.DiscoveryClient, timeout time.Duration, log logr.Logger) error {
-	var requiredCRDs = []schema.GroupVersionResource{
-		{Group: "karpenter.sh", Version: "v1", Resource: "nodepools"},
-		{Group: "karpenter.sh", Version: "v1", Resource: "nodeclaims"},
-		{Group: "karpenter.azure.com", Version: "v1alpha2", Resource: "aksnodeclasses"},
+func WaitForCRDs(ctx context.Context, timeout time.Duration, config *rest.Config, log logr.Logger) error {
+	gvk := func(obj runtime.Object) schema.GroupVersionKind {
+		return lo.Must(apiutil.GVKForObject(obj, scheme.Scheme))
+	}
+	var requiredGVKs = []schema.GroupVersionKind{
+		gvk(&karpv1.NodePool{}),
+		gvk(&karpv1.NodeClaim{}),
+		gvk(&v1alpha2.AKSNodeClass{}),
+	}
+
+	client, err := rest.HTTPClientFor(config)
+	if err != nil {
+		return fmt.Errorf("creating kubernetes client, %w", err)
+	}
+	restMapper, err := apiutil.NewDynamicRESTMapper(config, client)
+	if err != nil {
+		return fmt.Errorf("creating dynamic rest mapper, %w", err)
 	}
 
 	log.WithValues("timeout", timeout).Info("waiting for required CRDs to be available")
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	for _, crd := range requiredCRDs {
-		crdName := fmt.Sprintf("%s.%s/%s", crd.Resource, crd.GroupVersion().Group, crd.Version)
-		if err := wait.PollUntilContextCancel(ctx, 10*time.Second, true, func(ctx context.Context) (bool, error) {
-			_, err := client.RESTClient().Get().AbsPath("/apis", crd.Group, crd.Version, crd.Resource).Do(ctx).Raw()
-
-			if err != nil {
-				if errors.IsNotFound(err) {
-					log.V(1).WithValues("crd", crdName).Info("waiting for CRD to be available")
+	for _, gvk := range requiredGVKs {
+		err := wait.PollUntilContextCancel(ctx, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+			if _, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
+				if meta.IsNoMatchError(err) {
+					log.V(1).WithValues("gvk", gvk).Info("waiting for CRD to be available")
 					return false, nil
 				}
 				return false, err
 			}
-			log.V(1).WithValues("crd", crdName).Info("CRD is available")
+			log.V(1).WithValues("gvk", gvk).Info("CRD is available")
 			return true, nil
-		}); err != nil {
+		})
+		if err != nil {
 			if ctx.Err() == context.DeadlineExceeded {
-				return fmt.Errorf("timed out waiting for CRD %s to be available", crdName)
+				return fmt.Errorf("timed out waiting for CRD %s to be available", gvk)
 			}
-			return fmt.Errorf("failed to wait for CRD %s: %w", crdName, err)
+			return fmt.Errorf("failed to wait for CRD %s: %w", gvk, err)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Add wait for CRDs on start, prior to starting core operator with timeout (2m) - though note that liveness probe, if not tuned, is likely to kill the process earlier.

##### Background

We had removed the alternative operator that waited for CRDs. The current core operator implementation ["fails open"](https://github.com/kubernetes-sigs/karpenter/pull/1683) on missing CRDs, proceeding without configuring indexers. Unfortunately, for now there are controller (including in core) that use caching client with `client.MatchingFields` option, which require indexes. These controllers will stay broken after CRDs are deployed, since there is nothing that would (re-)create the indexes then. On top of this, after CRDs are in place, it will stop exiting on CacheSyncTimeout (2m by default), so it will stay broken. Consequently (in the absence of something that would restart the process, or rebuild indexes), waiting for CRDs on startup is appropriate.

The implementation is similar to what core uses for readyz probe (probably introduced as a gate for webhooks).

**How was this change tested?**

* Starting w/CRDs in place
* Starting w/o CRDs in place
* Starting w/o CRDs in place and deploying them later

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Wait for CRDs on startup
```
