### PR TITLE
fix: Fix getAKSClusterID function

### DIFF
--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -26,6 +26,7 @@ import (
 	"math/rand"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -175,11 +176,25 @@ func FromContext(ctx context.Context) *Options {
 	return retval.(*Options)
 }
 
+var clusterIDRegex = regexp.MustCompile(`^([^.-]+(?:-[^.-]+)*?)(?:-[^.-]+)?\.`)
+
 // getAKSClusterID returns cluster ID based on the DNS prefix of the cluster.
-// The logic comes from AgentBaker and other places, originally from aks-engine
-// with the additional assumption of DNS prefix being the first 33 chars of FQDN
 func getAKSClusterID(apiServerFQDN string) string {
-	dnsPrefix := apiServerFQDN[:33]
+	// TODO: This doesn't work for clusters with BYO private dns zone with fqdnSubdomain. For those clusters
+	//       we need to hash the emptyString to get the cluster ID (that's what AKS RP does), but
+	//       you can't actually tell by examining a fqdn record if it's using dnsPrefix or fqdnSubdomain.
+	//       You ALMOST could, by looking for <dnsprefix>-<8 character random string>.privatelink.<region>.azmk8s.io, but
+	//       There's nothing stopping users from making their dns subdomain with an 8 character random string in the same
+	//       location that AKS put it.
+	//       I think it would be cleaner to just read this value directly from the nsg in the MC RG, rather than
+	//       trying to recompute it.
+	match := clusterIDRegex.FindStringSubmatch(apiServerFQDN)
+
+	var dnsPrefix string
+	if len(match) > 1 {
+		dnsPrefix = match[1]
+	}
+
 	h := fnv.New64a()
 	h.Write([]byte(dnsPrefix))
 	r := rand.New(rand.NewSource(int64(h.Sum64()))) //nolint:gosec

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Options", func() {
 	Context("Env Vars", func() {
 		It("should correctly fallback to env vars when CLI flags aren't set", func() {
 			os.Setenv("CLUSTER_NAME", "env-cluster")
-			os.Setenv("CLUSTER_ENDPOINT", "https://environment-cluster-id-value-for-testing")
+			os.Setenv("CLUSTER_ENDPOINT", "https://environment-cluster-id-value-for-testing-00000000.hcp.westus2.staging.azmk8s.io")
 			os.Setenv("VM_MEMORY_OVERHEAD_PERCENT", "0.3")
 			os.Setenv("KUBELET_BOOTSTRAP_TOKEN", "env-bootstrap-token")
 			os.Setenv("SSH_PUBLIC_KEY", "env-ssh-public-key")
@@ -125,9 +125,9 @@ var _ = Describe("Options", func() {
 			Expect(err).ToNot(HaveOccurred())
 			expectedOpts := test.Options(test.OptionsFields{
 				ClusterName:                    lo.ToPtr("env-cluster"),
-				ClusterEndpoint:                lo.ToPtr("https://environment-cluster-id-value-for-testing"),
+				ClusterEndpoint:                lo.ToPtr("https://environment-cluster-id-value-for-testing-00000000.hcp.westus2.staging.azmk8s.io"),
 				VMMemoryOverheadPercent:        lo.ToPtr(0.3),
-				ClusterID:                      lo.ToPtr("46593302"),
+				ClusterID:                      lo.ToPtr("87594193"), // computed manually via: https://go.dev/play/p/VapArZu12cy
 				KubeletClientTLSBootstrapToken: lo.ToPtr("env-bootstrap-token"),
 				LinuxAdminUsername:             lo.ToPtr("customadminusername"),
 				SSHPublicKey:                   lo.ToPtr("env-ssh-public-key"),
@@ -500,5 +500,34 @@ var _ = Describe("Options", func() {
 			)
 			Expect(err).ToNot(HaveOccurred())
 		})
+	})
+
+	Context("Cluster ID processing", func() {
+		DescribeTable(
+			"should generate a cluster ID from the cluster endpoint",
+			func(endpoint string, expectedHash string) {
+				err := opts.Parse(
+					fs,
+					"--cluster-name", "my-name",
+					"--cluster-endpoint", endpoint,
+					"--kubelet-bootstrap-token", "flag-bootstrap-token",
+					"--ssh-public-key", "flag-ssh-public-key",
+					"--vnet-subnet-id", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub",
+					"--network-plugin", "azure",
+					"--network-plugin-mode", "overlay",
+					"--vnet-guid", "a519e60a-cac0-40b2-b883-084477fe6f5c",
+					"--node-resource-group", "my-node-rg",
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(opts.ClusterID).To(Equal(expectedHash))
+			},
+			// Note: The expected hashes here have been computed manually (I used this Go playground: https://go.dev/play/p/iyS4Eim8jZV)
+			Entry("Simple dnsPrefix", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io", "36684763"),
+			Entry("Custom dnsPrefix", "https://tooshort-nx4kgdbw.hcp.westcentralus.azmk8s.io", "18484614"),
+			Entry("Default dnsPrefix", "https://matthchr-t-matthchr-temp2-82acd5-3lxfm0a4.hcp.westcentralus.azmk8s.io", "42705019"),
+			Entry("Basic private cluster", "https://foo-bar-000000000000.e429a643-530a-4380-b704-90b3ae449e07.privatelink.eastus.azmk8s.io", "23262821"),
+			Entry("Private cluster in subzone", "https://foo-bar-000000000000.e429a643-530a-4380-b704-90b3ae449e07.mysubzone.privatelink.eastus.azmk8s.io", "23262821"),
+		)
 	})
 })


### PR DESCRIPTION
DNSPrefix is not always 33 characters

This fixes a bug which could cause the ClusterID to be created/parsed incorrectly when the cluster has a non-default DNS prefix, resulting in incorrect azure.json entries in standalone mode (no impact on managed Karpenter via NAP)


**How was this change tested?**

* Unit tests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix bug which could cause the ClusterID to be created/parsed incorrectly when the cluster has a non-default DNS prefix, resulting in incorrect azure.json entries in standalone mode (no impact on managed Karpenter via NAP)
```
