### PR TITLE
fix: Propagate missing kubelet flags to node bootstrap variables

### DIFF
--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -350,7 +350,7 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 	nodeclaimKubeletConfig := KubeletConfigToMap(a.KubeletConfig)
 	kubeletFlags = lo.Assign(kubeletFlags, nodeclaimKubeletConfig)
 
-	// striginify kubelet flags (including taints)
+	// stringify kubelet flags (including taints)
 	nbv.KubeletFlags = strings.Join(lo.MapToSlice(kubeletFlags, func(k, v string) string {
 		return fmt.Sprintf("%s=%s", k, v)
 	}), " ")
@@ -398,6 +398,24 @@ func KubeletConfigToMap(kubeletConfig *KubeletConfiguration) map[string]string {
 	}
 	if kubeletConfig.CPUCFSQuota != nil {
 		args["--cpu-cfs-quota"] = fmt.Sprintf("%t", lo.FromPtr(kubeletConfig.CPUCFSQuota))
+	}
+	if kubeletConfig.CPUManagerPolicy != "" {
+		args["--cpu-manager-policy"] = kubeletConfig.CPUManagerPolicy
+	}
+	if kubeletConfig.TopologyManagerPolicy != "" {
+		args["--topology-manager-policy"] = kubeletConfig.TopologyManagerPolicy
+	}
+	if kubeletConfig.ContainerLogMaxSize != "" {
+		args["--container-log-max-size"] = kubeletConfig.ContainerLogMaxSize
+	}
+	if kubeletConfig.ContainerLogMaxFiles != nil {
+		args["--container-log-max-files"] = fmt.Sprintf("%d", lo.FromPtr(kubeletConfig.ContainerLogMaxFiles))
+	}
+	if kubeletConfig.PodPidsLimit != nil {
+		args["--pod-max-pids"] = fmt.Sprintf("%d", lo.FromPtr(kubeletConfig.PodPidsLimit))
+	}
+	if len(kubeletConfig.AllowedUnsafeSysctls) > 0 {
+		args["--allowed-unsafe-sysctls"] = strings.Join(kubeletConfig.AllowedUnsafeSysctls, ",")
 	}
 
 	return args

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -347,7 +347,7 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 		kubeletFlags = lo.Assign(kubeletFlags, map[string]string{"--register-with-taints": strings.Join(taintStrs, ",")})
 	}
 
-	nodeclaimKubeletConfig := KubeletConfigToMap(a.KubeletConfig)
+	nodeclaimKubeletConfig := kubeletConfigToMap(a.KubeletConfig)
 	kubeletFlags = lo.Assign(kubeletFlags, nodeclaimKubeletConfig)
 
 	// stringify kubelet flags (including taints)
@@ -373,7 +373,7 @@ func getCustomDataFromNodeBootstrapVars(nbv *NodeBootstrapVariables) (string, er
 }
 
 // nolint: gocyclo
-func KubeletConfigToMap(kubeletConfig *KubeletConfiguration) map[string]string {
+func kubeletConfigToMap(kubeletConfig *KubeletConfiguration) map[string]string {
 	args := make(map[string]string)
 
 	if kubeletConfig == nil {

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -372,6 +372,7 @@ func getCustomDataFromNodeBootstrapVars(nbv *NodeBootstrapVariables) (string, er
 	return buffer.String(), nil
 }
 
+// nolint: gocyclo
 func KubeletConfigToMap(kubeletConfig *KubeletConfiguration) map[string]string {
 	args := make(map[string]string)
 

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
@@ -182,7 +182,7 @@ func TestKubeletConfigMap(t *testing.T) {
 		"--eviction-soft-grace-period":    "memory.available=1m30s",
 		"--eviction-max-pod-grace-period": "11",
 	}
-	actualKubeletConfig := KubeletConfigToMap(&kubeletConfiguration)
+	actualKubeletConfig := kubeletConfigToMap(&kubeletConfiguration)
 
 	for k, v := range expectedKubeletConfigs {
 		assert.Equal(t, v, actualKubeletConfig[k], fmt.Sprintf("parameter mismatch for %s", k))

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
@@ -18,13 +18,14 @@ package bootstrap
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
-	"time"
 )
 
 func TestKubeBinaryURL(t *testing.T) {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -601,9 +601,16 @@ var _ = Describe("InstanceType Provider", func() {
 	Context("Nodepool with KubeletConfig", func() {
 		It("should support provisioning with kubeletConfig, computeResources and maxPods not specified", func() {
 			nodeClass.Spec.Kubelet = &v1beta1.KubeletConfiguration{
+				CPUManagerPolicy:            "static",
+				CPUCFSQuota:                 lo.ToPtr(true),
+				CPUCFSQuotaPeriod:           metav1.Duration{},
 				ImageGCHighThresholdPercent: lo.ToPtr(int32(30)),
 				ImageGCLowThresholdPercent:  lo.ToPtr(int32(20)),
-				CPUCFSQuota:                 lo.ToPtr(true),
+				TopologyManagerPolicy:       "best-effort",
+				AllowedUnsafeSysctls:        []string{"Allowed", "Unsafe", "Sysctls"},
+				ContainerLogMaxSize:         "42Mi",
+				ContainerLogMaxFiles:        lo.ToPtr[int32](13),
+				PodPidsLimit:                lo.ToPtr[int64](99),
 			}
 
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
@@ -619,6 +626,12 @@ var _ = Describe("InstanceType Provider", func() {
 				"image-gc-low-threshold":  "20",
 				"cpu-cfs-quota":           "true",
 				"max-pods":                "250",
+				"topology-manager-policy": "best-effort",
+				"container-log-max-size":  "42Mi",
+				"allowed-unsafe-sysctls":  "Allowed,Unsafe,Sysctls",
+				"cpu-manager-policy":      "static",
+				"container-log-max-files": "13",
+				"pod-max-pids":            "99",
 			}
 
 			ExpectKubeletFlags(azureEnv, customData, expectedFlags)
@@ -664,9 +677,16 @@ var _ = Describe("InstanceType Provider", func() {
 		})
 		It("should support provisioning with kubeletConfig, computeResources and maxPods not specified", func() {
 			nodeClass.Spec.Kubelet = &v1beta1.KubeletConfiguration{
+				CPUManagerPolicy:            "static",
+				CPUCFSQuota:                 lo.ToPtr(true),
+				CPUCFSQuotaPeriod:           metav1.Duration{},
 				ImageGCHighThresholdPercent: lo.ToPtr(int32(30)),
 				ImageGCLowThresholdPercent:  lo.ToPtr(int32(20)),
-				CPUCFSQuota:                 lo.ToPtr(true),
+				TopologyManagerPolicy:       "best-effort",
+				AllowedUnsafeSysctls:        []string{"Allowed", "Unsafe", "Sysctls"},
+				ContainerLogMaxSize:         "42Mi",
+				ContainerLogMaxFiles:        lo.ToPtr[int32](13),
+				PodPidsLimit:                lo.ToPtr[int64](99),
 			}
 
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
@@ -681,6 +701,12 @@ var _ = Describe("InstanceType Provider", func() {
 				"image-gc-low-threshold":  "20",
 				"image-gc-high-threshold": "30",
 				"cpu-cfs-quota":           "true",
+				"topology-manager-policy": "best-effort",
+				"container-log-max-size":  "42Mi",
+				"allowed-unsafe-sysctls":  "Allowed,Unsafe,Sysctls",
+				"cpu-manager-policy":      "static",
+				"container-log-max-files": "13",
+				"pod-max-pids":            "99",
 			}
 			ExpectKubeletFlags(azureEnv, customData, expectedFlags)
 			Expect(customData).To(SatisfyAny( // AKS default
@@ -694,9 +720,16 @@ var _ = Describe("InstanceType Provider", func() {
 		})
 		It("should support provisioning with kubeletConfig, computeResources and maxPods specified", func() {
 			nodeClass.Spec.Kubelet = &v1beta1.KubeletConfiguration{
+				CPUManagerPolicy:            "static",
+				CPUCFSQuota:                 lo.ToPtr(true),
+				CPUCFSQuotaPeriod:           metav1.Duration{},
 				ImageGCHighThresholdPercent: lo.ToPtr(int32(30)),
 				ImageGCLowThresholdPercent:  lo.ToPtr(int32(20)),
-				CPUCFSQuota:                 lo.ToPtr(true),
+				TopologyManagerPolicy:       "best-effort",
+				AllowedUnsafeSysctls:        []string{"Allowed", "Unsafe", "Sysctls"},
+				ContainerLogMaxSize:         "42Mi",
+				ContainerLogMaxFiles:        lo.ToPtr[int32](13),
+				PodPidsLimit:                lo.ToPtr[int64](99),
 			}
 			nodeClass.Spec.MaxPods = lo.ToPtr(int32(15))
 
@@ -712,6 +745,12 @@ var _ = Describe("InstanceType Provider", func() {
 				"image-gc-low-threshold":  "20",
 				"image-gc-high-threshold": "30",
 				"cpu-cfs-quota":           "true",
+				"topology-manager-policy": "best-effort",
+				"container-log-max-size":  "42Mi",
+				"allowed-unsafe-sysctls":  "Allowed,Unsafe,Sysctls",
+				"cpu-manager-policy":      "static",
+				"container-log-max-files": "13",
+				"pod-max-pids":            "99",
 			}
 
 			ExpectKubeletFlags(azureEnv, customData, expectedFlags)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

This change propagates the following missing flags to node bootsrap vars: 
```
--cpu-manager-policy
--topology-manager-policy
--container-log-max-size
--container-log-max-files
--pod-max-pids
--allowed-unsafe-sysctls
```

**How was this change tested?**

* Ran `make test`, every test passed.
* Verified that a selected kubelet flag (allowed-unsafe-sysctls) on a live cluster, the flag worked.
* Added a new unit test `KubeletConfigToMap` function.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
