### PR TITLE
chore: add new NSG provider

### DIFF
--- a/pkg/fake/networksecuritygroupapi.go
+++ b/pkg/fake/networksecuritygroupapi.go
@@ -1,0 +1,105 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/networksecuritygroup"
+	"github.com/samber/lo"
+)
+
+type NetworkSecurityGroupBevhavior struct {
+	NSGs sync.Map
+}
+
+// assert that the fake implements the interface
+var _ networksecuritygroup.API = &NetworkSecurityGroupAPI{}
+
+type NetworkSecurityGroupAPI struct {
+	NetworkSecurityGroupBevhavior
+}
+
+// Reset must be called between tests otherwise tests will pollute each other.
+func (api *NetworkSecurityGroupAPI) Reset() {
+	api.NSGs.Range(func(k, v any) bool {
+		api.NSGs.Delete(k)
+		return true
+	})
+}
+
+// Get implements networksecuritygroup.API.
+func (api *NetworkSecurityGroupAPI) Get(
+	ctx context.Context,
+	resourceGroupName string,
+	securityGroupName string,
+	options *armnetwork.SecurityGroupsClientGetOptions,
+) (armnetwork.SecurityGroupsClientGetResponse, error) {
+	id := MakeNetworkSecurityGroupID(resourceGroupName, securityGroupName)
+	nsg, ok := api.NSGs.Load(id)
+	if !ok {
+		return armnetwork.SecurityGroupsClientGetResponse{}, fmt.Errorf("not found")
+	}
+	return armnetwork.SecurityGroupsClientGetResponse{
+		SecurityGroup: nsg.(armnetwork.SecurityGroup),
+	}, nil
+}
+
+// NewListPager implements networksecuritygroup.API.
+func (api *NetworkSecurityGroupAPI) NewListPager(resourceGroupName string, options *armnetwork.SecurityGroupsClientListOptions) *runtime.Pager[armnetwork.SecurityGroupsClientListResponse] {
+	pagingHandler := runtime.PagingHandler[armnetwork.SecurityGroupsClientListResponse]{
+		More: func(page armnetwork.SecurityGroupsClientListResponse) bool {
+			return false // TODO: It might be ideal if we had a MockPager which sometimes simulated multiple pages of results to ensure we handle that correctly
+		},
+		Fetcher: func(ctx context.Context, _ *armnetwork.SecurityGroupsClientListResponse) (armnetwork.SecurityGroupsClientListResponse, error) {
+			output := armnetwork.SecurityGroupListResult{
+				Value: []*armnetwork.SecurityGroup{},
+			}
+			api.NSGs.Range(func(key, value any) bool {
+				cast := value.(armnetwork.SecurityGroup)
+				output.Value = append(output.Value, &cast)
+
+				return true
+			})
+
+			// Sort the result according to ID so that we have a stable base to write asserts upon
+			sort.Slice(output.Value, func(i, j int) bool {
+				l := output.Value[i]
+				r := output.Value[j]
+
+				return lo.FromPtr(l.ID) < lo.FromPtr(r.ID)
+			})
+
+			return armnetwork.SecurityGroupsClientListResponse{
+				SecurityGroupListResult: output,
+			}, nil
+		},
+	}
+	return runtime.NewPager(pagingHandler)
+}
+
+func MakeNetworkSecurityGroupID(resourceGroupName, networkSecurityGroupName string) string {
+	const subscriptionID = "12345678-1234-1234-1234-123456789012" // TODO: This is duplicated from other places, we should consider putting it in a common place
+	const idFormat = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkSecurityGroups/%s"
+
+	return fmt.Sprintf(idFormat, subscriptionID, resourceGroupName, networkSecurityGroupName)
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -56,6 +56,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/kubernetesversion"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/launchtemplate"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/networksecuritygroup"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 	armopts "github.com/Azure/karpenter-provider-azure/pkg/utils/opts"
@@ -156,11 +157,16 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		cache.New(loadbalancer.LoadBalancersCacheTTL, azurecache.DefaultCleanupInterval),
 		options.FromContext(ctx).NodeResourceGroup,
 	)
+	networkSecurityGroupProvider := networksecuritygroup.NewProvider(
+		azClient.NetworkSecurityGroupsClient,
+		options.FromContext(ctx).NodeResourceGroup,
+	)
 	instanceProvider := instance.NewDefaultProvider(
 		azClient,
 		instanceTypeProvider,
 		launchTemplateProvider,
 		loadBalancerProvider,
+		networkSecurityGroupProvider,
 		unavailableOfferingsCache,
 		azConfig.Location,
 		options.FromContext(ctx).NodeResourceGroup,

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -44,6 +44,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instancetype"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/launchtemplate"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/networksecuritygroup"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 )
 
@@ -95,15 +96,16 @@ type Provider interface {
 var _ Provider = (*DefaultProvider)(nil)
 
 type DefaultProvider struct {
-	location               string
-	azClient               *AZClient
-	instanceTypeProvider   instancetype.Provider
-	launchTemplateProvider *launchtemplate.Provider
-	loadBalancerProvider   *loadbalancer.Provider
-	resourceGroup          string
-	subscriptionID         string
-	unavailableOfferings   *cache.UnavailableOfferings
-	provisionMode          string
+	location                     string
+	azClient                     *AZClient
+	instanceTypeProvider         instancetype.Provider
+	launchTemplateProvider       *launchtemplate.Provider
+	loadBalancerProvider         *loadbalancer.Provider
+	networkSecurityGroupProvider *networksecuritygroup.Provider
+	resourceGroup                string
+	subscriptionID               string
+	unavailableOfferings         *cache.UnavailableOfferings
+	provisionMode                string
 
 	vmListQuery, nicListQuery string
 }
@@ -113,6 +115,7 @@ func NewDefaultProvider(
 	instanceTypeProvider instancetype.Provider,
 	launchTemplateProvider *launchtemplate.Provider,
 	loadBalancerProvider *loadbalancer.Provider,
+	networkSecurityGroupProvider *networksecuritygroup.Provider,
 	offeringsCache *cache.UnavailableOfferings,
 	location string,
 	resourceGroup string,
@@ -120,15 +123,16 @@ func NewDefaultProvider(
 	provisionMode string,
 ) *DefaultProvider {
 	return &DefaultProvider{
-		azClient:               azClient,
-		instanceTypeProvider:   instanceTypeProvider,
-		launchTemplateProvider: launchTemplateProvider,
-		loadBalancerProvider:   loadBalancerProvider,
-		location:               location,
-		resourceGroup:          resourceGroup,
-		subscriptionID:         subscriptionID,
-		unavailableOfferings:   offeringsCache,
-		provisionMode:          provisionMode,
+		azClient:                     azClient,
+		instanceTypeProvider:         instanceTypeProvider,
+		launchTemplateProvider:       launchTemplateProvider,
+		loadBalancerProvider:         loadBalancerProvider,
+		networkSecurityGroupProvider: networkSecurityGroupProvider,
+		location:                     location,
+		resourceGroup:                resourceGroup,
+		subscriptionID:               subscriptionID,
+		unavailableOfferings:         offeringsCache,
+		provisionMode:                provisionMode,
 
 		vmListQuery:  GetVMListQueryBuilder(resourceGroup).String(),
 		nicListQuery: GetNICListQueryBuilder(resourceGroup).String(),

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -89,7 +89,7 @@ func TestGetPriorityCapacityAndInstanceType(t *testing.T) {
 			expectedPriority:     karpv1.CapacityTypeOnDemand,
 		},
 	}
-	provider := NewDefaultProvider(nil, nil, nil, nil, cache.NewUnavailableOfferings(),
+	provider := NewDefaultProvider(nil, nil, nil, nil, nil, cache.NewUnavailableOfferings(),
 		"westus-2",
 		"MC_xxxxx_yyyy-region",
 		"0000000-0000-0000-0000-0000000000",

--- a/pkg/providers/networksecuritygroup/networksecuritygroup.go
+++ b/pkg/providers/networksecuritygroup/networksecuritygroup.go
@@ -1,0 +1,104 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networksecuritygroup
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type API interface {
+	Get(ctx context.Context, resourceGroupName string, securityGroupName string, options *armnetwork.SecurityGroupsClientGetOptions) (armnetwork.SecurityGroupsClientGetResponse, error)
+	NewListPager(resourceGroupName string, options *armnetwork.SecurityGroupsClientListOptions) *runtime.Pager[armnetwork.SecurityGroupsClientListResponse]
+}
+
+var managedNSGRegex = regexp.MustCompile(`(?i)^aks-agentpool-\d{8}-nsg$`)
+
+type Provider struct {
+	nsgAPI        API
+	resourceGroup string
+
+	nsg *armnetwork.SecurityGroup
+	mu  sync.Mutex
+}
+
+// NewProvider creates a new LoadBalancer provider
+func NewProvider(nsgAPI API, resourceGroup string) *Provider {
+	return &Provider{
+		nsgAPI:        nsgAPI,
+		resourceGroup: resourceGroup,
+	}
+}
+
+func (p *Provider) ManagedNetworkSecurityGroup(ctx context.Context) (*armnetwork.SecurityGroup, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// If we've already found the managed NSG, returned the cached result
+	if p.nsg != nil {
+		return p.nsg, nil
+	}
+
+	nsgs, err := p.loadFromAzure(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only consider the NSGs we actually care about
+	managedNSGs := lo.Filter(nsgs, isClusterNSG)
+	log.FromContext(ctx).Info(fmt.Sprintf("Found %d NSGs of interest", len(managedNSGs)))
+
+	if len(managedNSGs) == 0 {
+		return nil, fmt.Errorf("couldn't find managed NSG")
+	}
+	if len(managedNSGs) > 1 {
+		return nil, fmt.Errorf("found multiple NSGs: %s", strings.Join(lo.Map(managedNSGs, func(nsg *armnetwork.SecurityGroup, _ int) string { return lo.FromPtr(nsg.Name) }), ","))
+	}
+
+	p.nsg = managedNSGs[0]
+	return p.nsg, nil
+}
+
+func (p *Provider) loadFromAzure(ctx context.Context) ([]*armnetwork.SecurityGroup, error) {
+	log.FromContext(ctx).Info(fmt.Sprintf("Querying nsgs in resource group %s", p.resourceGroup))
+
+	pager := p.nsgAPI.NewListPager(p.resourceGroup, nil)
+
+	var nsgs []*armnetwork.SecurityGroup
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get next nsg page: %w", err)
+		}
+		nsgs = append(nsgs, page.Value...)
+	}
+
+	return nsgs, nil
+}
+
+func isClusterNSG(nsg *armnetwork.SecurityGroup, _ int) bool {
+	name := lo.FromPtr(nsg.Name)
+	return managedNSGRegex.MatchString(name)
+}

--- a/pkg/providers/networksecuritygroup/suite_test.go
+++ b/pkg/providers/networksecuritygroup/suite_test.go
@@ -1,0 +1,94 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networksecuritygroup_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/fake"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/networksecuritygroup"
+	"github.com/Azure/karpenter-provider-azure/pkg/test"
+)
+
+var ctx context.Context
+var stop context.CancelFunc
+
+var resourceGroup string
+var fakeNetworkSecurityGroupsAPI *fake.NetworkSecurityGroupAPI
+var networkSecurityGroupProvider *networksecuritygroup.Provider
+
+func TestNetworkSecurityGroupProvider(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Providers/NetworkSecurityGroup")
+}
+
+var _ = BeforeSuite(func() {
+	ctx, stop = context.WithCancel(ctx)
+
+	fakeNetworkSecurityGroupsAPI = &fake.NetworkSecurityGroupAPI{}
+	resourceGroup = "test-rg"
+})
+
+var _ = AfterSuite(func() {
+	stop()
+})
+
+var _ = BeforeEach(func() {
+	networkSecurityGroupProvider = networksecuritygroup.NewProvider(fakeNetworkSecurityGroupsAPI, resourceGroup)
+	fakeNetworkSecurityGroupsAPI.Reset()
+})
+
+var _ = Describe("NetworkSecurityGroup Provider", func() {
+	It("should return only well-known network security groups", func() {
+		standardNSG := test.MakeNetworkSecurityGroup(resourceGroup, "aks-agentpool-12345678-nsg")
+		otherNSG := test.MakeNetworkSecurityGroup(resourceGroup, "some-nsg")
+
+		fakeNetworkSecurityGroupsAPI.NSGs.Store(standardNSG.ID, standardNSG)
+		fakeNetworkSecurityGroupsAPI.NSGs.Store(otherNSG.ID, otherNSG)
+
+		nsg, err := networkSecurityGroupProvider.ManagedNetworkSecurityGroup(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nsg).ToNot(BeNil())
+		Expect(*nsg).To(Equal(standardNSG))
+	})
+
+	It("should error if it cannot find the managed network security group", func() {
+		otherNSG := test.MakeNetworkSecurityGroup(resourceGroup, "some-nsg")
+
+		fakeNetworkSecurityGroupsAPI.NSGs.Store(otherNSG.ID, otherNSG)
+
+		_, err := networkSecurityGroupProvider.ManagedNetworkSecurityGroup(ctx)
+		Expect(err).To(MatchError("couldn't find managed NSG"))
+	})
+
+	It("should error if it finds multiple managed network security groups", func() {
+		standardNSG1 := test.MakeNetworkSecurityGroup(resourceGroup, "aks-agentpool-12345678-nsg")
+		standardNSG2 := test.MakeNetworkSecurityGroup(resourceGroup, "aks-agentpool-23456789-nsg")
+
+		fakeNetworkSecurityGroupsAPI.NSGs.Store(standardNSG1.ID, standardNSG1)
+		fakeNetworkSecurityGroupsAPI.NSGs.Store(standardNSG2.ID, standardNSG2)
+
+		_, err := networkSecurityGroupProvider.ManagedNetworkSecurityGroup(ctx)
+		Expect(err).To(MatchError("found multiple NSGs: aks-agentpool-12345678-nsg,aks-agentpool-23456789-nsg"))
+	})
+})

--- a/pkg/test/networksecuritygroup.go
+++ b/pkg/test/networksecuritygroup.go
@@ -1,0 +1,42 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"github.com/Azure/karpenter-provider-azure/pkg/fake"
+	"github.com/samber/lo"
+)
+
+func MakeNetworkSecurityGroup(resourceGroup string, name string) armnetwork.SecurityGroup {
+	nsgID := fake.MakeNetworkSecurityGroupID(resourceGroup, name)
+
+	result := armnetwork.SecurityGroup{
+		ID:   &nsgID,
+		Name: &name,
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{
+			SecurityRules: []*armnetwork.SecurityRule{
+				{
+					Name: lo.ToPtr("k8s-azure-lb_allow_IPv4_0000"),
+					// TODO: Not filling this in now, can later if we need it
+				},
+			},
+		},
+	}
+
+	return result
+}


### PR DESCRIPTION
This provider discovers the AKS Managed NSG and caches its details for the life of the process.

This is a prerequisite for fixing #562.

Note that since this provider is not actually called in the real production code at the moment, it doesn't do anything yet.

**How was this change tested?**

* Unit tests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
