### PR TITLE
fix: Attach Managed NSG to NIC when in BYO VNET mode

### DIFF
--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -102,7 +102,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.NetworkPolicy, "network-policy", env.WithDefaultString("NETWORK_POLICY", ""), "The network policy used by the cluster.")
 	fs.StringVar(&o.NetworkDataplane, "network-dataplane", env.WithDefaultString("NETWORK_DATAPLANE", "cilium"), "The network dataplane used by the cluster.")
 	fs.StringVar(&o.VnetGUID, "vnet-guid", env.WithDefaultString("VNET_GUID", ""), "The vnet guid of the clusters vnet, only required by azure cni with overlay + byo vnet")
-	fs.StringVar(&o.SubnetID, "vnet-subnet-id", env.WithDefaultString("VNET_SUBNET_ID", ""), "The default subnet ID to use for new nodes. This must be a valid ARM resource ID for subnet that does not overlap with the service CIDR or the pod CIDR.")
+	fs.StringVar(&o.SubnetID, "vnet-subnet-id", env.WithDefaultString("VNET_SUBNET_ID", ""), "[REQUIRED] The default subnet ID to use for new nodes. This must be a valid ARM resource ID for subnet that does not overlap with the service CIDR or the pod CIDR.")
 	fs.Var(newNodeIdentitiesValue(env.WithDefaultString("NODE_IDENTITIES", ""), &o.NodeIdentities), "node-identities", "User assigned identities for nodes.")
 	fs.StringVar(&o.ProvisionMode, "provision-mode", env.WithDefaultString("PROVISION_MODE", consts.ProvisionModeAKSScriptless), "[UNSUPPORTED] The provision mode for the cluster.")
 	fs.StringVar(&o.NodeBootstrappingServerURL, "nodebootstrapping-server-url", env.WithDefaultString("NODEBOOTSTRAPPING_SERVER_URL", ""), "[UNSUPPORTED] The url for the node bootstrapping provider server.")

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -306,6 +306,14 @@ func (p *DefaultProvider) newNetworkInterfaceForVM(opts *createNICOptions) armne
 	if err := opts.InstanceType.Requirements.Compatible(skuAcceleratedNetworkingRequirements); err == nil {
 		enableAcceleratedNetworking = true
 	}
+
+	var nsgRef *armnetwork.SecurityGroup
+	if opts.NetworkSecurityGroupID != "" {
+		nsgRef = &armnetwork.SecurityGroup{
+			ID: &opts.NetworkSecurityGroupID,
+		}
+	}
+
 	nic := armnetwork.Interface{
 		Location: lo.ToPtr(p.location),
 		Properties: &armnetwork.InterfacePropertiesFormat{
@@ -320,6 +328,7 @@ func (p *DefaultProvider) newNetworkInterfaceForVM(opts *createNICOptions) armne
 					},
 				},
 			},
+			NetworkSecurityGroup:        nsgRef,
 			EnableAcceleratedNetworking: lo.ToPtr(enableAcceleratedNetworking),
 			EnableIPForwarding:          lo.ToPtr(false),
 		},
@@ -348,13 +357,14 @@ func GenerateResourceName(nodeClaimName string) string {
 }
 
 type createNICOptions struct {
-	NICName           string
-	BackendPools      *loadbalancer.BackendAddressPools
-	InstanceType      *corecloudprovider.InstanceType
-	LaunchTemplate    *launchtemplate.Template
-	NetworkPlugin     string
-	NetworkPluginMode string
-	MaxPods           int32
+	NICName                string
+	BackendPools           *loadbalancer.BackendAddressPools
+	InstanceType           *corecloudprovider.InstanceType
+	LaunchTemplate         *launchtemplate.Template
+	NetworkPlugin          string
+	NetworkPluginMode      string
+	MaxPods                int32
+	NetworkSecurityGroupID string
 }
 
 func (p *DefaultProvider) createNetworkInterface(ctx context.Context, opts *createNICOptions) (string, error) {
@@ -540,6 +550,7 @@ func (p *DefaultProvider) createVirtualMachine(ctx context.Context, opts *create
 // beginLaunchInstance starts the launch of a VM instance.
 // The returned VirtualMachinePromise must be called to gather any errors
 // that are retrieved during async provisioning, as well as to complete the provisioning process.
+// nolint: gocyclo
 func (p *DefaultProvider) beginLaunchInstance(
 	ctx context.Context,
 	nodeClass *v1beta1.AKSNodeClass,
@@ -567,6 +578,20 @@ func (p *DefaultProvider) beginLaunchInstance(
 	}
 	networkPlugin := options.FromContext(ctx).NetworkPlugin
 	networkPluginMode := options.FromContext(ctx).NetworkPluginMode
+
+	isAKSManagedVNET, err := utils.IsAKSManagedVNET(options.FromContext(ctx).NodeResourceGroup, launchTemplate.SubnetID)
+	if err != nil {
+		return nil, fmt.Errorf("checking if vnet is managed: %w", err)
+	}
+	var nsgID string
+	if !isAKSManagedVNET {
+		nsg, err := p.networkSecurityGroupProvider.ManagedNetworkSecurityGroup(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("getting managed network security group: %w", err)
+		}
+		nsgID = lo.FromPtr(nsg.ID)
+	}
+
 	// TODO: Not returning after launching this LRO because
 	// TODO: doing so would bypass the capacity and other errors that are currently handled by
 	// TODO: core pkg/controllers/nodeclaim/lifecycle/controller.go - in particular, there are metrics/events
@@ -574,13 +599,14 @@ func (p *DefaultProvider) beginLaunchInstance(
 	nicReference, err := p.createNetworkInterface(
 		ctx,
 		&createNICOptions{
-			NICName:           resourceName,
-			NetworkPlugin:     networkPlugin,
-			NetworkPluginMode: networkPluginMode,
-			MaxPods:           utils.GetMaxPods(nodeClass, networkPlugin, networkPluginMode),
-			LaunchTemplate:    launchTemplate,
-			BackendPools:      backendPools,
-			InstanceType:      instanceType,
+			NICName:                resourceName,
+			NetworkPlugin:          networkPlugin,
+			NetworkPluginMode:      networkPluginMode,
+			MaxPods:                utils.GetMaxPods(nodeClass, networkPlugin, networkPluginMode),
+			LaunchTemplate:         launchTemplate,
+			BackendPools:           backendPools,
+			InstanceType:           instanceType,
+			NetworkSecurityGroupID: nsgID,
 		},
 	)
 	if err != nil {

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -18,6 +18,7 @@ package instance_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -91,7 +92,6 @@ var _ = AfterSuite(func() {
 })
 
 var _ = Describe("InstanceProvider", func() {
-
 	var nodeClass *v1beta1.AKSNodeClass
 	var nodePool *karpv1.NodePool
 	var nodeClaim *karpv1.NodeClaim
@@ -138,7 +138,7 @@ var _ = Describe("InstanceProvider", func() {
 		ExpectCleanedUp(ctx, env.Client)
 	})
 
-	var ZonalAndNonZonalRegions = []TableEntry{
+	ZonalAndNonZonalRegions := []TableEntry{
 		Entry("zonal", azureEnv, cloudProvider),
 		Entry("non-zonal", azureEnvNonZonal, cloudProviderNonZonal),
 	}
@@ -198,7 +198,6 @@ var _ = Describe("InstanceProvider", func() {
 				"max-pods": "30",
 			}
 			ExpectKubeletFlags(azureEnv, customData, expectedFlags)
-
 		})
 		It("should include 1 ip config for Azure CNI Overlay", func() {
 			ctx = options.ToContext(
@@ -227,7 +226,6 @@ var _ = Describe("InstanceProvider", func() {
 				"max-pods": "250",
 			}
 			ExpectKubeletFlags(azureEnv, customData, expectedFlags)
-
 		})
 		It("should set the number of secondary ips equal to max pods (NodeSubnet)", func() {
 			nodeClass.Spec.MaxPods = lo.ToPtr(int32(11))
@@ -245,6 +243,7 @@ var _ = Describe("InstanceProvider", func() {
 			Expect(len(nic.Properties.IPConfigurations)).To(Equal(11))
 		})
 	})
+
 	It("should create VM and NIC with valid ARM tags", func() {
 		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 
@@ -291,6 +290,7 @@ var _ = Describe("InstanceProvider", func() {
 		Expect(len(interfaces)).To(Equal(1))
 		Expect(interfaces[0].Name).To(Equal(managedNic.Name))
 	})
+
 	It("should create VM with custom Linux admin username", func() {
 		customUsername := "customuser"
 		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{
@@ -316,5 +316,52 @@ var _ = Describe("InstanceProvider", func() {
 		Expect(vm.Properties.OSProfile.LinuxConfiguration.SSH.PublicKeys).To(HaveLen(1))
 		expectedPath := "/home/" + customUsername + "/.ssh/authorized_keys"
 		Expect(*vm.Properties.OSProfile.LinuxConfiguration.SSH.PublicKeys[0].Path).To(Equal(expectedPath))
+	})
+
+	It("should attach nsg to nic when in BYO VNET mode", func() {
+		ctx = options.ToContext(
+			ctx,
+			test.Options(test.OptionsFields{
+				SubnetID: lo.ToPtr("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/aks-vnet-12345678/subnets/aks-subnet"), // different RG
+			}))
+		nsg := test.MakeNetworkSecurityGroup(options.FromContext(ctx).NodeResourceGroup, "aks-agentpool-00000000-nsg")
+		azureEnv.NetworkSecurityGroupAPI.NSGs.Store(nsg.ID, nsg)
+
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+
+		pod := coretest.UnschedulablePod(coretest.PodOptions{})
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
+		ExpectScheduled(ctx, env.Client, pod)
+
+		Expect(azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+		nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop().Interface
+		Expect(nic).ToNot(BeNil())
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+
+		expectedNSGID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkSecurityGroups/aks-agentpool-%s-nsg", azureEnv.SubscriptionID, options.FromContext(ctx).NodeResourceGroup, options.FromContext(ctx).ClusterID)
+		Expect(nic.Properties.NetworkSecurityGroup).ToNot(BeNil())
+		Expect(lo.FromPtr(nic.Properties.NetworkSecurityGroup.ID)).To(Equal(expectedNSGID))
+	})
+
+	It("should attach nsg to nic when NodeClass VNET specified", func() {
+		nodeClass.Spec.VNETSubnetID = lo.ToPtr("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/aks-vnet-12345678/subnets/aks-subnet") // different RG
+
+		nsg := test.MakeNetworkSecurityGroup(options.FromContext(ctx).NodeResourceGroup, "aks-agentpool-00000000-nsg")
+		azureEnv.NetworkSecurityGroupAPI.NSGs.Store(nsg.ID, nsg)
+
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+
+		pod := coretest.UnschedulablePod(coretest.PodOptions{})
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
+		ExpectScheduled(ctx, env.Client, pod)
+
+		Expect(azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+		nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop().Interface
+		Expect(nic).ToNot(BeNil())
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+
+		expectedNSGID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkSecurityGroups/aks-agentpool-%s-nsg", azureEnv.SubscriptionID, options.FromContext(ctx).NodeResourceGroup, options.FromContext(ctx).ClusterID)
+		Expect(nic.Properties.NetworkSecurityGroup).ToNot(BeNil())
+		Expect(lo.FromPtr(nic.Properties.NetworkSecurityGroup.ID)).To(Equal(expectedNSGID))
 	})
 })

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -147,6 +147,10 @@ var _ = Describe("InstanceType Provider", func() {
 		clusterNonZonal.Reset()
 		azureEnv.Reset()
 		azureEnvNonZonal.Reset()
+
+		// Populate the expected cluster NSG
+		nsg := test.MakeNetworkSecurityGroup(options.FromContext(ctx).NodeResourceGroup, fmt.Sprintf("aks-agentpool-%s-nsg", options.FromContext(ctx).ClusterID))
+		azureEnv.NetworkSecurityGroupAPI.NSGs.Store(nsg.ID, nsg)
 	})
 
 	AfterEach(func() {
@@ -160,7 +164,7 @@ var _ = Describe("InstanceType Provider", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop()
 			Expect(nic).NotTo(BeNil())
-			Expect(lo.FromPtr(nic.Interface.Properties.IPConfigurations[0].Properties.Subnet.ID)).To(Equal("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub"))
+			Expect(lo.FromPtr(nic.Interface.Properties.IPConfigurations[0].Properties.Subnet.ID)).To(Equal("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-resourceGroup/providers/Microsoft.Network/virtualNetworks/aks-vnet-12345678/subnets/aks-subnet"))
 		})
 		It("should produce all required azure cni labels", func() {
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
@@ -171,7 +175,7 @@ var _ = Describe("InstanceType Provider", func() {
 			decodedString := ExpectDecodedCustomData(azureEnv)
 			Expect(decodedString).To(SatisfyAll(
 				ContainSubstring("kubernetes.azure.com/ebpf-dataplane=cilium"),
-				ContainSubstring("kubernetes.azure.com/network-subnet=karpentersub"),
+				ContainSubstring("kubernetes.azure.com/network-subnet=aks-subnet"),
 				ContainSubstring("kubernetes.azure.com/nodenetwork-vnetguid=a519e60a-cac0-40b2-b883-084477fe6f5c"),
 				ContainSubstring("kubernetes.azure.com/podnetwork-type=overlay"),
 				ContainSubstring("kubernetes.azure.com/azure-cni-overlay=true"),
@@ -183,6 +187,7 @@ var _ = Describe("InstanceType Provider", func() {
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
 			ExpectScheduled(ctx, env.Client, pod)
+
 			nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop()
 			Expect(nic).NotTo(BeNil())
 			Expect(lo.FromPtr(nic.Interface.Properties.IPConfigurations[0].Properties.Subnet.ID)).To(Equal("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpenter/subnets/nodeclassSubnet"))
@@ -652,7 +657,7 @@ var _ = Describe("InstanceType Provider", func() {
 			customData := ExpectDecodedCustomData(azureEnv)
 			// Since the network plugin is not "azure" it should not include the following kubeletLabels
 			Expect(customData).To(Not(SatisfyAny(
-				ContainSubstring("kubernetes.azure.com/network-subnet=karpentersub"),
+				ContainSubstring("kubernetes.azure.com/network-subnet=aks-subnet"),
 				ContainSubstring("kubernetes.azure.com/nodenetwork-vnetguid=a519e60a-cac0-40b2-b883-084477fe6f5c"),
 				ContainSubstring("kubernetes.azure.com/podnetwork-type=overlay"),
 			)))
@@ -1477,7 +1482,7 @@ var _ = Describe("InstanceType Provider", func() {
 			"none",
 			sets.New(
 				"kubernetes.azure.com/azure-cni-overlay=true",
-				"kubernetes.azure.com/network-subnet=karpentersub",
+				"kubernetes.azure.com/network-subnet=aks-subnet",
 				"kubernetes.azure.com/nodenetwork-vnetguid=a519e60a-cac0-40b2-b883-084477fe6f5c",
 				"kubernetes.azure.com/podnetwork-type=overlay",
 			)),
@@ -1489,7 +1494,7 @@ var _ = Describe("InstanceType Provider", func() {
 			"none",
 			sets.New(
 				"kubernetes.azure.com/azure-cni-overlay=true",
-				"kubernetes.azure.com/network-subnet=karpentersub",
+				"kubernetes.azure.com/network-subnet=aks-subnet",
 				"kubernetes.azure.com/nodenetwork-vnetguid=a519e60a-cac0-40b2-b883-084477fe6f5c",
 				"kubernetes.azure.com/podnetwork-type=overlay",
 				"kubernetes.azure.com/ebpf-dataplane=cilium",

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -19,6 +19,7 @@ package test
 import (
 	"context"
 
+	gomegaformat "github.com/onsi/gomega/format"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 
@@ -42,6 +43,9 @@ import (
 
 func init() {
 	karpv1.NormalizedLabels = lo.Assign(karpv1.NormalizedLabels, map[string]string{"topology.disk.csi.azure.com/zone": corev1.LabelTopologyZone})
+
+	// Configuing this here because it's commonly imported and has an init already
+	gomegaformat.CharactersAroundMismatchToInclude = 40
 }
 
 const (
@@ -79,7 +83,8 @@ type Environment struct {
 	NetworkSecurityGroupProvider *networksecuritygroup.Provider
 
 	// Settings
-	nonZonal bool
+	nonZonal       bool
+	SubscriptionID string
 }
 
 func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment {
@@ -192,7 +197,8 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		LoadBalancerProvider:         loadBalancerProvider,
 		NetworkSecurityGroupProvider: networkSecurityGroupProvider,
 
-		nonZonal: nonZonal,
+		nonZonal:       nonZonal,
+		SubscriptionID: subscription,
 	}
 }
 

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -74,7 +74,7 @@ func Options(overrides ...OptionsFields) *azoptions.Options {
 		NetworkDataplane:               lo.FromPtrOr(options.NetworkDataplane, "cilium"),
 		VMMemoryOverheadPercent:        lo.FromPtrOr(options.VMMemoryOverheadPercent, 0.075),
 		NodeIdentities:                 options.NodeIdentities,
-		SubnetID:                       lo.FromPtrOr(options.SubnetID, "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub"),
+		SubnetID:                       lo.FromPtrOr(options.SubnetID, "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-resourceGroup/providers/Microsoft.Network/virtualNetworks/aks-vnet-12345678/subnets/aks-subnet"),
 		NodeResourceGroup:              lo.FromPtrOr(options.NodeResourceGroup, "test-resourceGroup"),
 		ProvisionMode:                  lo.FromPtrOr(options.ProvisionMode, "aksscriptless"),
 		NodeBootstrappingServerURL:     lo.FromPtrOr(options.NodeBootstrappingServerURL, ""),

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,94 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/utils"
+	. "github.com/onsi/gomega"
+)
+
+func TestIsAKSManagedVNET(t *testing.T) {
+	cases := []struct {
+		name           string
+		subnetID       string
+		nrg            string
+		expectedError  string
+		expectedResult bool
+	}{
+		{
+			name:           "Not a BYO vnet",
+			subnetID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg/providers/Microsoft.Network/virtualNetworks/aks-vnet-18484614/subnets/aks-subnet",
+			nrg:            "MC_rg",
+			expectedError:  "",
+			expectedResult: true,
+		},
+		{
+			name:           "Not a BYO vnet (different casing)",
+			subnetID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg/providers/Microsoft.Network/virtualNetworks/AKS-VNET-18484614/subnets/aks-subnet",
+			nrg:            "mc_rg",
+			expectedError:  "",
+			expectedResult: true,
+		},
+		{
+			name:           "BYO vnet in the MC RG",
+			subnetID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/aks-subnet",
+			nrg:            "mc_rg",
+			expectedError:  "",
+			expectedResult: false,
+		},
+		{
+			name:           "A BYO subnet in the managed vnet",
+			subnetID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg/providers/Microsoft.Network/virtualNetworks/AKS-VNET-18484614/subnets/my-subnet",
+			nrg:            "MC_rg",
+			expectedError:  "",
+			expectedResult: false,
+		},
+		{
+			name:           "BYO vnet in a different RG",
+			subnetID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myrg/providers/Microsoft.Network/virtualNetworks/aks-vnet-18484614/subnets/aks-subnet",
+			nrg:            "MC_rg",
+			expectedError:  "",
+			expectedResult: false,
+		},
+		{
+			name:           "not a subnet errors",
+			subnetID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg/providers/Microsoft.Compute/virtualMachines/myVM",
+			expectedError:  "invalid vnet subnet id",
+			expectedResult: false,
+		},
+		{
+			name:           "not a valid ARM ID errors",
+			subnetID:       "not a valid ID",
+			expectedError:  "invalid vnet subnet id",
+			expectedResult: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			g := NewWithT(t)
+			byo, err := utils.IsAKSManagedVNET(c.nrg, c.subnetID)
+			if c.expectedError != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(c.expectedError)))
+			} else {
+				g.Expect(byo).To(Equal(c.expectedResult))
+			}
+		})
+	}
+}

--- a/test/pkg/environment/azure/environment.go
+++ b/test/pkg/environment/azure/environment.go
@@ -64,6 +64,7 @@ type Environment struct {
 	// to ensure they are cleaned up after the test.
 	vmClient             *armcompute.VirtualMachinesClient
 	vnetClient           *armnetwork.VirtualNetworksClient
+	subnetClient         *armnetwork.SubnetsClient
 	interfacesClient     *armnetwork.InterfacesClient
 	managedClusterClient *containerservice.ManagedClustersClient
 }
@@ -86,6 +87,7 @@ func NewEnvironment(t *testing.T) *Environment {
 	cred := lo.Must(azidentity.NewDefaultAzureCredential(nil))
 	azureEnv.vmClient = lo.Must(armcompute.NewVirtualMachinesClient(azureEnv.SubscriptionID, cred, nil))
 	azureEnv.vnetClient = lo.Must(armnetwork.NewVirtualNetworksClient(azureEnv.SubscriptionID, cred, nil))
+	azureEnv.subnetClient = lo.Must(armnetwork.NewSubnetsClient(azureEnv.SubscriptionID, cred, nil))
 	azureEnv.interfacesClient = lo.Must(armnetwork.NewInterfacesClient(azureEnv.SubscriptionID, cred, nil))
 	azureEnv.managedClusterClient = lo.Must(containerservice.NewManagedClustersClient(azureEnv.SubscriptionID, cred, nil))
 	return azureEnv

--- a/test/suites/integration/subnet_test.go
+++ b/test/suites/integration/subnet_test.go
@@ -1,0 +1,89 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/karpenter/pkg/test"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Subnets", func() {
+	var dep *appsv1.Deployment
+	var selector labels.Selector
+	var numPods int
+
+	BeforeEach(func() {
+		numPods = 1
+		dep = test.Deployment(test.DeploymentOptions{
+			Replicas: int32(numPods),
+			PodOptions: test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "my-app"},
+				},
+			},
+		})
+		selector = labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
+	})
+
+	It("should allocate node in NodeClass subnet", func() {
+		subnetName := "test-subnet"
+		subnet := &armnetwork.Subnet{
+			Name: lo.ToPtr(subnetName),
+			Properties: &armnetwork.SubnetPropertiesFormat{
+				AddressPrefix: lo.ToPtr("10.225.0.0/16"),
+			},
+		}
+		vnet := env.GetClusterVNET()
+		env.ExpectCreatedSubnet(lo.FromPtr(vnet.Name), subnet)
+		nodeClass.Spec.VNETSubnetID = subnet.ID // Should be populated by the Expect call above
+
+		env.ExpectCreated(nodeClass, nodePool, dep)
+
+		env.EventuallyExpectCreatedNodeClaimCount("==", 1)
+		nodes := env.EventuallyExpectCreatedNodeCount("==", 1)
+		env.EventuallyExpectHealthyPodCount(selector, numPods)
+
+		vm := env.GetVM(nodes[0].Name)
+		Expect(vm.Properties).ToNot(BeNil())
+		Expect(vm.Properties.NetworkProfile).ToNot(BeNil())
+		Expect(vm.Properties.NetworkProfile.NetworkInterfaces).To(HaveLen(1))
+		Expect(vm.Properties.NetworkProfile.NetworkInterfaces[0].ID).ToNot(BeNil())
+		nicID, err := arm.ParseResourceID(*vm.Properties.NetworkProfile.NetworkInterfaces[0].ID)
+		Expect(err).ToNot(HaveOccurred())
+
+		// The NIC should have the right subnet
+		nic := env.GetNetworkInterface(nicID.Name)
+		Expect(nic.Properties).ToNot(BeNil())
+		Expect(nic.Properties.IPConfigurations).To(HaveLen(1))
+		Expect(nic.Properties.IPConfigurations[0].Properties).ToNot(BeNil())
+		Expect(nic.Properties.IPConfigurations[0].Properties.Subnet).ToNot(BeNil())
+		Expect(nic.Properties.IPConfigurations[0].Properties.Subnet.ID).To(Equal(subnet.ID))
+
+		// The NIC should have the right NSG
+		Expect(nic.Properties.NetworkSecurityGroup).ToNot(BeNil())
+		Expect(nic.Properties.NetworkSecurityGroup.ID).ToNot(BeNil())
+		Expect(*nic.Properties.NetworkSecurityGroup.ID).To(MatchRegexp(`aks-agentpool-\d{8}-nsg`))
+	})
+})


### PR DESCRIPTION
This mirrors what AKS does. This is not required in managed VNET mode because then the NSG is attached to the Subnet (created by AKS), so it doesn't need to be attached to each NIC individually.

Fixes #562.
This supersedes #610, which should be closed.

**How was this change tested?**

* Unit tests
* E2E tests (see newly added test). Full E2E run results: https://github.com/Azure/karpenter-provider-azure/actions/runs/15312805268
* Manually tested the scenario reported in #562 using `make az-all-custom-vnet`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix bug which caused load balancing to not work correctly in BYO VNET scenarios.
```
