### PR TITLE
fix: issue where container can come up but be unable to access token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e
 	sigs.k8s.io/cloud-provider-azure v1.32.4
+	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.5.20
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/karpenter v1.4.0
 )
@@ -161,7 +162,6 @@ require (
 	k8s.io/component-helpers v0.32.3 // indirect
 	k8s.io/csi-translation-lib v0.32.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
-	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.5.20 // indirect
 	sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.5.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/go-logr/logr"
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
@@ -35,6 +37,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/flowcontrol"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/operator"
@@ -87,10 +90,16 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	azConfig, err := GetAZConfig()
 	lo.Must0(err, "creating Azure config") // NOTE: we prefer this over the cleaner azConfig := lo.Must(GetAzConfig()), as when initializing the client there are helpful error messages in initializing clients and the azure config
 
-	azClient, err := instance.CreateAZClient(ctx, azConfig)
+	cred, err := getCredential()
+	lo.Must0(err, "getting Azure credential")
+
+	// Get a token to ensure we can
+	lo.Must0(ensureToken(cred, azConfig), "ensuring Azure token can be retrieved")
+
+	azClient, err := instance.CreateAZClient(ctx, azConfig, cred)
 	lo.Must0(err, "creating Azure client")
 	if options.FromContext(ctx).VnetGUID == "" && options.FromContext(ctx).NetworkPluginMode == consts.NetworkPluginModeOverlay {
-		vnetGUID, err := getVnetGUID(azConfig, options.FromContext(ctx).SubnetID)
+		vnetGUID, err := getVnetGUID(cred, azConfig, options.FromContext(ctx).SubnetID)
 		lo.Must0(err, "getting VNET GUID")
 		options.FromContext(ctx).VnetGUID = vnetGUID
 	}
@@ -199,11 +208,7 @@ func getCABundle(restConfig *rest.Config) (*string, error) {
 	return lo.ToPtr(base64.StdEncoding.EncodeToString(transportConfig.TLS.CAData)), nil
 }
 
-func getVnetGUID(cfg *auth.Config, subnetID string) (string, error) {
-	creds, err := azidentity.NewDefaultAzureCredential(nil)
-	if err != nil {
-		return "", err
-	}
+func getVnetGUID(creds azcore.TokenCredential, cfg *auth.Config, subnetID string) (string, error) {
 	opts := armopts.DefaultArmOpts()
 	vnetClient, err := armnetwork.NewVirtualNetworksClient(cfg.SubscriptionID, creds, opts)
 	if err != nil {
@@ -270,4 +275,33 @@ func WaitForCRDs(ctx context.Context, timeout time.Duration, config *rest.Config
 
 	log.Info("all required CRDs are available")
 	return nil
+}
+
+// ensureToken ensures we can get a token for the Azure environment. Note that this doesn't actually
+// use the token for anything, it just checks that we can get one.
+func ensureToken(cred azcore.TokenCredential, cfg *auth.Config) error {
+	cloudEnv := azclient.EnvironmentFromName(cfg.Cloud)
+
+	// Short timeout to avoid hanging forever if something bad happens
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{cloudEnv.ServiceManagementEndpoint + "/.default"},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getCredential() (azcore.TokenCredential, error) {
+	// TODO: Don't use NewDefaultAzureCredential
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return auth.NewTokenWrapper(cred), nil
 }

--- a/pkg/providers/instance/azure_client.go
+++ b/pkg/providers/instance/azure_client.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	armcomputev5 "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
@@ -97,7 +97,7 @@ func NewAZClientFromAPI(
 	}
 }
 
-func CreateAZClient(ctx context.Context, cfg *auth.Config) (*AZClient, error) {
+func CreateAZClient(ctx context.Context, cfg *auth.Config, cred azcore.TokenCredential) (*AZClient, error) {
 	// Defaulting env to Azure Public Cloud.
 	env := azure.PublicCloud
 	var err error
@@ -108,7 +108,7 @@ func CreateAZClient(ctx context.Context, cfg *auth.Config) (*AZClient, error) {
 		}
 	}
 
-	azClient, err := NewAZClient(ctx, cfg, &env)
+	azClient, err := NewAZClient(ctx, cfg, &env, cred)
 	if err != nil {
 		return nil, err
 	}
@@ -116,12 +116,8 @@ func CreateAZClient(ctx context.Context, cfg *auth.Config) (*AZClient, error) {
 	return azClient, nil
 }
 
-func NewAZClient(ctx context.Context, cfg *auth.Config, env *azure.Environment) (*AZClient, error) {
-	defaultAzureCred, err := azidentity.NewDefaultAzureCredential(nil)
-	if err != nil {
-		return nil, err
-	}
-	cred := auth.NewTokenWrapper(defaultAzureCred)
+// nolint: gocyclo
+func NewAZClient(ctx context.Context, cfg *auth.Config, env *azure.Environment, cred azcore.TokenCredential) (*AZClient, error) {
 	opts := armopts.DefaultArmOpts()
 	extensionsClient, err := armcompute.NewVirtualMachineExtensionsClient(cfg.SubscriptionID, cred, opts)
 	if err != nil {


### PR DESCRIPTION
When the process launches, if it doesn't check that it can retrieve a token, then if it's unable to retrieve a token later it will continue to retry getting a token, but won't ever exit the process.

This is a problem especially in the managed NAP case, because there's an IMDS proxy that needs to be set up before the NAP pod can get a token, but if the Karpenter pod starts too quickly it will open a connection in the transport connection pool to the wrong address (not the proxy), which will never serve it the correct token. This will mostly self-recover if request load is low, because the transport idle timeout will be hit and a new connection will go to the proxy, but if request load is high enough it can keep the connection open forever.

Better to lose the race gracefully and just exit the pod if we can't get a token.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix bug impacting managed Karpenter (aka NAP) which could cause the pod to very occasionally fail to authenticate with Azure for long periods of time
```
