### PR TITLE
chore: add release-assets.githubusercontent.com to allowed-endpoints

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -30,6 +30,7 @@ jobs:
           coveralls.io:443
           github.com:443
           objects.githubusercontent.com:443
+          release-assets.githubusercontent.com:443
           proxy.golang.org:443
           raw.githubusercontent.com:443
           storage.googleapis.com:443

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           dl.k8s.io:443
           github.com:443
           objects.githubusercontent.com:443
+          release-assets.githubusercontent.com:443
           proxy.golang.org:443
           raw.githubusercontent.com:443
           storage.googleapis.com:443

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,6 +34,7 @@ jobs:
             github.com:443
             login.microsoftonline.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             proxy.golang.org:443
             raw.githubusercontent.com:443
             storage.googleapis.com:443

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -22,6 +22,7 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             proxy.golang.org:443
             storage.googleapis.com:443
             sum.golang.org:443

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -73,6 +73,7 @@ jobs:
             management.azure.com:443
             mcr.microsoft.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             proxy.golang.org:443
             raw.githubusercontent.com:443
             storage.googleapis.com:443


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Add `release-assets.githubusercontent.com` to Harden Runner allowed-endpoints, to fix selected CI tests. The issue is not observed on all builds, but some failures are clearly due to this ([example](https://github.com/Azure/karpenter-provider-azure/actions/runs/15548557535/job/43782630888?pr=928#step:5:752) - setup-envtest trying to download release artifacts). This is a relatively new change in GitHub, see https://www.stepsecurity.io/blog/harden-runner-detects-new-traffic-to-release-assets-githubusercontent-com-across-multiple-customers.

**How was this change tested?**

* CI

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
