### PR TITLE
fix: make artifact streaming conditional on architecture and distribution

### DIFF
--- a/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
@@ -112,7 +112,7 @@ func (p ProvisionClientBootstrap) GetCustomDataAndCSE(ctx context.Context) (stri
 		// GpuInstanceProfile:      lo.ToPtr(models.GPUInstanceProfileUnspecified), // Unsupported as of now (MIG)
 		// WorkloadRuntime:         lo.ToPtr(models.WorkloadRuntimeUnspecified),    // Unsupported as of now (Kata)
 		ArtifactStreamingProfile: &models.ArtifactStreamingProfile{
-			Enabled: to.Ptr(enableArtifactStreaming),
+			Enabled: lo.ToPtr(enableArtifactStreaming),
 		},
 	}
 

--- a/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
@@ -107,9 +107,10 @@ func (p ProvisionClientBootstrap) GetCustomDataAndCSE(ctx context.Context) (stri
 		// EnableFIPS:              lo.ToPtr(false),                                 // Unsupported as of now
 		// GpuInstanceProfile:      lo.ToPtr(models.GPUInstanceProfileUnspecified), // Unsupported as of now (MIG)
 		// WorkloadRuntime:         lo.ToPtr(models.WorkloadRuntimeUnspecified),    // Unsupported as of now (Kata)
-		// ArtifactStreamingProfile: &models.ArtifactStreamingProfile{
-		// Enabled: lo.ToPtr(false), // Unsupported as of now
-		// },
+		ArtifactStreamingProfile: &models.ArtifactStreamingProfile{
+			// TODO: Revisit when adding support for Azure Linux v3 and Ubuntu 24.04, this may have to be conditional then
+			Enabled: lo.ToPtr(true),
+		},
 	}
 
 	switch p.ImageFamily {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Make artifact streaming conditional on architecture (x64 only) and distribution (only the currently supported ones)

**How was this change tested?**

* `make presubmit` (though w/o unit tests for bootstrapping client)
* E2E: self-hosted does not exercise bootstrap client, will be tested elsewhere

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
