### PR TITLE
test(fake): move MkVMID to fake pkg

### DIFF
--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
 
+	"github.com/Azure/karpenter-provider-azure/pkg/fake"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -194,7 +195,7 @@ var _ = Describe("CloudProvider", func() {
 			nodeClaim = coretest.NodeClaim(karpv1.NodeClaim{
 				Status: karpv1.NodeClaimStatus{
 					NodeName:   node.Name,
-					ProviderID: utils.ResourceIDToProviderID(ctx, utils.MkVMID(rg, vmName)),
+					ProviderID: utils.ResourceIDToProviderID(ctx, fake.MkVMID(rg, vmName)),
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/controllers/nodeclaim/inplaceupdate/suite_test.go
+++ b/pkg/controllers/nodeclaim/inplaceupdate/suite_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclaim/inplaceupdate"
+	"github.com/Azure/karpenter-provider-azure/pkg/fake"
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
@@ -230,7 +231,7 @@ var _ = Describe("In Place Update Controller", func() {
 	BeforeEach(func() {
 		vmName = "vm-a"
 		vm = &armcompute.VirtualMachine{
-			ID:   lo.ToPtr(utils.MkVMID(azureEnv.AzureResourceGraphAPI.ResourceGroup, vmName)),
+			ID:   lo.ToPtr(fake.MkVMID(azureEnv.AzureResourceGraphAPI.ResourceGroup, vmName)),
 			Name: lo.ToPtr(vmName),
 		}
 

--- a/pkg/fake/azureresourcegraphapi_test.go
+++ b/pkg/fake/azureresourcegraphapi_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
-	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
@@ -98,7 +97,7 @@ func checkVM(vm instance.Resource, rg string) error {
 	if !ok {
 		return fmt.Errorf("VM is missing name")
 	}
-	expectedID := utils.MkVMID(rg, name.(string))
+	expectedID := MkVMID(rg, name.(string))
 	id, ok := vm["id"]
 	if !ok {
 		return fmt.Errorf("VM is missing id")

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -198,7 +198,7 @@ var _ = Describe("InstanceType Provider", func() {
 			vmName := instance.GenerateResourceName(nodeClaim.Name)
 			vm := &armcompute.VirtualMachine{
 				Name:     lo.ToPtr(vmName),
-				ID:       lo.ToPtr(utils.MkVMID(options.FromContext(ctx).NodeResourceGroup, vmName)),
+				ID:       lo.ToPtr(fake.MkVMID(options.FromContext(ctx).NodeResourceGroup, vmName)),
 				Location: lo.ToPtr(fake.Region),
 				Zones:    []*string{lo.ToPtr("fantasy-zone")}, // Makes sure we do not get a match from the existing set of zones
 				Properties: &armcompute.VirtualMachineProperties{

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -65,11 +65,6 @@ func ResourceIDToProviderID(ctx context.Context, id string) string {
 	return providerIDLowerRG
 }
 
-func MkVMID(resourceGroupName string, vmName string) string {
-	const idFormat = "/subscriptions/subscriptionID/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s"
-	return fmt.Sprintf(idFormat, resourceGroupName, vmName)
-}
-
 // WithDefaultFloat64 returns the float64 value of the supplied environment variable or, if not present,
 // the supplied default value. If the float64 conversion fails, returns the default
 func WithDefaultFloat64(key string, def float64) float64 {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
I noticed the `MkVMID` method was sitting in a prod pkg which concerns be quite a bit. Thankfully it wasn't reference anywhere expect tests. Moving it to the `fake` pkg where it belongs.

**How was this change tested?**
- `make presubmit`
- E2E Runs:
    - https://github.com/Azure/karpenter-provider-azure/actions/runs/15056131604 (latest)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
