### PR TITLE
chore(logging): update logging for nodeclass status controllers

### DIFF
--- a/pkg/controllers/nodeclass/status/images.go
+++ b/pkg/controllers/nodeclass/status/images.go
@@ -161,6 +161,7 @@ func (r *NodeImageReconciler) Reconcile(ctx context.Context, nodeClass *v1beta1.
 	nodeClass.StatusConditions().SetTrue(v1beta1.ConditionTypeImagesReady)
 	// Note: the ChangeMonitor uses SlicesAsSets=true. However, we do actually care about the ordering of the Images, meaning we'll
 	//     miss logging potential updates on the ordering. Although, this is unexpected to occur.
+	//     https://github.com/kubernetes-sigs/karpenter/blob/349487633193bced541ad05bb76d02e633e73473/pkg/utils/pretty/changemonitor.go#L42
 	if r.cm.HasChanged(fmt.Sprintf("nodeclass-%s-images", nodeClass.Name), nodeClass.Status.Images) {
 		logger.WithValues("images", nodeClass.Status.Images).Info("new available images updated for nodeclass")
 	}
@@ -195,7 +196,7 @@ func (r *NodeImageReconciler) isMaintenanceWindowOpen(ctx context.Context, nodeC
 		return false, fmt.Errorf("error getting maintenance window configmap, %w", err)
 	}
 	// Monitoring the entire ConfigMap's data might catch more data changes than we care about. However, I think it makes sense to monitor
-	//     here as catches the entire spread of cases we care about, and will give us direct insight on the raw data.
+	//     here as it does catch the entire spread of cases we care about, and will give us direct insight on the raw data.
 	if r.cm.HasChanged(fmt.Sprintf("nodeclass-%s-mwdata", nodeClassName), mwConfigMap.Data) {
 		logger.WithValues("maintenancewindowdata", mwConfigMap.Data).Info("new maintenance window data discovered")
 	}

--- a/pkg/controllers/nodeclass/status/images.go
+++ b/pkg/controllers/nodeclass/status/images.go
@@ -197,7 +197,7 @@ func (r *NodeImageReconciler) isMaintenanceWindowOpen(ctx context.Context, nodeC
 	}
 	// Monitoring the entire ConfigMap's data might catch more data changes than we care about. However, I think it makes sense to monitor
 	//     here as it does catch the entire spread of cases we care about, and will give us direct insight on the raw data.
-	if r.cm.HasChanged(fmt.Sprintf("nodeclass-%s-mwdata", nodeClassName), mwConfigMap.Data) {
+	if r.cm.HasChanged("nodeclass-mwdata", mwConfigMap.Data) {
 		logger.WithValues("maintenancewindowdata", mwConfigMap.Data).Info("new maintenance window data discovered")
 	}
 	if len(mwConfigMap.Data) == 0 {

--- a/pkg/controllers/nodeclass/status/images.go
+++ b/pkg/controllers/nodeclass/status/images.go
@@ -157,14 +157,14 @@ func (r *NodeImageReconciler) Reconcile(ctx context.Context, nodeClass *v1beta1.
 		return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
 
-	nodeClass.Status.Images = goalImages
-	nodeClass.StatusConditions().SetTrue(v1beta1.ConditionTypeImagesReady)
 	// Note: the ChangeMonitor uses SlicesAsSets=true. However, we do actually care about the ordering of the Images, meaning we'll
 	//     miss logging potential updates on the ordering. Although, this is unexpected to occur.
 	//     https://github.com/kubernetes-sigs/karpenter/blob/349487633193bced541ad05bb76d02e633e73473/pkg/utils/pretty/changemonitor.go#L42
-	if r.cm.HasChanged(fmt.Sprintf("nodeclass-%s-images", nodeClass.Name), nodeClass.Status.Images) {
-		logger.WithValues("images", nodeClass.Status.Images).Info("new available images updated for nodeclass")
+	if r.cm.HasChanged(fmt.Sprintf("nodeclass-%s-images", nodeClass.Name), goalImages) {
+		logger.WithValues("existingimages", nodeClass.Status.Images).WithValues("newimages", goalImages).Info("new available images updated for nodeclass")
 	}
+	nodeClass.Status.Images = goalImages
+	nodeClass.StatusConditions().SetTrue(v1beta1.ConditionTypeImagesReady)
 	return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 }
 

--- a/pkg/controllers/nodeclass/status/images.go
+++ b/pkg/controllers/nodeclass/status/images.go
@@ -161,7 +161,7 @@ func (r *NodeImageReconciler) Reconcile(ctx context.Context, nodeClass *v1beta1.
 	//     miss logging potential updates on the ordering. Although, this is unexpected to occur.
 	//     https://github.com/kubernetes-sigs/karpenter/blob/349487633193bced541ad05bb76d02e633e73473/pkg/utils/pretty/changemonitor.go#L42
 	if r.cm.HasChanged(fmt.Sprintf("nodeclass-%s-images", nodeClass.Name), goalImages) {
-		logger.WithValues("existingimages", nodeClass.Status.Images).WithValues("newimages", goalImages).Info("new available images updated for nodeclass")
+		logger.WithValues("existingImages", nodeClass.Status.Images).WithValues("newImages", goalImages).Info("new available images updated for nodeclass")
 	}
 	nodeClass.Status.Images = goalImages
 	nodeClass.StatusConditions().SetTrue(v1beta1.ConditionTypeImagesReady)

--- a/pkg/controllers/nodeclass/status/images.go
+++ b/pkg/controllers/nodeclass/status/images.go
@@ -198,7 +198,7 @@ func (r *NodeImageReconciler) isMaintenanceWindowOpen(ctx context.Context, nodeC
 	// Monitoring the entire ConfigMap's data might catch more data changes than we care about. However, I think it makes sense to monitor
 	//     here as it does catch the entire spread of cases we care about, and will give us direct insight on the raw data.
 	if r.cm.HasChanged("nodeclass-mwdata", mwConfigMap.Data) {
-		logger.WithValues("maintenancewindowdata", mwConfigMap.Data).Info("new maintenance window data discovered")
+		logger.WithValues("maintenanceWindowData", mwConfigMap.Data).Info("new maintenance window data discovered")
 	}
 	if len(mwConfigMap.Data) == 0 {
 		// An empty configmap means there's no maintenance windows defined, and its up to us when to preform maintenance

--- a/pkg/controllers/nodeclass/status/images.go
+++ b/pkg/controllers/nodeclass/status/images.go
@@ -159,6 +159,7 @@ func (r *NodeImageReconciler) Reconcile(ctx context.Context, nodeClass *v1beta1.
 		return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
 
+	// We care about the ordering of the slices here, as it translates to priority during selection, so not treating them as sets
 	if utils.HasChanged(nodeClass.Status.Images, goalImages, &hashstructure.HashOptions{SlicesAsSets: false}) {
 		logger.WithValues("existingImages", nodeClass.Status.Images).WithValues("newImages", goalImages).Info("new available images updated for nodeclass")
 	}

--- a/pkg/controllers/nodeclass/status/images.go
+++ b/pkg/controllers/nodeclass/status/images.go
@@ -32,10 +32,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/awslabs/operatorpkg/reasonable"
+	"github.com/mitchellh/hashstructure/v2"
 	"github.com/samber/lo"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
+	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -157,10 +159,7 @@ func (r *NodeImageReconciler) Reconcile(ctx context.Context, nodeClass *v1beta1.
 		return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
 
-	// Note: the ChangeMonitor uses SlicesAsSets=true. However, we do actually care about the ordering of the Images, meaning we'll
-	//     miss logging potential updates on the ordering. Although, this is unexpected to occur.
-	//     https://github.com/kubernetes-sigs/karpenter/blob/349487633193bced541ad05bb76d02e633e73473/pkg/utils/pretty/changemonitor.go#L42
-	if r.cm.HasChanged(fmt.Sprintf("nodeclass-%s-images", nodeClass.Name), goalImages) {
+	if utils.HasChanged(nodeClass.Status.Images, goalImages, &hashstructure.HashOptions{SlicesAsSets: false}) {
 		logger.WithValues("existingImages", nodeClass.Status.Images).WithValues("newImages", goalImages).Info("new available images updated for nodeclass")
 	}
 	nodeClass.Status.Images = goalImages
@@ -197,6 +196,11 @@ func (r *NodeImageReconciler) isMaintenanceWindowOpen(ctx context.Context) (bool
 	}
 	// Monitoring the entire ConfigMap's data might catch more data changes than we care about. However, I think it makes sense to monitor
 	//     here as it does catch the entire spread of cases we care about, and will give us direct insight on the raw data.
+	// Note: we don't need to add the nodeclass name into the monitoring here, as we actually want the entries to collide, since
+	//     maintenance windows are a cluster level concept, rather that a nodeclass level type, meaning we'd have repeat redundant info
+	//     if scoping to the nodeclass.
+	// TODO: In the longer run, the maintenance window handling should be factored out into a sharable provider, rather than being contained
+	//     within the image controller itself.
 	if r.cm.HasChanged("nodeclass-maintenancewindowdata", mwConfigMap.Data) {
 		logger.WithValues("maintenanceWindowData", mwConfigMap.Data).Info("new maintenance window data discovered")
 	}

--- a/pkg/controllers/nodeclass/status/kubernetesversion.go
+++ b/pkg/controllers/nodeclass/status/kubernetesversion.go
@@ -104,7 +104,7 @@ func (r *KubernetesVersionReconciler) Reconcile(ctx context.Context, nodeClass *
 	nodeClass.Status.KubernetesVersion = goalK8sVersion
 	nodeClass.StatusConditions().SetTrue(v1beta1.ConditionTypeKubernetesVersionReady)
 	if r.cm.HasChanged(fmt.Sprintf("nodeclass-%s-kubernetesversion", nodeClass.Name), nodeClass.Status.KubernetesVersion) {
-		logger.WithValues("newkubernetesversion", nodeClass.Status.KubernetesVersion).Info("new kubernetes version updated for nodeclass")
+		logger.WithValues("newKubernetesVersion", nodeClass.Status.KubernetesVersion).Info("new kubernetes version updated for nodeclass")
 	}
 	return reconcile.Result{RequeueAfter: azurecache.KubernetesVersionTTL}, nil
 }

--- a/pkg/controllers/nodeclass/status/kubernetesversion.go
+++ b/pkg/controllers/nodeclass/status/kubernetesversion.go
@@ -71,7 +71,7 @@ func (r *KubernetesVersionReconciler) Register(_ context.Context, m manager.Mana
 //     - Note: We will indirectly trigger an upgrade to latest image version as well, by resetting the Images readiness.
 func (r *KubernetesVersionReconciler) Reconcile(ctx context.Context, nodeClass *v1beta1.AKSNodeClass) (reconcile.Result, error) {
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName(kubernetesVersionReconcilerName))
-	logger := log.FromContext(ctx).WithValues("existingkubernetesversion", nodeClass.Status.KubernetesVersion)
+	logger := log.FromContext(ctx).WithValues("existingKubernetesVersion", nodeClass.Status.KubernetesVersion)
 
 	goalK8sVersion, err := r.kubernetesVersionProvider.KubeServerVersion(ctx)
 	if err != nil {

--- a/pkg/controllers/nodeclass/status/kubernetesversion.go
+++ b/pkg/controllers/nodeclass/status/kubernetesversion.go
@@ -71,8 +71,7 @@ func (r *KubernetesVersionReconciler) Register(_ context.Context, m manager.Mana
 //     - Note: We will indirectly trigger an upgrade to latest image version as well, by resetting the Images readiness.
 func (r *KubernetesVersionReconciler) Reconcile(ctx context.Context, nodeClass *v1beta1.AKSNodeClass) (reconcile.Result, error) {
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName(kubernetesVersionReconcilerName))
-	logger := log.FromContext(ctx)
-	logger.V(1).Info("starting reconcile")
+	logger := log.FromContext(ctx).WithValues("existingkubernetesversion", nodeClass.Status.KubernetesVersion)
 
 	goalK8sVersion, err := r.kubernetesVersionProvider.KubeServerVersion(ctx)
 	if err != nil {
@@ -81,7 +80,7 @@ func (r *KubernetesVersionReconciler) Reconcile(ctx context.Context, nodeClass *
 
 	// Handles case 1: init, update kubernetes status to API server version found
 	if !nodeClass.StatusConditions().Get(v1beta1.ConditionTypeKubernetesVersionReady).IsTrue() || nodeClass.Status.KubernetesVersion == "" {
-		logger.Info(fmt.Sprintf("init kubernetes version: %s", goalK8sVersion))
+		logger.V(1).Info(fmt.Sprintf("init kubernetes version: %s", goalK8sVersion))
 	} else {
 		// Check if there is an upgrade
 		newK8sVersion, err := semver.Parse(goalK8sVersion)
@@ -94,16 +93,18 @@ func (r *KubernetesVersionReconciler) Reconcile(ctx context.Context, nodeClass *
 		}
 		// Handles case 2: Upgrade kubernetes version [Note: we set node image to not ready, since we upgrade node image when there is a kubernetes upgrade]
 		if newK8sVersion.GT(currentK8sVersion) {
-			logger.Info(fmt.Sprintf("kubernetes upgrade detected: from %s (current), to %s (discovered)", currentK8sVersion.String(), newK8sVersion.String()))
+			logger.V(1).Info(fmt.Sprintf("kubernetes upgrade detected: from %s (current), to %s (discovered)", currentK8sVersion.String(), newK8sVersion.String()))
 			nodeClass.StatusConditions().SetFalse(v1beta1.ConditionTypeImagesReady, "KubernetesUpgrade", "Performing kubernetes upgrade, need to get latest images")
 		} else if newK8sVersion.LT(currentK8sVersion) {
-			logger.Info(fmt.Sprintf("detected potential kubernetes downgrade: from %s (current), to %s (discovered)", currentK8sVersion.String(), newK8sVersion.String()))
+			logger.Info(fmt.Sprintf("WARN: detected potential kubernetes downgrade: from %s (current), to %s (discovered)", currentK8sVersion.String(), newK8sVersion.String()))
 			// We do not currently support downgrading, so keep the kubernetes version the same
 			goalK8sVersion = nodeClass.Status.KubernetesVersion
 		}
 	}
 	nodeClass.Status.KubernetesVersion = goalK8sVersion
 	nodeClass.StatusConditions().SetTrue(v1beta1.ConditionTypeKubernetesVersionReady)
-	logger.V(1).Info("successful reconcile")
+	if r.cm.HasChanged(fmt.Sprintf("nodeclass-%s-kubernetesversion", nodeClass.Name), nodeClass.Status.KubernetesVersion) {
+		logger.WithValues("newkubernetesversion", nodeClass.Status.KubernetesVersion).Info("new kubernetes version updated for nodeclass")
+	}
 	return reconcile.Result{RequeueAfter: azurecache.KubernetesVersionTTL}, nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
+	"github.com/mitchellh/hashstructure/v2"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Azure/karpenter-provider-azure/pkg/consts"
@@ -177,4 +178,15 @@ func IsAKSManagedVNET(nodeResourceGroup string, subnetID string) (bool, error) {
 	return managedVNETPattern.MatchString(id.VNetName) &&
 		strings.EqualFold(nodeResourceGroup, id.ResourceGroupName) &&
 		strings.EqualFold(id.SubnetName, managedSubnetName), nil
+}
+
+// HasChanged returns if the given value has changed, given the existing and new instance
+//
+// This option is accessible in place of using a ChangeMonitor, when there's access to both
+// the existing and new data.
+func HasChanged(existing, new any, options *hashstructure.HashOptions) bool {
+	// In the case of errors, the zero value from hashing will be compared, similar to ChangeMonitor
+	existingHV, _ := hashstructure.Hash(existing, hashstructure.FormatV2, options)
+	newHV, _ := hashstructure.Hash(new, hashstructure.FormatV2, options)
+	return existingHV != newHV
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
+	"github.com/mitchellh/hashstructure/v2"
 	. "github.com/onsi/gomega"
 )
 
@@ -91,4 +92,33 @@ func TestIsAKSManagedVNET(t *testing.T) {
 			}
 		})
 	}
+}
+func TestHasChanged_SimpleCases(t *testing.T) {
+	g := NewWithT(t)
+
+	// Case: Has not changed (same int)
+	g.Expect(utils.HasChanged(42, 42, nil)).To(BeFalse())
+
+	// Case: Has changed (different int)
+	g.Expect(utils.HasChanged(42, 43, nil)).To(BeTrue())
+
+	// Case: Has not changed (same string)
+	g.Expect(utils.HasChanged("azure", "azure", nil)).To(BeFalse())
+
+	// Case: Has changed (different string)
+	g.Expect(utils.HasChanged("azure", "cloud", nil)).To(BeTrue())
+}
+
+func TestHasChanged_SliceOrderWithSlicesAsSets(t *testing.T) {
+	g := NewWithT(t)
+
+	a := []int{1, 2, 3}
+	b := []int{3, 2, 1}
+
+	// By default, order matters
+	g.Expect(utils.HasChanged(a, b, nil)).To(BeTrue())
+
+	// With SlicesAsSets, order does not matter
+	opts := &hashstructure.HashOptions{SlicesAsSets: true}
+	g.Expect(utils.HasChanged(a, b, opts)).To(BeFalse())
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Doing some testing surrounding the maintenance window integration, and the nodeclass status controllers in general, had me uncovering multiple ways for improvement, which this PR aims to do.

**How was this change tested?**
- `make presubmit`
- manual testing of `make az-all` + inspecting of logs for different cases.
- E2E Runs:
    - https://github.com/Azure/karpenter-provider-azure/actions/runs/15592313549
    - https://github.com/Azure/karpenter-provider-azure/actions/runs/15594986110 (latest)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
