### PR TITLE
fix: use ttl param in MarkSpotUnavailableWithTTL

### DIFF
--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -69,7 +69,7 @@ func (u *UnavailableOfferings) IsUnavailable(instanceType, zone, capacityType st
 
 // MarkSpotUnavailable communicates recently observed temporary capacity shortages for spot
 func (u *UnavailableOfferings) MarkSpotUnavailableWithTTL(ctx context.Context, ttl time.Duration) {
-	u.MarkUnavailableWithTTL(ctx, "SpotUnavailable", "", "", karpv1.CapacityTypeSpot, UnavailableOfferingsTTL)
+	u.MarkUnavailableWithTTL(ctx, "SpotUnavailable", "", "", karpv1.CapacityTypeSpot, ttl)
 }
 
 // MarkUnavailableWithTTL allows us to mark an offering unavailable with a custom TTL


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

**Description**
`MarkSpotUnavailableWithTTL` now correctly passes value of `ttl` param to the function it calls. This PR is a no-op - the only call site of `MarkSpotUnavailableWithTTL` passes in a 1hr long ttl, which is the same as currently used hard-coded value in `MarkSpotUnavailableWithTTL`.

**How was this change tested?**

* 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
