### PR TITLE
fix: adjust TTL for unavailable offerings when allocation error happens

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -67,7 +67,7 @@ var (
 	SKUNotAvailableReason                       = "SKUNotAvailable"
 
 	SubscriptionQuotaReachedTTL = 1 * time.Hour
-	AllocationFailureTTL        = 15 * time.Minute
+	AllocationFailureTTL        = 1 * time.Hour
 	SKUNotAvailableSpotTTL      = 1 * time.Hour
 	SKUNotAvailableOnDemandTTL  = 23 * time.Hour
 )

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -67,6 +67,7 @@ var (
 	SKUNotAvailableReason                       = "SKUNotAvailable"
 
 	SubscriptionQuotaReachedTTL = 1 * time.Hour
+	AllocationFailureTTL        = 15 * time.Minute
 	SKUNotAvailableSpotTTL      = 1 * time.Hour
 	SKUNotAvailableOnDemandTTL  = 23 * time.Hour
 )
@@ -698,8 +699,8 @@ func (p *DefaultProvider) handleResponseErrors(ctx context.Context, instanceType
 	}
 	if sdkerrors.ZonalAllocationFailureOccurred(err) {
 		log.FromContext(ctx).WithValues("zone", zone).Error(err, "")
-		p.unavailableOfferings.MarkUnavailable(ctx, ZonalAllocationFailureReason, instanceType.Name, zone, karpv1.CapacityTypeOnDemand)
-		p.unavailableOfferings.MarkUnavailable(ctx, ZonalAllocationFailureReason, instanceType.Name, zone, karpv1.CapacityTypeSpot)
+		p.unavailableOfferings.MarkUnavailableWithTTL(ctx, ZonalAllocationFailureReason, instanceType.Name, zone, karpv1.CapacityTypeOnDemand, AllocationFailureTTL)
+		p.unavailableOfferings.MarkUnavailableWithTTL(ctx, ZonalAllocationFailureReason, instanceType.Name, zone, karpv1.CapacityTypeSpot, AllocationFailureTTL)
 
 		return fmt.Errorf("unable to allocate resources in the selected zone (%s). (will try a different zone to fulfill your request)", zone)
 	}
@@ -712,8 +713,8 @@ func (p *DefaultProvider) handleResponseErrors(ctx context.Context, instanceType
 			zonesToBlock[offeringZone] = struct{}{}
 		}
 		for zone := range zonesToBlock {
-			p.unavailableOfferings.MarkUnavailable(ctx, AllocationFailureReason, instanceType.Name, zone, karpv1.CapacityTypeOnDemand)
-			p.unavailableOfferings.MarkUnavailable(ctx, AllocationFailureReason, instanceType.Name, zone, karpv1.CapacityTypeSpot)
+			p.unavailableOfferings.MarkUnavailableWithTTL(ctx, AllocationFailureReason, instanceType.Name, zone, karpv1.CapacityTypeOnDemand, AllocationFailureTTL)
+			p.unavailableOfferings.MarkUnavailableWithTTL(ctx, AllocationFailureReason, instanceType.Name, zone, karpv1.CapacityTypeSpot, AllocationFailureTTL)
 		}
 
 		return fmt.Errorf("unable to allocate resources with selected VM size (%s). (will try a different VM size to fulfill your request)", instanceType.Name)
@@ -721,7 +722,7 @@ func (p *DefaultProvider) handleResponseErrors(ctx context.Context, instanceType
 	// OverconstrainedZonalAllocationFailure means that specific zone cannot accommodate the selected size and capacity combination.
 	if sdkerrors.OverconstrainedZonalAllocationFailureOccurred(err) {
 		log.FromContext(ctx).WithValues("zone", zone, "capacity-type", capacityType, "vm size", instanceType.Name).Error(err, "")
-		p.unavailableOfferings.MarkUnavailable(ctx, OverconstrainedZonalAllocationFailureReason, instanceType.Name, zone, capacityType)
+		p.unavailableOfferings.MarkUnavailableWithTTL(ctx, OverconstrainedZonalAllocationFailureReason, instanceType.Name, zone, capacityType, AllocationFailureTTL)
 
 		return fmt.Errorf("unable to allocate resources in the selected zone (%s) with %s capacity type and %s VM size. (will try a different zone, capacity type or VM size to fulfill your request)", zone, capacityType, instanceType.Name)
 	}
@@ -733,7 +734,7 @@ func (p *DefaultProvider) handleResponseErrors(ctx context.Context, instanceType
 			if getOfferingCapacityType(offering) != capacityType {
 				continue
 			}
-			p.unavailableOfferings.MarkUnavailable(ctx, SKUNotAvailableReason, instanceType.Name, getOfferingZone(offering), capacityType)
+			p.unavailableOfferings.MarkUnavailableWithTTL(ctx, SKUNotAvailableReason, instanceType.Name, getOfferingZone(offering), capacityType, AllocationFailureTTL)
 		}
 
 		return fmt.Errorf("unable to allocate resources in all zones with %s capacity type and %s VM size. (will try a different capacity type or VM size to fulfill your request)", capacityType, instanceType.Name)

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -18,8 +18,14 @@ package instance
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
+	sdkerrors "github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/karpenter-provider-azure/pkg/cache"
@@ -230,5 +236,269 @@ func TestCreateVMFromQueryResponseData(t *testing.T) {
 		if err != nil {
 			assert.Equal(t, c.expectedError, err.Error(), c.testName)
 		}
+	}
+}
+
+const (
+	responseErrorTestInstanceName = "Standard_D2s_v3"
+	testZone1                     = "westus-1"
+	testZone2                     = "westus-2"
+	testZone3                     = "westus-3"
+)
+
+type responseErrorTestCase struct {
+	testName                                string
+	instanceType                            *cloudprovider.InstanceType
+	zone                                    string
+	capacityType                            string
+	responseErr                             error
+	expectedErr                             error
+	expectedUnavailableOfferingsInformation []offeringToCheck
+	expectedAvailableOfferingsInformation   []offeringToCheck
+}
+
+// createOfferingType creates a struct with zone and capacity type for defining instance type offerings
+func createOfferingType(zone, capacityType string) struct{ zone, capacityType string } {
+	return struct{ zone, capacityType string }{
+		zone:         zone,
+		capacityType: capacityType,
+	}
+}
+
+func createInstanceType(offerings ...struct{ zone, capacityType string }) *cloudprovider.InstanceType {
+	it := &cloudprovider.InstanceType{
+		Name:      responseErrorTestInstanceName,
+		Offerings: []*cloudprovider.Offering{},
+	}
+
+	for _, o := range offerings {
+		it.Offerings = append(it.Offerings, &cloudprovider.Offering{
+			Requirements: scheduling.NewRequirements(
+				scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, o.capacityType),
+				scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, o.zone),
+			),
+		})
+	}
+
+	return it
+}
+
+type offeringToCheck struct {
+	instanceTypeName string
+	zone             string
+	capacityType     string
+}
+
+func offeringInformation(zone, capacityType string) offeringToCheck {
+	return offeringToCheck{
+		instanceTypeName: responseErrorTestInstanceName,
+		zone:             zone,
+		capacityType:     capacityType,
+	}
+}
+
+func createResponseError(errorCode, errorMessage string) error {
+	errorBody := fmt.Sprintf(`{"error": {"code": "%s", "message": "%s"}}`, errorCode, errorMessage)
+	return &azcore.ResponseError{
+		ErrorCode: errorCode,
+		RawResponse: &http.Response{
+			Body: io.NopCloser(strings.NewReader(errorBody)),
+		},
+	}
+}
+
+func TestHandleResponseErrors(t *testing.T) {
+	testCases := []responseErrorTestCase{
+		{
+			testName:                                "Response error is nil",
+			instanceType:                            &cloudprovider.InstanceType{},
+			zone:                                    "",
+			capacityType:                            karpv1.CapacityTypeOnDemand,
+			responseErr:                             nil,
+			expectedErr:                             nil,
+			expectedUnavailableOfferingsInformation: []offeringToCheck{},
+		},
+		{
+			testName:     "Low priority quota has been reached",
+			instanceType: &cloudprovider.InstanceType{},
+			zone:         testZone2,
+			capacityType: karpv1.CapacityTypeSpot,
+			responseErr:  createResponseError(sdkerrors.OperationNotAllowed, sdkerrors.LowPriorityQuotaExceededTerm),
+			expectedErr:  fmt.Errorf("this subscription has reached the regional vCPU quota for spot (LowPriorityQuota). To scale beyond this limit, please review the quota increase process here: https://docs.microsoft.com/en-us/azure/azure-portal/supportability/low-priority-quota"),
+			expectedUnavailableOfferingsInformation: []offeringToCheck{
+				offeringInformation("", karpv1.CapacityTypeSpot),
+			},
+		},
+		{
+			testName: "SKU family quota has been reached",
+			instanceType: createInstanceType(
+				createOfferingType(testZone2, karpv1.CapacityTypeOnDemand),
+				createOfferingType(testZone3, karpv1.CapacityTypeOnDemand),
+			),
+			zone:         testZone2,
+			capacityType: karpv1.CapacityTypeOnDemand,
+			responseErr:  createResponseError(sdkerrors.OperationNotAllowed, sdkerrors.SKUFamilyQuotaExceededTerm),
+			expectedErr:  fmt.Errorf("subscription level %s vCPU quota for %s has been reached (may try provision an alternative instance type)", karpv1.CapacityTypeOnDemand, responseErrorTestInstanceName),
+			expectedUnavailableOfferingsInformation: []offeringToCheck{
+				offeringInformation(testZone2, karpv1.CapacityTypeOnDemand),
+				offeringInformation(testZone3, karpv1.CapacityTypeOnDemand),
+			},
+		},
+		{
+			testName: "SKU family quota 0 CPUs",
+			instanceType: createInstanceType(
+				createOfferingType(testZone2, karpv1.CapacityTypeOnDemand),
+				createOfferingType(testZone3, karpv1.CapacityTypeOnDemand),
+			),
+			zone:         testZone2,
+			capacityType: karpv1.CapacityTypeOnDemand,
+			responseErr:  createResponseError(sdkerrors.OperationNotAllowed, "Family Cores quota Current Limit: 0"),
+			expectedErr:  fmt.Errorf("subscription level %s vCPU quota for %s has been reached (may try provision an alternative instance type)", karpv1.CapacityTypeOnDemand, responseErrorTestInstanceName),
+			expectedUnavailableOfferingsInformation: []offeringToCheck{
+				offeringInformation(testZone2, karpv1.CapacityTypeOnDemand),
+				offeringInformation(testZone3, karpv1.CapacityTypeOnDemand),
+			},
+		},
+		{
+			testName: "SKU not available for spot",
+			instanceType: createInstanceType(
+				createOfferingType(testZone2, karpv1.CapacityTypeOnDemand),
+				createOfferingType(testZone3, karpv1.CapacityTypeSpot),
+			),
+			zone:         testZone2,
+			capacityType: karpv1.CapacityTypeSpot,
+			responseErr:  createResponseError(sdkerrors.SKUNotAvailableErrorCode, ""),
+			expectedErr:  fmt.Errorf("the requested SKU is unavailable for instance type %s in zone %s with capacity type %s, for more details please visit: https://aka.ms/azureskunotavailable", responseErrorTestInstanceName, testZone2, karpv1.CapacityTypeSpot),
+			expectedUnavailableOfferingsInformation: []offeringToCheck{
+				offeringInformation(testZone3, karpv1.CapacityTypeSpot),
+			},
+			expectedAvailableOfferingsInformation: []offeringToCheck{
+				offeringInformation(testZone2, karpv1.CapacityTypeOnDemand),
+			},
+		},
+		{
+			testName: "SKU not available for on-demand",
+			instanceType: createInstanceType(
+				createOfferingType(testZone2, karpv1.CapacityTypeOnDemand),
+				createOfferingType(testZone3, karpv1.CapacityTypeSpot),
+			),
+			zone:         testZone2,
+			capacityType: karpv1.CapacityTypeOnDemand,
+			responseErr:  createResponseError(sdkerrors.SKUNotAvailableErrorCode, ""),
+			expectedErr:  fmt.Errorf("the requested SKU is unavailable for instance type %s in zone %s with capacity type %s, for more details please visit: https://aka.ms/azureskunotavailable", responseErrorTestInstanceName, testZone2, karpv1.CapacityTypeOnDemand),
+			expectedUnavailableOfferingsInformation: []offeringToCheck{
+				offeringInformation(testZone2, karpv1.CapacityTypeOnDemand),
+			},
+			expectedAvailableOfferingsInformation: []offeringToCheck{
+				offeringInformation(testZone3, karpv1.CapacityTypeSpot),
+			},
+		},
+		{
+			testName: "Zonal allocation failure",
+			instanceType: createInstanceType(
+				createOfferingType(testZone2, karpv1.CapacityTypeOnDemand),
+				createOfferingType(testZone2, karpv1.CapacityTypeSpot),
+				createOfferingType(testZone3, karpv1.CapacityTypeSpot),
+			),
+			zone:         testZone2,
+			capacityType: karpv1.CapacityTypeOnDemand,
+			responseErr:  createResponseError(sdkerrors.ZoneAllocationFailed, ""),
+			expectedErr:  fmt.Errorf("unable to allocate resources in the selected zone (%s). (will try a different zone to fulfill your request)", testZone2),
+			expectedUnavailableOfferingsInformation: []offeringToCheck{
+				offeringInformation(testZone2, karpv1.CapacityTypeOnDemand),
+				offeringInformation(testZone2, karpv1.CapacityTypeSpot),
+			},
+			expectedAvailableOfferingsInformation: []offeringToCheck{
+				offeringInformation(testZone3, karpv1.CapacityTypeSpot),
+			},
+		},
+		{
+			testName: "Allocation failure",
+			instanceType: createInstanceType(
+				createOfferingType(testZone1, karpv1.CapacityTypeSpot),
+				createOfferingType(testZone2, karpv1.CapacityTypeOnDemand),
+				createOfferingType(testZone3, karpv1.CapacityTypeSpot),
+			),
+			zone:         testZone2,
+			capacityType: karpv1.CapacityTypeOnDemand,
+			responseErr:  createResponseError(sdkerrors.AllocationFailed, ""),
+			expectedErr:  fmt.Errorf("unable to allocate resources with selected VM size (%s). (will try a different VM size to fulfill your request)", responseErrorTestInstanceName),
+			expectedUnavailableOfferingsInformation: []offeringToCheck{
+				offeringInformation(testZone1, karpv1.CapacityTypeOnDemand),
+				offeringInformation(testZone1, karpv1.CapacityTypeSpot),
+				offeringInformation(testZone2, karpv1.CapacityTypeOnDemand),
+				offeringInformation(testZone2, karpv1.CapacityTypeSpot),
+				offeringInformation(testZone3, karpv1.CapacityTypeOnDemand),
+				offeringInformation(testZone3, karpv1.CapacityTypeSpot),
+			},
+		},
+		{
+			testName: "Overconstrained zonal allocation failure",
+			instanceType: createInstanceType(
+				createOfferingType(testZone2, karpv1.CapacityTypeOnDemand),
+				createOfferingType(testZone3, karpv1.CapacityTypeSpot),
+			),
+			zone:         testZone2,
+			capacityType: karpv1.CapacityTypeOnDemand,
+			responseErr:  createResponseError(sdkerrors.OverconstrainedZonalAllocationRequest, ""),
+			expectedErr:  fmt.Errorf("unable to allocate resources in the selected zone (%s) with %s capacity type and %s VM size. (will try a different zone, capacity type or VM size to fulfill your request)", testZone2, karpv1.CapacityTypeOnDemand, responseErrorTestInstanceName),
+			expectedUnavailableOfferingsInformation: []offeringToCheck{
+				offeringInformation(testZone2, karpv1.CapacityTypeOnDemand),
+			},
+			expectedAvailableOfferingsInformation: []offeringToCheck{
+				offeringInformation(testZone3, karpv1.CapacityTypeSpot),
+			},
+		},
+		{
+			testName: "Overconstrained allocation failure",
+			instanceType: createInstanceType(
+				createOfferingType(testZone1, karpv1.CapacityTypeOnDemand),
+				createOfferingType(testZone2, karpv1.CapacityTypeOnDemand),
+				createOfferingType(testZone3, karpv1.CapacityTypeSpot),
+			),
+			zone:         testZone2,
+			capacityType: karpv1.CapacityTypeOnDemand,
+			responseErr:  createResponseError(sdkerrors.OverconstrainedAllocationRequest, ""),
+			expectedErr:  fmt.Errorf("unable to allocate resources in all zones with %s capacity type and %s VM size. (will try a different capacity type or VM size to fulfill your request)", karpv1.CapacityTypeOnDemand, responseErrorTestInstanceName),
+			expectedUnavailableOfferingsInformation: []offeringToCheck{
+				offeringInformation(testZone2, karpv1.CapacityTypeOnDemand),
+				offeringInformation(testZone1, karpv1.CapacityTypeOnDemand),
+			},
+			expectedAvailableOfferingsInformation: []offeringToCheck{
+				offeringInformation(testZone3, karpv1.CapacityTypeSpot),
+			},
+		},
+		{
+			testName: "Regional quota exceeded",
+			instanceType: createInstanceType(
+				createOfferingType(testZone2, karpv1.CapacityTypeOnDemand),
+				createOfferingType(testZone3, karpv1.CapacityTypeSpot),
+			),
+			zone:         testZone2,
+			capacityType: karpv1.CapacityTypeOnDemand,
+			responseErr:  createResponseError(sdkerrors.OperationNotAllowed, sdkerrors.RegionalQuotaExceededTerm),
+			expectedErr:  cloudprovider.NewInsufficientCapacityError(fmt.Errorf("regional on-demand vCPU quota limit for subscription has been reached. To scale beyond this limit, please review the quota increase process here: https://learn.microsoft.com/en-us/azure/quotas/regional-quota-requests")),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			testProvider := &DefaultProvider{
+				unavailableOfferings: cache.NewUnavailableOfferings(),
+			}
+
+			err := testProvider.handleResponseErrors(context.Background(), tc.instanceType, tc.zone, tc.capacityType, tc.responseErr)
+			assert.Equal(t, tc.expectedErr, err)
+			for _, info := range tc.expectedUnavailableOfferingsInformation {
+				if !testProvider.unavailableOfferings.IsUnavailable(info.instanceTypeName, info.zone, info.capacityType) {
+					t.Errorf("Expected offering %s in zone %s with capacity type %s to be marked as unavailable", info.instanceTypeName, info.zone, info.capacityType)
+				}
+			}
+			for _, info := range tc.expectedAvailableOfferingsInformation {
+				if testProvider.unavailableOfferings.IsUnavailable(info.instanceTypeName, info.zone, info.capacityType) {
+					t.Errorf("Expected offering %s in zone %s with capacity type %s to not be marked as unavailable", info.instanceTypeName, info.zone, info.capacityType)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->


**Description**
Adjusts TTL for unavailable offerings when allocation related failures are reported back by Azure, adds unit tests

**How was this change tested?**

* [x] Unit Tests
* [x] E2E: https://github.com/Azure/karpenter-provider-azure/actions/runs/15224626927

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adjusts TTL for unavailable offerings when Azure reports Allocation related errors from 3 minutes to 15 minutes.
```
