### PR TITLE
fix(drift): improve NotFound and Deleting Nodes case in Drift

### DIFF
--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -108,7 +108,7 @@ func (c *CloudProvider) isK8sVersionDrifted(ctx context.Context, nodeClaim *karp
 		// We do not return an error here as its expected within the lifecycle of the nodeclaims registration.
 		// Drift can be called for a nodeclaim once its launched, but .Status.NodeName is only filled out after the node is registered:
 		// https://github.com/kubernetes-sigs/karpenter/blob/8b9ea2e7cd10acdb40bccdf91a153a2e69b71107/pkg/controllers/nodeclaim/lifecycle/registration.go#L83
-		return "", nil //
+		return "", nil
 	}
 
 	n, err := nodeclaimutils.NodeForNodeClaim(ctx, c.kubeClient, nodeClaim)

--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -122,7 +122,7 @@ func (c *CloudProvider) isK8sVersionDrifted(ctx context.Context, nodeClaim *karp
 		if nodeclaimutils.IsDuplicateNodeError(err) {
 			logger.V(1).Info("WARN: Duplicate node error, invariant violated.")
 		}
-		return "case 2", err
+		return "", err
 	}
 	if !n.DeletionTimestamp.IsZero() {
 		// We do not need to check for drift if the node is being deleted.

--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -108,7 +108,7 @@ func (c *CloudProvider) isK8sVersionDrifted(ctx context.Context, nodeClaim *karp
 		// We do not return an error here as its expected within the lifecycle of the nodeclaims registration.
 		// Drift can be called for a nodeclaim once its launched, but .Status.NodeName is only filled out after the node is registered:
 		// https://github.com/kubernetes-sigs/karpenter/blob/8b9ea2e7cd10acdb40bccdf91a153a2e69b71107/pkg/controllers/nodeclaim/lifecycle/registration.go#L83
-		return "", nil
+		return "", nil //
 	}
 
 	n, err := nodeclaimutils.NodeForNodeClaim(ctx, c.kubeClient, nodeClaim)

--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -30,12 +30,9 @@ import (
 	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	v1 "k8s.io/api/core/v1"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 )
 
 const (
@@ -114,16 +111,24 @@ func (c *CloudProvider) isK8sVersionDrifted(ctx context.Context, nodeClaim *karp
 		return "", nil
 	}
 
-	n := &v1.Node{}
-	if err := c.kubeClient.Get(ctx, client.ObjectKey{Name: nodeName}, n); err != nil {
-		// Core's check for Launched status should currently prevent us from getting here before the node exists because of the LRO block on Create:
-		// https://github.com/kubernetes-sigs/karpenter/blob/9877cf639e665eadcae9e46e5a702a1b30ced1d3/pkg/controllers/nodeclaim/disruption/drift.go#L51
-		// However, in my opinion, we should look at updating this logic to ignore NotFound errors as we fix the LRO issue.
-		// Shouldn't cause an issue to my awareness, but could be noisy.
-		// TODO: re-evaluate ignoring NotFound error, and using core's library for nodeclaims. Similar to usage here:
-		// https://github.com/kubernetes-sigs/karpenter/blob/bbe6bd27e65d88fe55376b6c3c2c828312c105c4/pkg/controllers/nodeclaim/lifecycle/registration.go#L53
-		return "", err
+	n, err := nodeclaimutils.NodeForNodeClaim(ctx, c.kubeClient, nodeClaim)
+	if err != nil {
+		if nodeclaimutils.IsNodeNotFoundError(err) {
+			// We do not return an error here as its expected within the lifecycle of the nodeclaims registration.
+			// Core's checks only for Launched status which means we've started the create, but the node doesn't nessicarially exist yet
+			// https://github.com/kubernetes-sigs/karpenter/blob/9877cf639e665eadcae9e46e5a702a1b30ced1d3/pkg/controllers/nodeclaim/disruption/drift.go#L51
+			return cloudprovider.DriftReason(nodeClaim.Status.ProviderID), nil
+		}
+		if nodeclaimutils.IsDuplicateNodeError(err) {
+			logger.V(1).Info("WARN: Duplicate node error, invariant violated.")
+		}
+		return "case 2", err
 	}
+	if !n.DeletionTimestamp.IsZero() {
+		// We do not need to check for drift if the node is being deleted.
+		return "", nil
+	}
+
 	nodeK8sVersion := strings.TrimPrefix(n.Status.NodeInfo.KubeletVersion, "v")
 
 	if nodeK8sVersion != k8sVersion {

--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -117,7 +117,7 @@ func (c *CloudProvider) isK8sVersionDrifted(ctx context.Context, nodeClaim *karp
 			// We do not return an error here as its expected within the lifecycle of the nodeclaims registration.
 			// Core's checks only for Launched status which means we've started the create, but the node doesn't nessicarially exist yet
 			// https://github.com/kubernetes-sigs/karpenter/blob/9877cf639e665eadcae9e46e5a702a1b30ced1d3/pkg/controllers/nodeclaim/disruption/drift.go#L51
-			return cloudprovider.DriftReason(nodeClaim.Status.ProviderID), nil
+			return "", nil
 		}
 		if nodeclaimutils.IsDuplicateNodeError(err) {
 			logger.V(1).Info("WARN: Duplicate node error, invariant violated.")

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -344,7 +344,7 @@ var _ = Describe("CloudProvider", func() {
 				node.Finalizers = lo.Reject(node.Finalizers, func(finalizer string, _ int) bool {
 					return finalizer == test.TestingFinalizer
 				})
-				env.Client.Patch(ctx, node, client.StrategicMergeFrom(deepCopy))
+				Expect(env.Client.Patch(ctx, node, client.StrategicMergeFrom(deepCopy))).NotTo(HaveOccurred())
 				ExpectDeleted(ctx, env.Client, node)
 			})
 

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
 
-	"github.com/Azure/karpenter-provider-azure/pkg/fake"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -329,7 +329,7 @@ var _ = Describe("CloudProvider", func() {
 			})
 
 			// TODO (charliedmcb): Do we need to test "shouldn't error or be drifted when node is deleting"?
-			//     This case is tricker since we can't directly setup the DeletionTimestamp on the node,
+			//     This case is tricker since we can't directly set the DeletionTimestamp on the node,
 			//     and instead need to setup a finalizer and delete the node from my understanding.
 
 			It("should succeed with drift true when KubernetesVersion is new", func() {

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -21,6 +21,13 @@ import (
 	k8srand "k8s.io/apimachinery/pkg/util/rand"
 )
 
+const (
+	// Note: this already exists in test/pkg/environment/common
+	// https://github.com/Azure/karpenter-provider-azure/blob/84e449787ec72268efb0c7af81ec87a6b3ee95fa/test/pkg/environment/common/setup.go#L47
+	// However, I'd prefer to keep our unit tests dept self-contained instead of depending upon the e2e testing package.
+	TestingFinalizer = "testing/finalizer"
+)
+
 // RandomName returns a pseudo-random resource name with a given prefix.
 func RandomName(prefix string) string {
 	// You could make this more robust by including additional random characters.

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	// Note: this already exists in test/pkg/environment/common
+	// Note (charliedmcb): this already exists in test/pkg/environment/common
 	// https://github.com/Azure/karpenter-provider-azure/blob/84e449787ec72268efb0c7af81ec87a6b3ee95fa/test/pkg/environment/common/setup.go#L47
-	// However, I'd prefer to keep our unit tests dept self-contained instead of depending upon the e2e testing package.
+	// However, I'd prefer to keep our unit test dependants self-contained instead of depending upon the e2e testing package.
 	TestingFinalizer = "testing/finalizer"
 )
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Currently we error out on the case of NotFound and Deleting nodes. However, these cases are actually expected to be able to occur during the lifecycle of nodeclaims, so switching their handling to return no error.

**How was this change tested?**

- `make presubmit`
- E2E runs:
    - https://github.com/Azure/karpenter-provider-azure/actions/runs/15056128931
    - https://github.com/Azure/karpenter-provider-azure/actions/runs/15056727146
    - https://github.com/Azure/karpenter-provider-azure/actions/runs/15057293409
        - Got a failure in NodeClaim, and Drift tests.
            - NodeClaim appears to be a flake, and failure doesn't seem related to this change. It failed waiting for the initialized node count to be 1 
            - Drift case appears to be unrelated. I dug into the Drift code, and don't see it being related here.
    - https://github.com/Azure/karpenter-provider-azure/actions/runs/15074039135
    - https://github.com/Azure/karpenter-provider-azure/actions/runs/15076946728
    - https://github.com/Azure/karpenter-provider-azure/actions/runs/15077659416 (latest)

- Note there have been some transient failures in the tests:
    - https://github.com/Azure/karpenter-provider-azure/actions/runs/15057451583/job/42326189710?pr=891#step:6:1858
        - error of the form: `Log in goroutine after TestAPIs has completed`
        - However, it appears to be transient. Ran the `pkg/cloudprovider/` suite 50+ times locally, and got no failures.
    - https://github.com/Azure/karpenter-provider-azure/actions/runs/15077655519/job/42388539086?pr=891#step:6:1861
        - Another error of the form: `Log in goroutine after TestAPIs has completed`
    - https://github.com/Azure/karpenter-provider-azure/actions/runs/15077655519/job/42389072837?pr=891#step:6:1868
        - Another error of the form: `Log in goroutine after TestAPIs has completed`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
fix the NodeNotFound and Deleting case in Drift to return no error, since its expected within the lifecycle of nodeclaims
```
