### PR TITLE
feat: add support for customer-managed keys in AKSNodeClass for OS disk encryption

### DIFF
--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -20,6 +20,12 @@ KARPENTER_FEDERATED_IDENTITY_CREDENTIAL_NAME ?= KARPENTER_FID
 CUSTOM_VNET_NAME ?= $(AZURE_CLUSTER_NAME)-vnet
 CUSTOM_SUBNET_NAME ?= nodesubnet
 
+# You can override the Key Vault name by setting AZURE_KEYVAULT_NAME when running make, e.g.:
+#   make az-cmk-all AZURE_KEYVAULT_NAME=mycustomkv
+# This is useful if the default name is unavailable due to purge protection retention.
+AZURE_KEYVAULT_NAME ?= $(shell echo $(AZURE_RESOURCE_GROUP)kv | sed 's/[^a-zA-Z0-9]//g' | cut -c1-24)AZURE_KEYVAULT_KEY_NAME ?= karpenter-cmk
+AZURE_DES_NAME ?= $(AZURE_CLUSTER_NAME)-des
+
 .DEFAULT_GOAL := help	# make without arguments will show help
 
 az-all:              az-login az-create-workload-msi az-mkaks-cilium      az-create-federated-cred az-perm               az-perm-acr az-configure-values             az-build az-run          az-run-sample ## Provision the infra (ACR,AKS); build and deploy Karpenter; deploy sample Provisioner and workload
@@ -393,3 +399,94 @@ az-swagger-generate-clients-raw:
 az-swagger-generate-clients: az-swagger-generate-clients-raw
 	hack/boilerplate.sh
 	make tidy
+
+# --- Customer Managed Key (CMK) and Disk Encryption Set automation ---
+
+az-create-keyvault: az-mkrg ## Create a Key Vault for CMK
+	@if az keyvault show --name $(AZURE_KEYVAULT_NAME) --resource-group $(AZURE_RESOURCE_GROUP) > /dev/null 2>&1; then \
+		echo "Key Vault $(AZURE_KEYVAULT_NAME) already exists."; \
+	else \
+		echo "Attempting to create Key Vault $(AZURE_KEYVAULT_NAME)..."; \
+		if az keyvault create --name $(AZURE_KEYVAULT_NAME) --resource-group $(AZURE_RESOURCE_GROUP) --location $(AZURE_LOCATION) > /dev/null 2>&1; then \
+			echo "Key Vault $(AZURE_KEYVAULT_NAME) created successfully."; \
+		else \
+			if az keyvault show-deleted --name $(AZURE_KEYVAULT_NAME) > /dev/null 2>&1; then \
+				echo "ERROR: Key Vault name $(AZURE_KEYVAULT_NAME) is unavailable due to soft-delete or purge protection retention."; \
+				echo "If purge protection is enabled, you must wait for the retention period to expire before reusing this name."; \
+				echo "To use a different Key Vault name, set the AZURE_KEYVAULT_NAME environment variable when running make:"; \
+				echo "  make <target> AZURE_KEYVAULT_NAME=yournewkvname"; \
+			else \
+				echo "ERROR: Failed to create Key Vault $(AZURE_KEYVAULT_NAME). Please check your Azure permissions and configuration."; \
+			fi \
+		fi \
+	fi
+az-enable-keyvault-purge-protection: az-create-keyvault ## Enable purge protection on the Key Vault (required for CMK)
+	az keyvault update --name $(AZURE_KEYVAULT_NAME) --resource-group $(AZURE_RESOURCE_GROUP) --enable-purge-protection true
+
+az-grant-kv-admin: az-create-keyvault ## Assign Key Vault Administrator role to the signed-in user
+	$(eval USER_OBJECT_ID := $(shell az ad signed-in-user show --query objectId -o tsv))
+	$(eval USER_UPN := $(shell az ad signed-in-user show --query userPrincipalName -o tsv))
+	$(eval KV_ID := $(shell az keyvault show --name $(AZURE_KEYVAULT_NAME) --query id -o tsv))
+	@if [ -n "$(USER_OBJECT_ID)" ]; then \
+		ASSIGNEE="$(USER_OBJECT_ID)"; \
+	elif [ -n "$(USER_UPN)" ]; then \
+		ASSIGNEE="$(USER_UPN)"; \
+	else \
+		echo "ERROR: Could not determine user objectId or UPN. Please check your Azure login context."; \
+		exit 1; \
+	fi; \
+	if ! az role assignment list --assignee "$$ASSIGNEE" --scope $(KV_ID) --role "Key Vault Administrator" | grep -q '"roleDefinitionName": "Key Vault Administrator"'; then \
+		az role assignment create --role "Key Vault Administrator" --assignee "$$ASSIGNEE" --scope $(KV_ID); \
+	else \
+		echo "Key Vault Administrator role already assigned to user."; \
+	fi
+az-create-keyvault-key: az-grant-kv-admin ## Create a key in the Key Vault for CMK
+	if ! az keyvault key show --vault-name $(AZURE_KEYVAULT_NAME) --name $(AZURE_KEYVAULT_KEY_NAME) > /dev/null 2>&1; then \
+		az keyvault key create --vault-name $(AZURE_KEYVAULT_NAME) --name $(AZURE_KEYVAULT_KEY_NAME) --protection software; \
+	else \
+		echo "Key $(AZURE_KEYVAULT_KEY_NAME) already exists in Key Vault $(AZURE_KEYVAULT_NAME)."; \
+	fi
+
+az-create-disk-encryption-set: az-create-keyvault-key ## Create a Disk Encryption Set referencing the Key Vault key
+	if ! az disk-encryption-set show --name $(AZURE_DES_NAME) --resource-group $(AZURE_RESOURCE_GROUP) > /dev/null 2>&1; then \
+		az disk-encryption-set create --name $(AZURE_DES_NAME) --resource-group $(AZURE_RESOURCE_GROUP) \
+			--location $(AZURE_LOCATION) \
+			--source-vault $(shell az keyvault show --name $(AZURE_KEYVAULT_NAME) --resource-group $(AZURE_RESOURCE_GROUP) --query id -o tsv) \
+			--key-url $(shell az keyvault key show --vault-name $(AZURE_KEYVAULT_NAME) --name $(AZURE_KEYVAULT_KEY_NAME) --query key.kid -o tsv) \
+			--mi-system-assigned; \
+	else \
+		echo "Disk Encryption Set $(AZURE_DES_NAME) already exists."; \
+	fi
+
+az-grant-des-key-permissions: az-create-disk-encryption-set ## Grant DES access to the Key Vault key
+	$(eval DES_PRINCIPAL_ID := $(shell az disk-encryption-set show --name $(AZURE_DES_NAME) --resource-group $(AZURE_RESOURCE_GROUP) --query "identity.principalId" -o tsv))
+	$(eval KV_ID := $(shell az keyvault show --name $(AZURE_KEYVAULT_NAME) --query id -o tsv))
+	if ! az role assignment list --assignee $(DES_PRINCIPAL_ID) --scope $(KV_ID) --role "Key Vault Crypto Service Encryption User" | grep -q '"roleDefinitionName": "Key Vault Crypto Service Encryption User"'; then \
+		az role assignment create --assignee $(DES_PRINCIPAL_ID) --role "Key Vault Crypto Service Encryption User" --scope $(KV_ID); \
+	else \
+		echo "DES principal already has RBAC permissions in Key Vault."; \
+	fi
+
+az-grant-msi-des-reader: ## Grant Karpenter MSI Reader access to the Disk Encryption Set
+	$(eval KARPENTER_USER_ASSIGNED_CLIENT_ID=$(shell az identity show --resource-group "${AZURE_RESOURCE_GROUP}" --name "${AZURE_KARPENTER_USER_ASSIGNED_IDENTITY_NAME}" --query 'principalId' -o tsv))
+	$(eval DES_ID=$(shell az disk-encryption-set show --name $(AZURE_DES_NAME) --resource-group $(AZURE_RESOURCE_GROUP) --query id -o tsv))
+	if ! az role assignment list --assignee $(KARPENTER_USER_ASSIGNED_CLIENT_ID) --scope $(DES_ID) --role "Reader" | grep -q '"roleDefinitionName": "Reader"'; then \
+		az role assignment create --assignee $(KARPENTER_USER_ASSIGNED_CLIENT_ID) --role "Reader" --scope $(DES_ID); \
+	else \
+		echo "Karpenter MSI already has Reader role on DES."; \
+	fi
+
+az-grant-msi-key-permissions: ## Grant Karpenter MSI access to the Key Vault key
+	$(eval KARPENTER_USER_ASSIGNED_CLIENT_ID=$(shell az identity show --resource-group "${AZURE_RESOURCE_GROUP}" --name "${AZURE_KARPENTER_USER_ASSIGNED_IDENTITY_NAME}" --query 'principalId' -o tsv))
+	$(eval KV_ID := $(shell az keyvault show --name $(AZURE_KEYVAULT_NAME) --query id -o tsv))
+	if ! az role assignment list --assignee $(KARPENTER_USER_ASSIGNED_CLIENT_ID) --scope $(KV_ID) --role "Key Vault Crypto User" | grep -q '"roleDefinitionName": "Key Vault Crypto User"'; then \
+		az role assignment create --assignee $(KARPENTER_USER_ASSIGNED_CLIENT_ID) --role "Key Vault Crypto User" --scope $(KV_ID); \
+	else \
+		echo "Karpenter MSI already has RBAC permissions in Key Vault."; \
+	fi
+
+az-show-des-id: ## Show the Disk Encryption Set ID (for use in AKSNodeClass)
+	$(eval DES_ID=$(shell az disk-encryption-set show --name $(AZURE_DES_NAME) --resource-group $(AZURE_RESOURCE_GROUP) --query id -o tsv))
+	@echo "Disk Encryption Set ID: $(DES_ID)"
+
+az-cmk-all: az-create-keyvault az-enable-keyvault-purge-protection az-grant-kv-admin az-create-keyvault-key az-create-disk-encryption-set az-grant-des-key-permissions az-grant-msi-des-reader az-grant-msi-key-permissions az-show-des-id ## Create Key Vault, Key, Disk Encryption Set and grant necessary permissions for CMK

--- a/README.md
+++ b/README.md
@@ -310,6 +310,46 @@ az aks delete --name "${CLUSTER_NAME}" --resource-group "${RG}"
 
 ---
 
+## Using Customer Managed Keys (CMK) for OS Disk Encryption
+
+Karpenter supports encrypting the OS disk of provisioned nodes with your own Azure Customer Managed Key (CMK). This is achieved by specifying a Disk Encryption Set resource ID in your `AKSNodeClass`.
+
+### Prerequisites
+
+- You must have created an Azure Key Vault, a key, and a Disk Encryption Set (DES) with purge protection enabled.
+- The Karpenter managed identity must have the necessary permissions on the Key Vault and DES.
+- The Makefile provides automation for these steps (see `az-cmk-all` target).
+
+### Example
+
+```yaml
+apiVersion: karpenter.azure.com/v1beta1
+kind: AKSNodeClass
+metadata:
+  name: cmk-enabled
+spec:
+  imageFamily: Ubuntu2204
+  # Replace with your actual Disk Encryption Set resource ID
+  osDiskDiskEncryptionSetID: "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Compute/diskEncryptionSets/<des-name>"
+```
+
+If `osDiskDiskEncryptionSetID` is not specified, Microsoft-managed keys will be used by default.
+
+### Automating CMK Resource Creation
+
+You can use the Makefile to automate the creation of the required Azure resources:
+
+```bash
+# Optionally override the Key Vault name if needed
+make az-cmk-all AZURE_KEYVAULT_NAME=mycustomkv
+```
+
+If the Key Vault name is unavailable due to purge protection retention, specify a different name using the `AZURE_KEYVAULT_NAME` environment variable.
+
+See [`examples/v1beta1/cmk-enabled.yaml`](examples/v1beta1/cmk-enabled.yaml) and [`Makefile-az.mk](Makefile-az.mk) for a complete example of using a customer-managed key for OS disk encryption.
+
+---
+
 ### Source Attribution
 
 Notice: Files in this source code originated from a fork of https://github.com/aws/karpenter

--- a/charts/karpenter-crd/templates/karpenter.azure.com_aksnodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.azure.com_aksnodeclasses.yaml
@@ -466,6 +466,11 @@ spec:
                 maximum: 250
                 minimum: 10
                 type: integer
+              osDiskDiskEncryptionSetID:
+                description: |-
+                  OSDiskDiskEncryptionSetID is the Azure resource ID of the Disk Encryption Set to use for encrypting the OS disk with a customer-managed key (CMK).
+                  If not specified, Microsoft-managed keys will be used.
+                type: string
               osDiskSizeGB:
                 default: 128
                 description: osDiskSizeGB is the size of the OS disk in GB.

--- a/examples/v1beta1/cmk-enabled.yaml
+++ b/examples/v1beta1/cmk-enabled.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: karpenter.azure.com/v1beta1
+kind: AKSNodeClass
+metadata:
+  name: cmk-enabled
+  annotations:
+    kubernetes.io/description: "AKSNodeClass using a customer-managed key for OS disk encryption"
+spec:
+  imageFamily: Ubuntu2204
+  # Replace the value below with your actual Disk Encryption Set resource ID
+  osDiskDiskEncryptionSetID: "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Compute/diskEncryptionSets/<des-name>"

--- a/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
@@ -466,6 +466,11 @@ spec:
                 maximum: 250
                 minimum: 10
                 type: integer
+              osDiskDiskEncryptionSetID:
+                description: |-
+                  OSDiskDiskEncryptionSetID is the Azure resource ID of the Disk Encryption Set to use for encrypting the OS disk with a customer-managed key (CMK).
+                  If not specified, Microsoft-managed keys will be used.
+                type: string
               osDiskSizeGB:
                 default: 128
                 description: osDiskSizeGB is the size of the OS disk in GB.

--- a/pkg/apis/v1beta1/aksnodeclass.go
+++ b/pkg/apis/v1beta1/aksnodeclass.go
@@ -36,6 +36,10 @@ type AKSNodeClassSpec struct {
 	// +kubebuilder:validation:Minimum=30
 	// osDiskSizeGB is the size of the OS disk in GB.
 	OSDiskSizeGB *int32 `json:"osDiskSizeGB,omitempty"`
+	// OSDiskDiskEncryptionSetID is the Azure resource ID of the Disk Encryption Set to use for encrypting the OS disk with a customer-managed key (CMK).
+	// If not specified, Microsoft-managed keys will be used.
+	// +optional
+	OSDiskDiskEncryptionSetID *string `json:"osDiskDiskEncryptionSetID,omitempty"`
 	// ImageID is the ID of the image that instances use.
 	// Not exposed in the API yet
 	ImageID *string `json:"-"`

--- a/pkg/apis/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1beta1/zz_generated.deepcopy.go
@@ -98,6 +98,11 @@ func (in *AKSNodeClassSpec) DeepCopyInto(out *AKSNodeClassSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.OSDiskDiskEncryptionSetID != nil {
+		in, out := &in.OSDiskDiskEncryptionSetID, &out.OSDiskDiskEncryptionSetID
+		*out = new(string)
+		**out = **in
+	}
 	if in.ImageID != nil {
 		in, out := &in.ImageID, &out.ImageID
 		*out = new(string)

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -445,6 +445,7 @@ func newVMObject(opts *createVMOptions) *armcompute.VirtualMachine {
 		Tags:  opts.LaunchTemplate.Tags,
 	}
 	setVMPropertiesOSDiskType(vm.Properties, opts.LaunchTemplate.StorageProfile)
+	setVMPropertiesOSDiskDiskEncryptionSet(vm.Properties, opts.NodeClass.Spec.OSDiskDiskEncryptionSetID)
 	setImageReference(vm.Properties, opts.LaunchTemplate.ImageID, opts.UseSIG)
 	setVMPropertiesBillingProfile(vm.Properties, opts.CapacityType)
 
@@ -465,6 +466,16 @@ func setVMPropertiesOSDiskType(vmProperties *armcompute.VirtualMachineProperties
 			// placement (cache/resource) is left to CRP
 		}
 		vmProperties.StorageProfile.OSDisk.Caching = lo.ToPtr(armcompute.CachingTypesReadOnly)
+	}
+}
+
+func setVMPropertiesOSDiskDiskEncryptionSet(vmProperties *armcompute.VirtualMachineProperties, diskEncryptionSetID *string) {
+	if diskEncryptionSetID != nil && *diskEncryptionSetID != "" {
+		vmProperties.StorageProfile.OSDisk.ManagedDisk = &armcompute.ManagedDiskParameters{
+			DiskEncryptionSet: &armcompute.DiskEncryptionSetParameters{
+				ID: lo.ToPtr(*diskEncryptionSetID),
+			},
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #268 

**Description**

This PR introduces support for using Azure Customer Managed Keys (CMK) for encrypting the OS disk of AKS nodes provisioned by Karpenter. The following changes are included:

- **CRD and API changes:**  
  - Added the `osDiskDiskEncryptionSetID` field to the `AKSNodeClass` CRD and Go API, allowing users to specify the Azure resource ID of the Disk Encryption Set to use for OS disk encryption.
  - Updated CRD schema and documentation to reflect the new field.
- **Provider logic:**  
  - Updated the VM creation logic to set the Disk Encryption Set on the OS disk if `osDiskDiskEncryptionSetID` is specified in the `AKSNodeClass`.
- **Examples and tests:**  
  - Added an example manifest (`examples/v1beta1/cmk-enabled.yaml`) demonstrating how to use a customer-managed key for OS disk encryption.
  - Added unit tests to verify correct handling of the Disk Encryption Set ID in VM creation logic.
- **Makefile automation for CMK resources:**  
  - Added Makefile targets to automate the creation of an Azure Key Vault, key, and Disk Encryption Set (DES) with purge protection enabled, as required for CMK scenarios.
  - Includes error handling in the Key Vault creation step: if the Key Vault name is unavailable due to purge protection retention, the Makefile provides a clear error message and instructions for specifying a different Key Vault name via the `AZURE_KEYVAULT_NAME` environment variable.
  - Added documentation in the Makefile to guide users on how to override the Key Vault name for repeated or parallel test runs.

**How was this change tested?**

- Manual testing of the Makefile automation for Key Vault, key, and DES creation, including error scenarios with purge protection.
- Applied the new `AKSNodeClass` with `osDiskDiskEncryptionSetID` in a test cluster and verified that the OS disk is encrypted with the specified Disk Encryption Set.
- Added and ran unit tests for the provider logic.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates (`README.md`, `Makefile-az.md` including comments, CRD schema, and example manifest)
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

```release-note
feat: Added support for customer-managed keys (CMK) for OS disk encryption in AKSNodeClass via the new `osDiskDiskEncryptionSetID` field.
```
