### PR TITLE
test(e2e): add --fail as partial mitigation for skaffold install

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -101,7 +101,7 @@ jobs:
         run: az account set --subscription ${{ secrets.E2E_SUBSCRIPTION_ID }}
       - name: install skaffold
         run: |
-          curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.14.2/skaffold-linux-amd64
+          curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.14.2/skaffold-linux-amd64 --fail
           install skaffold /usr/local/bin/
       - name: generate rg name
         run: |


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
We noticed issues surrounding skaffold install today in our E2E pipeline:
https://github.com/Azure/karpenter-provider-azure/actions/runs/15618169710/job/43996177030
![image](https://github.com/user-attachments/assets/1398185e-8555-4968-b81c-44e9695a32aa)

Believe this is a GCP outage issue:
https://status.cloud.google.com/

To partially mitigate the issue, so we detect the skaffold install failing earlier, we are adding a `--fail` onto the `curl`

You can see the improved faster failure here:
https://github.com/Azure/karpenter-provider-azure/actions/runs/15619685185/job/44001160681#step:9:22

**How was this change tested?**
- Nothing additional. See description for previous debugging that lead to this solution.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
