### PR TITLE
fix: auxiliary token refresh and use sig in acceptance tests

### DIFF
--- a/pkg/auth/auxiliarytoken.go
+++ b/pkg/auth/auxiliarytoken.go
@@ -17,7 +17,6 @@ limitations under the License.
 package auth
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -70,7 +69,7 @@ func (p *AuxiliaryTokenPolicy) Do(req *policy.Request) (*http.Response, error) {
 	return req.Next()
 }
 
-func NewAuxiliaryTokenPolicy(ctx context.Context, client AuxiliaryTokenServer, url string, scope string) (*AuxiliaryTokenPolicy, error) {
+func NewAuxiliaryTokenPolicy(client AuxiliaryTokenServer, url string, scope string) *AuxiliaryTokenPolicy {
 	auxPolicy := AuxiliaryTokenPolicy{
 		Token:  azcore.AccessToken{},
 		url:    url,
@@ -78,8 +77,7 @@ func NewAuxiliaryTokenPolicy(ctx context.Context, client AuxiliaryTokenServer, u
 		client: client,
 		lock:   sync.Mutex{},
 	}
-	log.FromContext(ctx).V(1).Info("Will use auxiliary token policy for creating virtual machines")
-	return &auxPolicy, nil
+	return &auxPolicy
 }
 
 func getAuxiliaryToken(client AuxiliaryTokenServer, url string, scope string) (azcore.AccessToken, error) {

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -53,6 +53,7 @@ import (
 )
 
 var ctx context.Context
+var testOptions *options.Options
 var stop context.CancelFunc
 var env *coretest.Environment
 var azureEnv *test.Environment
@@ -75,7 +76,8 @@ func TestCloudProvider(t *testing.T) {
 var _ = BeforeSuite(func() {
 	env = coretest.NewEnvironment(coretest.WithCRDs(apis.CRDs...), coretest.WithCRDs(v1alpha1.CRDs...), coretest.WithFieldIndexers(coretest.NodeProviderIDFieldIndexer(ctx)))
 	ctx = coreoptions.ToContext(ctx, coretest.Options())
-	ctx = options.ToContext(ctx, test.Options())
+	testOptions = test.Options()
+	ctx = options.ToContext(ctx, testOptions)
 	ctx, stop = context.WithCancel(ctx)
 	azureEnv = test.NewEnvironment(ctx, env)
 	fakeClock = clock.NewFakeClock(time.Now())
@@ -91,11 +93,12 @@ var _ = AfterSuite(func() {
 })
 
 var _ = BeforeEach(func() {
+	testOptions = test.Options()
 	ctx = coreoptions.ToContext(ctx, coretest.Options())
-	ctx = options.ToContext(ctx, test.Options())
+	ctx = options.ToContext(ctx, testOptions)
 
 	nodeClass = test.AKSNodeClass()
-	test.ApplyDefaultStatus(nodeClass, env)
+	test.ApplyDefaultStatus(nodeClass, env, testOptions.UseSIG)
 
 	nodePool = coretest.NodePool(karpv1.NodePool{
 		Spec: karpv1.NodePoolSpec{

--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -55,6 +55,7 @@ import (
 )
 
 var ctx context.Context
+var testOptions *options.Options
 var env *coretest.Environment
 var azureEnv *test.Environment
 var fakeClock *clock.FakeClock
@@ -74,7 +75,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	ctx = coreoptions.ToContext(ctx, coretest.Options())
-	ctx = options.ToContext(ctx, test.Options())
+	testOptions = test.Options()
+	ctx = options.ToContext(ctx, testOptions)
 	env = coretest.NewEnvironment(coretest.WithCRDs(apis.CRDs...), coretest.WithCRDs(v1alpha1.CRDs...))
 	//	ctx, stop = context.WithCancel(ctx)
 	azureEnv = test.NewEnvironment(ctx, env)
@@ -94,7 +96,7 @@ var _ = AfterSuite(func() {
 
 var _ = BeforeEach(func() {
 	nodeClass = test.AKSNodeClass()
-	test.ApplyDefaultStatus(nodeClass, env)
+	test.ApplyDefaultStatus(nodeClass, env, testOptions.UseSIG)
 
 	nodePool = coretest.NodePool(karpv1.NodePool{
 		Spec: karpv1.NodePoolSpec{

--- a/pkg/fake/auxiliarytokenserver.go
+++ b/pkg/fake/auxiliarytokenserver.go
@@ -54,6 +54,14 @@ func NewAuxiliaryTokenServer(token string, expiresOn time.Time, refreshOn time.T
 	}
 }
 
+func (c *AuxiliaryTokenServer) SetToken(token string, expiresOn time.Time, refreshOn time.Time) {
+	c.Token = azcore.AccessToken{
+		Token:     token,
+		ExpiresOn: expiresOn,
+		RefreshOn: refreshOn,
+	}
+}
+
 // Reset must be called between tests otherwise tests will pollute each other.
 func (c *AuxiliaryTokenServer) Reset() {
 	c.AuxiliaryTokenDoBehavior.Reset()

--- a/pkg/fake/auxiliarytokenserver.go
+++ b/pkg/fake/auxiliarytokenserver.go
@@ -40,6 +40,18 @@ var _ auth.AuxiliaryTokenServer = &AuxiliaryTokenServer{}
 
 type AuxiliaryTokenServer struct {
 	AuxiliaryTokenBehavior
+	Token azcore.AccessToken
+}
+
+// NewAuxiliaryTokenServer creates a new AuxiliaryTokenServer with the given token.
+func NewAuxiliaryTokenServer(token string, expiresOn time.Time, refreshOn time.Time) *AuxiliaryTokenServer {
+	return &AuxiliaryTokenServer{
+		Token: azcore.AccessToken{
+			Token:     token,
+			ExpiresOn: expiresOn,
+			RefreshOn: refreshOn,
+		},
+	}
 }
 
 // Reset must be called between tests otherwise tests will pollute each other.
@@ -61,11 +73,7 @@ func (c *AuxiliaryTokenServer) Do(req *http.Request) (*http.Response, error) {
 			return resp, nil
 		}
 
-		token := azcore.AccessToken{
-			Token:     "fake-token",
-			ExpiresOn: time.Now().Add(1 * time.Hour),
-			RefreshOn: time.Now().Add(5 * time.Second), // Set suggested refresh time for use in acceptance tests
-		}
+		token := c.Token
 		tokenBytes, _ := json.Marshal(token)
 		resp.StatusCode = http.StatusOK
 		resp.Body = io.NopCloser(bytes.NewReader(tokenBytes))

--- a/pkg/fake/auxiliarytokenserver.go
+++ b/pkg/fake/auxiliarytokenserver.go
@@ -64,6 +64,7 @@ func (c *AuxiliaryTokenServer) Do(req *http.Request) (*http.Response, error) {
 		token := azcore.AccessToken{
 			Token:     "fake-token",
 			ExpiresOn: time.Now().Add(1 * time.Hour),
+			RefreshOn: time.Now().Add(5 * time.Second), // Set suggested refresh time for use in acceptance tests
 		}
 		tokenBytes, _ := json.Marshal(token)
 		resp.StatusCode = http.StatusOK

--- a/pkg/fake/auxiliarytokenserver_test.go
+++ b/pkg/fake/auxiliarytokenserver_test.go
@@ -19,6 +19,7 @@ package fake
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/karpenter-provider-azure/pkg/auth"
@@ -27,6 +28,11 @@ import (
 )
 
 func Test_AddAuxiliaryTokenPolicyClientOptions(t *testing.T) {
+	defaultToken := azcore.AccessToken{
+		Token:     "test-token",
+		ExpiresOn: time.Now().Add(1 * time.Hour),
+		RefreshOn: time.Now().Add(5 * time.Second),
+	}
 	tests := []struct {
 		name      string
 		expected  azcore.AccessToken
@@ -56,7 +62,7 @@ func Test_AddAuxiliaryTokenPolicyClientOptions(t *testing.T) {
 			scope:   "test-scope",
 		},
 	}
-	tokenServer := &AuxiliaryTokenServer{}
+	tokenServer := &AuxiliaryTokenServer{Token: defaultToken}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			clientOpts := armopts.DefaultArmOpts()

--- a/pkg/fake/virtualmachinesapi.go
+++ b/pkg/fake/virtualmachinesapi.go
@@ -93,8 +93,7 @@ func (c *VirtualMachinesAPI) Reset() {
 func (c *VirtualMachinesAPI) UseAuxiliaryPolicy() error {
 	if c.AuxiliaryTokenPolicy != nil {
 		request, _ := runtime.NewRequest(context.Background(), "GET", "http://example.com")
-		_, err := c.AuxiliaryTokenPolicy.Do(request)
-		if err != nil {
+		if _, err := c.AuxiliaryTokenPolicy.Do(request); err != nil {
 			return err
 		}
 	}
@@ -112,8 +111,7 @@ func (c *VirtualMachinesAPI) BeginCreateOrUpdate(ctx context.Context, resourceGr
 	// BeginCreateOrUpdate should fail, if the vm exists in the cache, and we are attempting to change properties for zone
 
 	return c.VirtualMachineCreateOrUpdateBehavior.Invoke(input, func(input *VirtualMachineCreateOrUpdateInput) (*armcompute.VirtualMachinesClientCreateOrUpdateResponse, error) {
-		err := c.UseAuxiliaryPolicy()
-		if err != nil {
+		if err := c.UseAuxiliaryPolicy(); err != nil {
 			return nil, &azcore.ResponseError{ErrorCode: errors.ResourceNotFound}
 		}
 		//if input.ResourceGroupName == "" {

--- a/pkg/providers/imagefamily/nodeimage_test.go
+++ b/pkg/providers/imagefamily/nodeimage_test.go
@@ -162,7 +162,7 @@ var _ = Describe("NodeImageProvider tests", func() {
 
 	Context("List SIG Images", func() {
 		BeforeEach(func() {
-			testOptions := options.FromContext(ctx)
+			testOptions = options.FromContext(ctx)
 			testOptions.UseSIG = true
 			testOptions.SIGSubscriptionID = sigSubscription
 			testOptions.SIGAccessTokenScope = "http://valid-scope.com/.default"

--- a/pkg/providers/imagefamily/nodeimage_test.go
+++ b/pkg/providers/imagefamily/nodeimage_test.go
@@ -100,7 +100,8 @@ var _ = Describe("NodeImageProvider tests", func() {
 
 	BeforeEach(func() {
 		ctx = coreoptions.ToContext(ctx, coretest.Options())
-		ctx = options.ToContext(ctx, test.Options())
+		testOptions = test.Options()
+		ctx = options.ToContext(ctx, testOptions)
 
 		communityImageVersionsAPI = &fake.CommunityGalleryImageVersionsAPI{}
 		cigImageVersionTest := cigImageVersion
@@ -110,7 +111,7 @@ var _ = Describe("NodeImageProvider tests", func() {
 		kubernetesVersion = lo.Must(env.KubernetesInterface.Discovery().ServerVersion()).String()
 
 		nodeClass = test.AKSNodeClass()
-		test.ApplyDefaultStatus(nodeClass, env)
+		test.ApplyDefaultStatus(nodeClass, env, testOptions.UseSIG)
 	})
 
 	Context("List CIG Images", func() {

--- a/pkg/providers/imagefamily/nodeimage_test.go
+++ b/pkg/providers/imagefamily/nodeimage_test.go
@@ -91,6 +91,7 @@ func getExpectedTestSIGImages(imageFamily string, version string, kubernetesVers
 
 var _ = Describe("NodeImageProvider tests", func() {
 	var (
+		testOptions               *options.Options
 		communityImageVersionsAPI *fake.CommunityGalleryImageVersionsAPI
 
 		nodeImageProvider imagefamily.NodeImageProvider

--- a/pkg/providers/imagefamily/suite_test.go
+++ b/pkg/providers/imagefamily/suite_test.go
@@ -27,14 +27,12 @@ import (
 	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
-	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
 )
 
 var (
-	ctx         context.Context
-	env         *coretest.Environment
-	testOptions *options.Options
+	ctx context.Context
+	env *coretest.Environment
 )
 
 func TestImageFamilyProvider(t *testing.T) {

--- a/pkg/providers/imagefamily/suite_test.go
+++ b/pkg/providers/imagefamily/suite_test.go
@@ -27,12 +27,14 @@ import (
 	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
 )
 
 var (
-	ctx context.Context
-	env *coretest.Environment
+	ctx         context.Context
+	env         *coretest.Environment
+	testOptions *options.Options
 )
 
 func TestImageFamilyProvider(t *testing.T) {

--- a/pkg/providers/instance/azure_client.go
+++ b/pkg/providers/instance/azure_client.go
@@ -69,7 +69,6 @@ type AZClient struct {
 	virtualMachinesClient          VirtualMachinesAPI
 	virtualMachinesExtensionClient VirtualMachineExtensionsAPI
 	networkInterfacesClient        NetworkInterfacesAPI
-	auxiliaryTokenClient           auth.AuxiliaryTokenServer
 
 	NodeImageVersionsClient imagefamilytypes.NodeImageVersionsAPI
 	ImageVersionsClient     imagefamilytypes.CommunityGalleryImageVersionsAPI
@@ -91,12 +90,10 @@ func NewAZClientFromAPI(
 	nodeImageVersionsClient imagefamilytypes.NodeImageVersionsAPI,
 	nodeBootstrappingClient imagefamilytypes.NodeBootstrappingAPI,
 	skuClient skuclient.SkuClient,
-	auxiliaryTokenClient auth.AuxiliaryTokenServer,
 ) *AZClient {
 	return &AZClient{
 		virtualMachinesClient:          virtualMachinesClient,
 		azureResourceGraphClient:       azureResourceGraphClient,
-		auxiliaryTokenClient:           auxiliaryTokenClient,
 		virtualMachinesExtensionClient: virtualMachinesExtensionClient,
 		networkInterfacesClient:        interfacesClient,
 		ImageVersionsClient:            imageVersionsClient,
@@ -207,6 +204,5 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *azclient.Environmen
 		communityImageVersionsClient,
 		nodeImageVersionsClient,
 		nodeBootstrappingClient,
-		skuClient,
-		auxiliaryTokenClient), nil
+		skuClient), nil
 }

--- a/pkg/providers/instance/azure_client.go
+++ b/pkg/providers/instance/azure_client.go
@@ -18,8 +18,6 @@ package instance
 
 import (
 	"context"
-	"net/http"
-	"time"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 
@@ -137,11 +135,9 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *azclient.Environmen
 	var auxiliaryTokenClient auth.AuxiliaryTokenServer
 	if o.UseSIG {
 		klog.V(1).Info("Using SIG for image versions")
-		auxiliaryTokenClient = &http.Client{Timeout: 10 * time.Second}
-		auxPolicy, err := auth.NewAuxiliaryTokenPolicy(ctx, auxiliaryTokenClient, o.SIGAccessTokenServerURL, o.SIGAccessTokenScope)
-		if err != nil {
-			return nil, err
-		}
+		auxiliaryTokenClient = armopts.DefaultHTTPClient()
+		klog.V(1).Info("Will use auxiliary token policy for creating virtual machines")
+		auxPolicy := auth.NewAuxiliaryTokenPolicy(auxiliaryTokenClient, o.SIGAccessTokenServerURL, o.SIGAccessTokenScope)
 		vmClientOptions.ClientOptions.PerRetryPolicies = append(vmClientOptions.ClientOptions.PerRetryPolicies, auxPolicy)
 	}
 	virtualMachinesClient, err := armcompute.NewVirtualMachinesClient(cfg.SubscriptionID, cred, &vmClientOptions)

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -364,4 +364,23 @@ var _ = Describe("InstanceProvider", func() {
 		Expect(nic.Properties.NetworkSecurityGroup).ToNot(BeNil())
 		Expect(lo.FromPtr(nic.Properties.NetworkSecurityGroup.ID)).To(Equal(expectedNSGID))
 	})
+
+	It("should use cached auxiliary token when not expired", func() {
+		// write a test that verifies the auxiliary token is cached and reused
+		// by ensuring the AuxiliaryTokenServer fake is not called
+		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+
+		pod := coretest.UnschedulablePod(coretest.PodOptions{})
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
+		ExpectScheduled(ctx, env.Client, pod)
+
+		Expect(azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+		Expect(azureEnv.AuxiliaryTokenServer.AuxiliaryTokenDoBehavior.CalledWithInput.Len()).To(Equal(0))
+	})
+
+	It("should refresh auxiliary token if expired", func() {
+		// write a test that verifies the auxiliary token is refreshed when it is expired
+		// by ensuring the AuxiliaryTokenServer fake is called since RefreshOn is set to 5 seconds in the fake server
+
+	})
 })

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -209,23 +209,22 @@ var _ = Describe("InstanceProvider", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 
 				Expect(azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
-				Expect(azureEnv.AuxiliaryTokenServer.AuxiliaryTokenDoBehavior.CalledWithInput.Len()).To(Equal(1))
+				Expect(azureEnv.AuxiliaryTokenServer.AuxiliaryTokenDoBehavior.CalledWithInput.Len()).To(Equal(1)) // init token
 			})
 		})
 
 		Context("token is cached by previous vmClient call", func() {
 			BeforeEach(func() {
-				azureEnv.VirtualMachinesAPI.AuxiliaryTokenPolicy.Token = azureEnv.AuxiliaryTokenServer.Token
+				_ = azureEnv.VirtualMachinesAPI.UseAuxiliaryTokenPolicy()
 			})
 			It("should use cached auxiliary token when still valid", func() {
 				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
-
 				pod := coretest.UnschedulablePod(coretest.PodOptions{})
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
 				ExpectScheduled(ctx, env.Client, pod)
 
 				Expect(azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
-				Expect(azureEnv.AuxiliaryTokenServer.AuxiliaryTokenDoBehavior.CalledWithInput.Len()).To(Equal(0))
+				Expect(azureEnv.AuxiliaryTokenServer.AuxiliaryTokenDoBehavior.CalledWithInput.Len()).To(Equal(1)) // init token
 				Expect(azureEnv.VirtualMachinesAPI.AuxiliaryTokenPolicy.Token).ToNot(BeNil())
 			})
 
@@ -238,7 +237,7 @@ var _ = Describe("InstanceProvider", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 
 				Expect(azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
-				Expect(azureEnv.AuxiliaryTokenServer.AuxiliaryTokenDoBehavior.CalledWithInput.Len()).To(Equal(1))
+				Expect(azureEnv.AuxiliaryTokenServer.AuxiliaryTokenDoBehavior.CalledWithInput.Len()).To(Equal(2)) // init + refresh token
 			})
 
 			It("should refresh auxiliary token if after RefreshOn", func() {
@@ -250,7 +249,7 @@ var _ = Describe("InstanceProvider", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 
 				Expect(azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
-				Expect(azureEnv.AuxiliaryTokenServer.AuxiliaryTokenDoBehavior.CalledWithInput.Len()).To(Equal(1))
+				Expect(azureEnv.AuxiliaryTokenServer.AuxiliaryTokenDoBehavior.CalledWithInput.Len()).To(Equal(2)) // init + refresh token
 			})
 		})
 	})

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -78,6 +78,7 @@ import (
 )
 
 var ctx context.Context
+var testOptions *options.Options
 var stop context.CancelFunc
 var env *coretest.Environment
 var azureEnv, azureEnvNonZonal *test.Environment
@@ -93,7 +94,8 @@ func TestAzure(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	ctx = coreoptions.ToContext(ctx, coretest.Options())
-	ctx = options.ToContext(ctx, test.Options())
+	testOptions = test.Options()
+	ctx = options.ToContext(ctx, testOptions)
 
 	env = coretest.NewEnvironment(coretest.WithCRDs(apis.CRDs...), coretest.WithCRDs(v1alpha1.CRDs...))
 
@@ -127,7 +129,7 @@ var _ = Describe("InstanceType Provider", func() {
 
 	BeforeEach(func() {
 		nodeClass = test.AKSNodeClass()
-		test.ApplyDefaultStatus(nodeClass, env)
+		test.ApplyDefaultStatus(nodeClass, env, testOptions.UseSIG)
 
 		nodePool = coretest.NodePool(karpv1.NodePool{
 			Spec: karpv1.NodePoolSpec{

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -64,6 +64,7 @@ type Environment struct {
 	PricingAPI                  *fake.PricingAPI
 	LoadBalancersAPI            *fake.LoadBalancersAPI
 	NetworkSecurityGroupAPI     *fake.NetworkSecurityGroupAPI
+	AuxiliaryTokenServer        *fake.AuxiliaryTokenServer
 
 	// Cache
 	KubernetesVersionCache    *cache.Cache
@@ -111,6 +112,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 	networkSecurityGroupAPI := &fake.NetworkSecurityGroupAPI{}
 	nodeImageVersionsAPI := &fake.NodeImageVersionsAPI{}
 	nodeBootstrappingAPI := &fake.NodeBootstrappingAPI{}
+	auxiliaryTokenServer := &fake.AuxiliaryTokenServer{}
 
 	azureResourceGraphAPI := fake.NewAzureResourceGraphAPI(resourceGroup, virtualMachinesAPI, networkInterfacesAPI)
 	// Cache
@@ -161,6 +163,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		nodeImageVersionsAPI,
 		nodeBootstrappingAPI,
 		skuClientSingleton,
+		auxiliaryTokenServer,
 	)
 	instanceProvider := instance.NewDefaultProvider(
 		azClient,

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -62,7 +62,6 @@ type Environment struct {
 	VirtualMachineExtensionsAPI *fake.VirtualMachineExtensionsAPI
 	NetworkInterfacesAPI        *fake.NetworkInterfacesAPI
 	CommunityImageVersionsAPI   *fake.CommunityGalleryImageVersionsAPI
-	NodeImageVersionsAPI        *fake.NodeImageVersionsAPI
 	MockSkuClientSingleton      *fake.MockSkuClientSingleton
 	PricingAPI                  *fake.PricingAPI
 	LoadBalancersAPI            *fake.LoadBalancersAPI
@@ -171,7 +170,6 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		nodeImageVersionsAPI,
 		nodeBootstrappingAPI,
 		skuClientSingleton,
-		auxiliaryTokenServer,
 	)
 	instanceProvider := instance.NewDefaultProvider(
 		azClient,
@@ -193,7 +191,6 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		VirtualMachineExtensionsAPI: virtualMachinesExtensionsAPI,
 		NetworkInterfacesAPI:        networkInterfacesAPI,
 		CommunityImageVersionsAPI:   communityImageVersionsAPI,
-		NodeImageVersionsAPI:        nodeImageVersionsAPI,
 		LoadBalancersAPI:            loadBalancersAPI,
 		NetworkSecurityGroupAPI:     networkSecurityGroupAPI,
 		MockSkuClientSingleton:      skuClientSingleton,

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -107,7 +107,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 	var auxiliaryTokenServer *fake.AuxiliaryTokenServer
 	if testOptions.UseSIG {
 		auxiliaryTokenServer = fake.NewAuxiliaryTokenServer("test-token", time.Now().Add(1*time.Hour), time.Now().Add(5*time.Minute))
-		auxTokenPolicy, _ = auth.NewAuxiliaryTokenPolicy(ctx, auxiliaryTokenServer, testOptions.SIGAccessTokenServerURL, testOptions.SIGAccessTokenScope)
+		auxTokenPolicy = auth.NewAuxiliaryTokenPolicy(auxiliaryTokenServer, testOptions.SIGAccessTokenServerURL, testOptions.SIGAccessTokenScope)
 	}
 	virtualMachinesAPI := &fake.VirtualMachinesAPI{AuxiliaryTokenPolicy: auxTokenPolicy}
 

--- a/pkg/test/nodeclass.go
+++ b/pkg/test/nodeclass.go
@@ -62,6 +62,7 @@ func AKSNodeClass(overrides ...v1beta1.AKSNodeClass) *v1beta1.AKSNodeClass {
 	}
 }
 
+// TODO: Pass in test.Options if we want to use more options within this func
 func ApplyDefaultStatus(nodeClass *v1beta1.AKSNodeClass, env *coretest.Environment, useSIG bool) {
 	if useSIG {
 		ApplySIGImages(nodeClass)

--- a/pkg/test/nodeclass.go
+++ b/pkg/test/nodeclass.go
@@ -62,8 +62,12 @@ func AKSNodeClass(overrides ...v1beta1.AKSNodeClass) *v1beta1.AKSNodeClass {
 	}
 }
 
-func ApplyDefaultStatus(nodeClass *v1beta1.AKSNodeClass, env *coretest.Environment) {
-	ApplyCIGImages(nodeClass)
+func ApplyDefaultStatus(nodeClass *v1beta1.AKSNodeClass, env *coretest.Environment, useSIG bool) {
+	if useSIG {
+		ApplySIGImages(nodeClass)
+	} else {
+		ApplyCIGImages(nodeClass)
+	}
 	nodeClass.StatusConditions().SetTrue(v1beta1.ConditionTypeImagesReady)
 
 	testK8sVersion := lo.Must(semver.ParseTolerant(lo.Must(env.KubernetesInterface.Discovery().ServerVersion()).String())).String()

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -79,8 +79,8 @@ func Options(overrides ...OptionsFields) *azoptions.Options {
 		ProvisionMode:                  lo.FromPtrOr(options.ProvisionMode, "aksscriptless"),
 		NodeBootstrappingServerURL:     lo.FromPtrOr(options.NodeBootstrappingServerURL, ""),
 		UseSIG:                         lo.FromPtrOr(options.UseSIG, false),
-		SIGSubscriptionID:              lo.FromPtrOr(options.SIGSubscriptionID, ""),
-		SIGAccessTokenServerURL:        lo.FromPtrOr(options.SIGAccessTokenServerURL, ""),
-		SIGAccessTokenScope:            lo.FromPtrOr(options.SIGAccessTokenScope, ""),
+		SIGSubscriptionID:              lo.FromPtrOr(options.SIGSubscriptionID, "12345678-1234-1234-1234-123456789012"),
+		SIGAccessTokenServerURL:        lo.FromPtrOr(options.SIGAccessTokenServerURL, "https://test-sig-access-token-server.com"),
+		SIGAccessTokenScope:            lo.FromPtrOr(options.SIGAccessTokenScope, "https://management.azure.com/.default"),
 	}
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**
* Follow-up from #540 and #910 
* AuxialiaryTokenPolicy will now call a function before every call made by the VM Client
* This function call aux token server if the token is expired or will expire soon. Otherwise, it will use a cached token

**How was this change tested?**
* acceptance tests (WIP)
* further e2e testing will be done w/ a test image used by managed Karpenter

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
