### PR TITLE
fix: issue where container can come up but be unable to access token

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/go-logr/logr"
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
@@ -35,6 +37,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/flowcontrol"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/operator"
@@ -90,10 +93,16 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	azConfig, err := GetAZConfig()
 	lo.Must0(err, "creating Azure config") // NOTE: we prefer this over the cleaner azConfig := lo.Must(GetAzConfig()), as when initializing the client there are helpful error messages in initializing clients and the azure config
 
-	azClient, err := instance.CreateAZClient(ctx, azConfig)
+	cred, err := getCredential()
+	lo.Must0(err, "getting Azure credential")
+
+	// Get a token to ensure we can
+	lo.Must0(ensureToken(cred, azConfig), "ensuring Azure token can be retrieved")
+
+	azClient, err := instance.CreateAZClient(ctx, azConfig, cred)
 	lo.Must0(err, "creating Azure client")
 	if options.FromContext(ctx).VnetGUID == "" && options.FromContext(ctx).NetworkPluginMode == consts.NetworkPluginModeOverlay {
-		vnetGUID, err := getVnetGUID(azConfig, options.FromContext(ctx).SubnetID)
+		vnetGUID, err := getVnetGUID(cred, azConfig, options.FromContext(ctx).SubnetID)
 		lo.Must0(err, "getting VNET GUID")
 		options.FromContext(ctx).VnetGUID = vnetGUID
 	}
@@ -210,11 +219,7 @@ func getCABundle(restConfig *rest.Config) (*string, error) {
 	return lo.ToPtr(base64.StdEncoding.EncodeToString(transportConfig.TLS.CAData)), nil
 }
 
-func getVnetGUID(cfg *auth.Config, subnetID string) (string, error) {
-	creds, err := azidentity.NewDefaultAzureCredential(nil)
-	if err != nil {
-		return "", err
-	}
+func getVnetGUID(creds azcore.TokenCredential, cfg *auth.Config, subnetID string) (string, error) {
 	opts := armopts.DefaultArmOpts()
 	vnetClient, err := armnetwork.NewVirtualNetworksClient(cfg.SubscriptionID, creds, opts)
 	if err != nil {
@@ -281,4 +286,33 @@ func WaitForCRDs(ctx context.Context, timeout time.Duration, config *rest.Config
 
 	log.Info("all required CRDs are available")
 	return nil
+}
+
+// ensureToken ensures we can get a token for the Azure environment. Note that this doesn't actually
+// use the token for anything, it just checks that we can get one.
+func ensureToken(cred azcore.TokenCredential, cfg *auth.Config) error {
+	cloudEnv := azclient.EnvironmentFromName(cfg.Cloud)
+
+	// Short timeout to avoid hanging forever if something bad happens
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{cloudEnv.ServiceManagementEndpoint + "/.default"},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getCredential() (azcore.TokenCredential, error) {
+	// TODO: Don't use NewDefaultAzureCredential
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return auth.NewTokenWrapper(cred), nil
 }

--- a/pkg/providers/instance/azure_client.go
+++ b/pkg/providers/instance/azure_client.go
@@ -23,8 +23,8 @@ import (
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	armcomputev5 "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
@@ -105,7 +105,7 @@ func NewAZClientFromAPI(
 	}
 }
 
-func CreateAZClient(ctx context.Context, cfg *auth.Config) (*AZClient, error) {
+func CreateAZClient(ctx context.Context, cfg *auth.Config, cred azcore.TokenCredential) (*AZClient, error) {
 	// Defaulting env to Azure Public Cloud.
 	env := azclient.PublicCloud
 	var err error
@@ -113,7 +113,7 @@ func CreateAZClient(ctx context.Context, cfg *auth.Config) (*AZClient, error) {
 		env = azclient.EnvironmentFromName(cfg.Cloud)
 	}
 
-	azClient, err := NewAZClient(ctx, cfg, env)
+	azClient, err := NewAZClient(ctx, cfg, env, cred)
 	if err != nil {
 		return nil, err
 	}
@@ -122,13 +122,8 @@ func CreateAZClient(ctx context.Context, cfg *auth.Config) (*AZClient, error) {
 }
 
 // nolint: gocyclo
-func NewAZClient(ctx context.Context, cfg *auth.Config, env *azclient.Environment) (*AZClient, error) {
+func NewAZClient(ctx context.Context, cfg *auth.Config, env *azclient.Environment, cred azcore.TokenCredential) (*AZClient, error) {
 	o := options.FromContext(ctx)
-	defaultAzureCred, err := azidentity.NewDefaultAzureCredential(nil)
-	if err != nil {
-		return nil, err
-	}
-	cred := auth.NewTokenWrapper(defaultAzureCred)
 	opts := armopts.DefaultArmOpts()
 
 	extensionsClient, err := armcompute.NewVirtualMachineExtensionsClient(cfg.SubscriptionID, cred, opts)


### PR DESCRIPTION
When the process launches, if it doesn't check that it can retrieve a token, then if it's unable to retrieve a token later it will continue to retry getting a token, but won't ever exit the process.

This is a problem especially in the managed NAP case, because there's an IMDS proxy that needs to be set up before the NAP pod can get a token, but if the Karpenter pod starts too quickly it will open a connection in the transport connection pool to the wrong address (not the proxy), which will never serve it the correct token. This will mostly self-recover if request load is low, because the transport idle timeout will be hit and a new connection will go to the proxy, but if request load is high enough it can keep the connection open forever.

Better to lose the race gracefully and just exit the pod if we can't get a token.

Fixes #964

Tested: https://github.com/Azure/karpenter-provider-azure/actions/runs/15645616204 -- few flakes but the pods launched which is the main thing

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix bug impacting managed Karpenter (aka NAP) which could cause the pod to very occasionally fail to authenticate with Azure for long periods of time
```
