### PR TITLE
feat: add VM family level cache to the unvailable offerings cache

### DIFF
--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -84,7 +84,7 @@ func (u *UnavailableOfferings) IsUnavailable(sku *skewer.SKU, zone, capacityType
 	if err != nil {
 		skuVCPUCount = 0 // default to 0 if we can't determine VCPU count
 	}
-	if u.isFamilyUnavailable(sku.GetFamilyName(), capacityType, zone, skuVCPUCount) {
+	if u.isFamilyUnavailable(sku.GetFamilyName(), zone, capacityType, skuVCPUCount) {
 		return true
 	}
 
@@ -93,9 +93,9 @@ func (u *UnavailableOfferings) IsUnavailable(sku *skewer.SKU, zone, capacityType
 	return found
 }
 
-func (u *UnavailableOfferings) isFamilyUnavailable(skuFamilyName, capacityType, zone string, cpuCount int64) bool {
+func (u *UnavailableOfferings) isFamilyUnavailable(skuFamilyName, zone, capacityType string, cpuCount int64) bool {
 	// Check if VM family is blocked in the specific zone
-	if val, found := u.vmFamilyCache.Get(vmFamilyKey(skuFamilyName, capacityType, zone)); found {
+	if val, found := u.vmFamilyCache.Get(vmFamilyKey(skuFamilyName, zone, capacityType)); found {
 		if blockedCPUCount, ok := val.(int64); ok {
 			if blockedCPUCount == wholeVMFamilyBlockedSentinel {
 				// Entire VM family is blocked in this zone
@@ -120,7 +120,7 @@ func (u *UnavailableOfferings) MarkFamilyUnavailableWithTTL(ctx context.Context,
 				return
 			}
 			// If new limit would be less restrictive, keep the existing one
-			// TODO - should we adjust TTL here? 
+			// TODO - should we adjust TTL here for the existing entry in cache?
 			if cpuCount != wholeVMFamilyBlockedSentinel && currentBlockedCPUCount <= cpuCount {
 				return
 			}

--- a/pkg/cache/unavailableofferings_test.go
+++ b/pkg/cache/unavailableofferings_test.go
@@ -21,16 +21,26 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/skewer"
 	"github.com/patrickmn/go-cache"
 )
 
+func createTestSKU(name, family string) *skewer.SKU {
+	return &skewer.SKU{
+		Name:   &name,
+		Family: &family,
+	}
+}
+
 func TestUnavailableOfferings(t *testing.T) {
 	// create a new cache with a short TTL
-	c := cache.New(time.Second, time.Second)
-	u := NewUnavailableOfferingsWithCache(c)
+	singleInstanceCache := cache.New(time.Second, time.Second)
+	vmFamilyCache := cache.New(time.Second, time.Second)
+	u := NewUnavailableOfferingsWithCache(singleInstanceCache, vmFamilyCache)
+	testSKU := createTestSKU("NV16as_v4", "NVas_v4")
 
 	// test that an offering is not marked as unavailable initially
-	if u.IsUnavailable("NV16as_v4", "westus", "spot") {
+	if u.IsUnavailable(testSKU, "westus", "spot") {
 		t.Error("Offering should not be marked as unavailable initially")
 	}
 
@@ -38,7 +48,7 @@ func TestUnavailableOfferings(t *testing.T) {
 	u.MarkUnavailableWithTTL(context.TODO(), "test reason", "NV16as_v4", "westus", "spot", time.Second)
 
 	// test that the offering is now marked as unavailable
-	if !u.IsUnavailable("NV16as_v4", "westus", "spot") {
+	if !u.IsUnavailable(testSKU, "westus", "spot") {
 		t.Error("Offering should be marked as unavailable after being marked as such")
 	}
 
@@ -46,14 +56,14 @@ func TestUnavailableOfferings(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// test that the offering is no longer marked as unavailable
-	if u.IsUnavailable("NV16as_v4", "westus", "spot") {
+	if u.IsUnavailable(testSKU, "westus", "spot") {
 		t.Error("Offering should not be marked as unavailable after cache entry has expired")
 	}
 }
 
 func TestUnavailableOfferings_KeyGeneration(t *testing.T) {
 	expectedKey := "spot:NV16as_v4:westus"
-	key := key("NV16as_v4", "westus", "spot")
+	key := singleInstanceKey("NV16as_v4", "westus", "spot")
 	if key != expectedKey {
 		t.Errorf("Expected key to be %s, but got %s", expectedKey, key)
 	}

--- a/pkg/cache/unavailableofferings_test.go
+++ b/pkg/cache/unavailableofferings_test.go
@@ -18,17 +18,36 @@ package cache
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
 	"github.com/Azure/skewer"
 	"github.com/patrickmn/go-cache"
+	"github.com/samber/lo"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
 
-func createTestSKU(name, family string) *skewer.SKU {
+func createTestSKU(name, family string, cpuCount int) *skewer.SKU {
 	return &skewer.SKU{
-		Name:   &name,
-		Family: &family,
+		Name:         &name,
+		Family:       &family,
+		Capabilities: &[]compute.ResourceSkuCapabilities{{Name: lo.ToPtr(skewer.VCPUs), Value: lo.ToPtr(strconv.Itoa(cpuCount))}},
+	}
+}
+
+func assertOfferingUnavailable(t *testing.T, u *UnavailableOfferings, sku *skewer.SKU, zone, capacityType, message string) {
+	t.Helper()
+	if !u.IsUnavailable(sku, zone, capacityType) {
+		t.Errorf("%s: %s", sku.GetName(), message)
+	}
+}
+
+func assertOfferingAvailable(t *testing.T, u *UnavailableOfferings, sku *skewer.SKU, zone, capacityType, message string) {
+	t.Helper()
+	if u.IsUnavailable(sku, zone, capacityType) {
+		t.Errorf("%s: %s", sku.GetName(), message)
 	}
 }
 
@@ -37,27 +56,82 @@ func TestUnavailableOfferings(t *testing.T) {
 	singleInstanceCache := cache.New(time.Second, time.Second)
 	vmFamilyCache := cache.New(time.Second, time.Second)
 	u := NewUnavailableOfferingsWithCache(singleInstanceCache, vmFamilyCache)
-	testSKU := createTestSKU("NV16as_v4", "NVas_v4")
+	testSKU := createTestSKU("NV16as_v4", "NVasv4Family", 16)
 
 	// test that an offering is not marked as unavailable initially
-	if u.IsUnavailable(testSKU, "westus", "spot") {
-		t.Error("Offering should not be marked as unavailable initially")
-	}
+	assertOfferingAvailable(t, u, testSKU, "westus", karpv1.CapacityTypeSpot, "Offering should not be marked as unavailable initially")
 
 	// mark the offering as unavailable
-	u.MarkUnavailableWithTTL(context.TODO(), "test reason", "NV16as_v4", "westus", "spot", time.Second)
+	u.MarkUnavailableWithTTL(context.TODO(), "test reason", "NV16as_v4", "westus", karpv1.CapacityTypeSpot, time.Second)
 
 	// test that the offering is now marked as unavailable
-	if !u.IsUnavailable(testSKU, "westus", "spot") {
-		t.Error("Offering should be marked as unavailable after being marked as such")
-	}
+	assertOfferingUnavailable(t, u, testSKU, "westus", karpv1.CapacityTypeSpot, "Offering should be marked as unavailable after being marked as such")
+	// test that offering is available for different capacity type
+	assertOfferingAvailable(t, u, testSKU, "westus", karpv1.CapacityTypeOnDemand, "Offering should be available for different capacity type")
 
 	// wait for the cache entry to expire
 	time.Sleep(time.Second)
 
 	// test that the offering is no longer marked as unavailable
-	if u.IsUnavailable(testSKU, "westus", "spot") {
-		t.Error("Offering should not be marked as unavailable after cache entry has expired")
+	assertOfferingAvailable(t, u, testSKU, "westus", karpv1.CapacityTypeSpot, "Offering should not be marked as unavailable after cache entry has expired")
+}
+
+func TestUnavailableOfferingsVMFamilyLevel(t *testing.T) {
+	// create a new cache with a short TTL
+	singleInstanceCache := cache.New(time.Second, time.Second)
+	vmFamilyCache := cache.New(time.Second, time.Second)
+	u := NewUnavailableOfferingsWithCache(singleInstanceCache, vmFamilyCache)
+
+	skus := []*skewer.SKU{
+		createTestSKU("NV8as_v4", "NVasv4Family", 8),
+		createTestSKU("NV16as_v4", "NVasv4Family", 16),
+		createTestSKU("NV24as_v4", "NVasv4Family", 24),
+	}
+
+	// Test that offerings are not marked as unavailable initially
+	for _, sku := range skus {
+		assertOfferingAvailable(t, u, sku, "westus-1", karpv1.CapacityTypeOnDemand, "Offering should not be marked as unavailable initially")
+	}
+
+	// Mark part of the VM family as unavailable (>= 16 CPUs)
+	u.MarkFamilyUnavailableWithTTL(context.TODO(), skus[0].GetFamilyName(), "westus-1", karpv1.CapacityTypeOnDemand, 16, time.Second)
+
+	// Test that 16+ CPU offerings are marked as unavailable, but 8 CPU is not
+	assertOfferingAvailable(t, u, skus[0], "westus-1", karpv1.CapacityTypeOnDemand, "8 CPU offering should remain available after partial family marking")
+	assertOfferingUnavailable(t, u, skus[1], "westus-1", karpv1.CapacityTypeOnDemand, "16 CPU offering should be unavailable after partial family marking")
+	assertOfferingUnavailable(t, u, skus[2], "westus-1", karpv1.CapacityTypeOnDemand, "24 CPU offering should be unavailable after partial family marking")
+
+	// Wait for cache expiration
+	time.Sleep(time.Second)
+
+	// Test that offerings are no longer marked as unavailable after expiration
+	for _, sku := range skus {
+		assertOfferingAvailable(t, u, sku, "westus-1", karpv1.CapacityTypeOnDemand, "Offering should not be marked as unavailable after cache expiration")
+	}
+
+	// Mark the entire VM family as unavailable
+	u.MarkFamilyUnavailableWithTTL(context.TODO(), skus[0].GetFamilyName(), "westus-1", karpv1.CapacityTypeOnDemand, -1, time.Second)
+
+	// Test that offerings with both more and fewer than 16 CPUs are now marked as unavailable
+	for _, sku := range skus {
+		assertOfferingUnavailable(t, u, sku, "westus-1", karpv1.CapacityTypeOnDemand, "Offering should be marked as unavailable after entire family marking")
+	}
+
+	// Test that offering from same VM family and version but in a different zone are available
+	for _, sku := range skus {
+		assertOfferingAvailable(t, u, sku, "westus-2", karpv1.CapacityTypeOnDemand, "Offering in a different zone should be available")
+	}
+
+	// Test that offerings from same VM family but different version are available
+	differentVersionSKU := createTestSKU("NV16as_v5", "NVasv5Family", 16)
+	assertOfferingAvailable(t, u, differentVersionSKU, "westus-1", karpv1.CapacityTypeOnDemand, "Offering from a different version of the same VM family should be available")
+
+	// Wait for cache expiration
+	time.Sleep(time.Second)
+
+	// // Test that offerings with both more and fewer than 16 CPUs are now marked as available after expiration
+	for _, sku := range skus {
+		assertOfferingAvailable(t, u, sku, "westus-1", karpv1.CapacityTypeOnDemand, "Offering should not be marked as unavailable after cache expiration")
 	}
 }
 

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -194,8 +194,8 @@ func (p *DefaultProvider) createOfferings(sku *skewer.SKU, zones sets.Set[string
 	for zone := range zones {
 		onDemandPrice, onDemandOk := p.pricingProvider.OnDemandPrice(*sku.Name)
 		spotPrice, spotOk := p.pricingProvider.SpotPrice(*sku.Name)
-		availableOnDemand := onDemandOk && !p.unavailableOfferings.IsUnavailable(*sku.Name, zone, karpv1.CapacityTypeOnDemand)
-		availableSpot := spotOk && !p.unavailableOfferings.IsUnavailable(*sku.Name, zone, karpv1.CapacityTypeSpot)
+		availableOnDemand := onDemandOk && !p.unavailableOfferings.IsUnavailable(sku, zone, karpv1.CapacityTypeOnDemand)
+		availableSpot := spotOk && !p.unavailableOfferings.IsUnavailable(sku, zone, karpv1.CapacityTypeSpot)
 
 		onDemandOffering := &cloudprovider.Offering{
 			Requirements: scheduling.NewRequirements(

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
+	"github.com/Azure/skewer"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
@@ -34,9 +35,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ExpectUnavailable(env *test.Environment, instanceType string, zone string, capacityType string) {
+func ExpectUnavailable(env *test.Environment, sku *skewer.SKU, zone string, capacityType string) {
 	GinkgoHelper()
-	Expect(env.UnavailableOfferingsCache.IsUnavailable(instanceType, zone, capacityType)).To(BeTrue())
+	Expect(env.UnavailableOfferingsCache.IsUnavailable(sku, zone, capacityType)).To(BeTrue())
 }
 
 func ExpectKubeletFlags(env *test.Environment, customData string, expectedFlags map[string]string) {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**
Adds VM family level cache to give an option of blocking a part of, or entire, vm SKU family when certain allocation errors are encountered.

**How was this change tested?**

* Unit tests
* E2E tests(??) TODO

**Does this change impact docs?**
- [x] Yes, PR includes docs updates  - TODO
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
TODO
```
