### PR TITLE
chore(providers): factor out KubernetesVersion provider

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -76,7 +76,7 @@ func main() {
 			aksCloudProvider,
 			op.InstanceProvider,
 			// TODO: refactor so we are passing in kubernetesVersionProvider and nodeImageProvider. Currently ImageProvider just implements both.
-			op.ImageProvider,
+			op.KubernetesVersionProvider,
 			op.ImageProvider,
 			op.InClusterKubernetesInterface,
 		)...).

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -75,7 +75,7 @@ func main() {
 			op.EventRecorder,
 			aksCloudProvider,
 			op.InstanceProvider,
-			// TODO: refactor so we are passing in kubernetesVersionProvider and nodeImageProvider. Currently ImageProvider just implements both.
+			// TODO: still need to refactor ImageProvider side of things.
 			op.KubernetesVersionProvider,
 			op.ImageProvider,
 			op.InClusterKubernetesInterface,

--- a/pkg/controllers/nodeclass/status/kubernetesversion_test.go
+++ b/pkg/controllers/nodeclass/status/kubernetesversion_test.go
@@ -66,7 +66,7 @@ var _ = Describe("NodeClass KubernetesVersion Status Controller", func() {
 		)
 
 		BeforeEach(func() {
-			k8sReconciler = status.NewKubernetesVersionReconciler(azureEnv.ImageProvider)
+			k8sReconciler = status.NewKubernetesVersionReconciler(azureEnv.KubernetesVersionProvider)
 		})
 
 		It("Should update KubernetesVersion when new kubernetes version is detected, and reset node image readiness to false", func() {

--- a/pkg/controllers/nodeclass/status/suite_test.go
+++ b/pkg/controllers/nodeclass/status/suite_test.go
@@ -63,7 +63,7 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	azureEnv = test.NewEnvironment(ctx, env)
 
-	controller = status.NewController(env.Client, azureEnv.ImageProvider, azureEnv.ImageProvider, env.KubernetesInterface)
+	controller = status.NewController(env.Client, azureEnv.KubernetesVersionProvider, azureEnv.ImageProvider, env.KubernetesInterface)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -74,13 +74,14 @@ type Operator struct {
 
 	UnavailableOfferingsCache *azurecache.UnavailableOfferings
 
-	ImageProvider          *imagefamily.Provider
-	ImageResolver          imagefamily.Resolver
-	LaunchTemplateProvider *launchtemplate.Provider
-	PricingProvider        *pricing.Provider
-	InstanceTypesProvider  instancetype.Provider
-	InstanceProvider       *instance.DefaultProvider
-	LoadBalancerProvider   *loadbalancer.Provider
+	KubernetesVersionProvider imagefamily.KubernetesVersionProvider
+	ImageProvider             *imagefamily.Provider
+	ImageResolver             imagefamily.Resolver
+	LaunchTemplateProvider    *launchtemplate.Provider
+	PricingProvider           *pricing.Provider
+	InstanceTypesProvider     instancetype.Provider
+	InstanceProvider          *instance.DefaultProvider
+	LoadBalancerProvider      *loadbalancer.Provider
 }
 
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
@@ -109,6 +110,11 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		operator.Elected(),
 	)
 
+	kubernetesVersionProvider := imagefamily.NewKubernetesVersionProvider(
+		operator.KubernetesInterface,
+		cache.New(azurecache.KubernetesVersionTTL,
+			azurecache.DefaultCleanupInterval),
+	)
 	imageProvider := imagefamily.NewProvider(
 		operator.KubernetesInterface,
 		cache.New(azurecache.KubernetesVersionTTL,
@@ -165,6 +171,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		Operator:                     operator,
 		InClusterKubernetesInterface: inClusterClient,
 		UnavailableOfferingsCache:    unavailableOfferingsCache,
+		KubernetesVersionProvider:    kubernetesVersionProvider,
 		ImageProvider:                imageProvider,
 		ImageResolver:                imageResolver,
 		LaunchTemplateProvider:       launchTemplateProvider,

--- a/pkg/providers/imagefamily/kubernetesversion.go
+++ b/pkg/providers/imagefamily/kubernetesversion.go
@@ -14,12 +14,53 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO (charliedmcb): factor provider into its own package
 package imagefamily
 
 import (
 	"context"
+	"strings"
+
+	"github.com/patrickmn/go-cache"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/karpenter/pkg/utils/pretty"
+)
+
+const (
+	kubernetesVersionCacheKey = "kubernetesVersion"
 )
 
 type KubernetesVersionProvider interface {
 	KubeServerVersion(ctx context.Context) (string, error)
+}
+
+type kubernetesVersionProvider struct {
+	kubernetesInterface    kubernetes.Interface
+	kubernetesVersionCache *cache.Cache
+	cm                     *pretty.ChangeMonitor
+}
+
+func NewKubernetesVersionProvider(kubernetesInterface kubernetes.Interface, kubernetesVersionCache *cache.Cache) *kubernetesVersionProvider {
+	return &kubernetesVersionProvider{
+		kubernetesInterface:    kubernetesInterface,
+		kubernetesVersionCache: kubernetesVersionCache,
+		cm:                     pretty.NewChangeMonitor(),
+	}
+}
+
+func (p *kubernetesVersionProvider) KubeServerVersion(ctx context.Context) (string, error) {
+	if version, ok := p.kubernetesVersionCache.Get(kubernetesVersionCacheKey); ok {
+		return version.(string), nil
+	}
+	serverVersion, err := p.kubernetesInterface.Discovery().ServerVersion()
+	if err != nil {
+		return "", err
+	}
+	version := strings.TrimPrefix(serverVersion.GitVersion, "v") // v1.24.9 -> 1.24.9
+	p.kubernetesVersionCache.SetDefault(kubernetesVersionCacheKey, version)
+	if p.cm.HasChanged("kubernetes-version", version) {
+		log.FromContext(ctx).WithValues("kubernetes-version", version).V(1).Info("discovered kubernetes version")
+	}
+	return version, nil
 }

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1119,7 +1119,7 @@ var _ = Describe("InstanceType Provider", func() {
 				UseSIG: lo.ToPtr(true),
 			})
 			ctx = options.ToContext(ctx)
-			statusController := status.NewController(env.Client, azureEnv.ImageProvider, azureEnv.ImageProvider, env.KubernetesInterface)
+			statusController := status.NewController(env.Client, azureEnv.KubernetesVersionProvider, azureEnv.ImageProvider, env.KubernetesInterface)
 
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
@@ -1161,7 +1161,7 @@ var _ = Describe("InstanceType Provider", func() {
 				UseSIG: lo.ToPtr(true),
 			})
 			ctx = options.ToContext(ctx)
-			statusController := status.NewController(env.Client, azureEnv.ImageProvider, azureEnv.ImageProvider, env.KubernetesInterface)
+			statusController := status.NewController(env.Client, azureEnv.KubernetesVersionProvider, azureEnv.ImageProvider, env.KubernetesInterface)
 
 			nodeClass.Spec.ImageFamily = lo.ToPtr(imageFamily)
 			coretest.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
@@ -1195,7 +1195,7 @@ var _ = Describe("InstanceType Provider", func() {
 		)
 		DescribeTable("should select the right image for a given instance type",
 			func(instanceType string, imageFamily string, expectedImageDefinition string, expectedGalleryURL string) {
-				statusController := status.NewController(env.Client, azureEnv.ImageProvider, azureEnv.ImageProvider, env.KubernetesInterface)
+				statusController := status.NewController(env.Client, azureEnv.KubernetesVersionProvider, azureEnv.ImageProvider, env.KubernetesInterface)
 				nodeClass.Spec.ImageFamily = lo.ToPtr(imageFamily)
 				coretest.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 					NodeSelectorRequirement: v1.NodeSelectorRequirement{
@@ -1402,7 +1402,7 @@ var _ = Describe("InstanceType Provider", func() {
 			customData = ExpectDecodedCustomData(azureEnv)
 			kubeletFlags = ExpectKubeletFlagsPassed(customData)
 
-			k8sVersion, err := azureEnv.ImageProvider.KubeServerVersion(ctx)
+			k8sVersion, err := azureEnv.KubernetesVersionProvider.KubeServerVersion(ctx)
 			Expect(err).To(BeNil())
 			minorVersion = semver.MustParse(k8sVersion).Minor
 			credentialProviderURL = bootstrap.CredentialProviderURL(k8sVersion, "amd64")
@@ -1596,7 +1596,7 @@ var _ = Describe("InstanceType Provider", func() {
 
 		It("should return error when instance type resolution fails", func() {
 			// Create and set up the status controller
-			statusController := status.NewController(env.Client, azureEnv.ImageProvider, azureEnv.ImageProvider, env.KubernetesInterface)
+			statusController := status.NewController(env.Client, azureEnv.KubernetesVersionProvider, azureEnv.ImageProvider, env.KubernetesInterface)
 
 			// Set NodeClass to Ready
 			nodeClass.StatusConditions().SetTrue(karpv1.ConditionTypeLaunched)

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -65,13 +65,14 @@ type Environment struct {
 	UnavailableOfferingsCache *azurecache.UnavailableOfferings
 
 	// Providers
-	InstanceTypesProvider  instancetype.Provider
-	InstanceProvider       instance.Provider
-	PricingProvider        *pricing.Provider
-	ImageProvider          *imagefamily.Provider
-	ImageResolver          imagefamily.Resolver
-	LaunchTemplateProvider *launchtemplate.Provider
-	LoadBalancerProvider   *loadbalancer.Provider
+	InstanceTypesProvider     instancetype.Provider
+	InstanceProvider          instance.Provider
+	PricingProvider           *pricing.Provider
+	KubernetesVersionProvider imagefamily.KubernetesVersionProvider
+	ImageProvider             *imagefamily.Provider
+	ImageResolver             imagefamily.Resolver
+	LaunchTemplateProvider    *launchtemplate.Provider
+	LoadBalancerProvider      *loadbalancer.Provider
 
 	// Settings
 	nonZonal bool
@@ -108,6 +109,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 
 	// Providers
 	pricingProvider := pricing.NewProvider(ctx, pricingAPI, region, make(chan struct{}))
+	kubernetesVersionProvider := imagefamily.NewKubernetesVersionProvider(env.KubernetesInterface, kubernetesVersionCache)
 	imageFamilyProvider := imagefamily.NewProvider(env.KubernetesInterface, kubernetesVersionCache, communityImageVersionsAPI, region, subscription, nodeImageVersionsAPI)
 	imageFamilyResolver := imagefamily.NewDefaultResolver(env.Client, imageFamilyProvider)
 	instanceTypesProvider := instancetype.NewDefaultProvider(region, instanceTypeCache, skuClientSingleton, pricingProvider, unavailableOfferingsCache)
@@ -168,13 +170,14 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		UnavailableOfferingsCache: unavailableOfferingsCache,
 		LoadBalancerCache:         loadBalancerCache,
 
-		InstanceTypesProvider:  instanceTypesProvider,
-		InstanceProvider:       instanceProvider,
-		PricingProvider:        pricingProvider,
-		ImageProvider:          imageFamilyProvider,
-		ImageResolver:          imageFamilyResolver,
-		LaunchTemplateProvider: launchTemplateProvider,
-		LoadBalancerProvider:   loadBalancerProvider,
+		InstanceTypesProvider:     instanceTypesProvider,
+		InstanceProvider:          instanceProvider,
+		PricingProvider:           pricingProvider,
+		KubernetesVersionProvider: kubernetesVersionProvider,
+		ImageProvider:             imageFamilyProvider,
+		ImageResolver:             imageFamilyResolver,
+		LaunchTemplateProvider:    launchTemplateProvider,
+		LoadBalancerProvider:      loadBalancerProvider,
 
 		nonZonal: nonZonal,
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
This is a follow up to previous refactoring of the `imagefamily` providers logic for provisioning. 

First refactor covered in this PR, splitting apart the provider, to have the KubernetesVersionProvider separate.

**How was this change tested?**
- `make presubmit`
- E2E
     - https://github.com/Azure/karpenter-provider-azure/actions/runs/15149246588
         - Failure in [should delete pod with do-not-disrupt when it reaches its terminationGracePeriodSeconds](https://github.com/Azure/karpenter-provider-azure/actions/runs/15149246588/job/42592111041#step:18:4477)
             - appears there is a race condition for the amount of time between the node deleting, and the watch for `ConsistentlyExpectHealthyPods`. Seeing the logs between being over `100*time.Millisecond`, which is the buffer given to prevent a race. Needs updating. I think closer to `time.Second` of buffer would be better, if not grabbing the exact time between the steps of the run and adding a little extra.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
