### PR TITLE
fix: don't use ephemeral disk if not supported

### DIFF
--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -178,7 +178,7 @@ func computeRequirements(sku *skewer.SKU, vmsize *skewer.VMSizeType, architectur
 	// size parts
 	requirements[v1beta1.LabelSKUFamily].Insert(vmsize.Family)
 
-	setRequirementsEphemeralOSDiskSupported(requirements, sku, vmsize)
+	setRequirementsEphemeralOSDiskSupported(requirements, sku)
 	setRequirementsHyperVGeneration(requirements, sku)
 	setRequirementsGPU(requirements, sku, vmsize)
 	setRequirementsVersion(requirements, vmsize)
@@ -186,7 +186,7 @@ func computeRequirements(sku *skewer.SKU, vmsize *skewer.VMSizeType, architectur
 	return requirements
 }
 
-func setRequirementsEphemeralOSDiskSupported(requirements scheduling.Requirements, sku *skewer.SKU, vmsize *skewer.VMSizeType) {
+func setRequirementsEphemeralOSDiskSupported(requirements scheduling.Requirements, sku *skewer.SKU) {
 	sizeGB, _ := FindMaxEphemeralSizeGBAndPlacement(sku)
 	if sizeGB > 0 {
 		requirements[v1beta1.LabelSKUStorageEphemeralOSMaxSize].Insert(fmt.Sprint(sizeGB))

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -187,8 +187,8 @@ func computeRequirements(sku *skewer.SKU, vmsize *skewer.VMSizeType, architectur
 }
 
 func setRequirementsEphemeralOSDiskSupported(requirements scheduling.Requirements, sku *skewer.SKU, vmsize *skewer.VMSizeType) {
-	if sku.IsEphemeralOSDiskSupported() && vmsize.Series != "Dlds_v5" { // Dlds_v5 does not support ephemeral OS disk, contrary to what it claims
-		sizeGB, _ := FindMaxEphemeralSizeGBAndPlacement(sku)
+	sizeGB, _ := FindMaxEphemeralSizeGBAndPlacement(sku)
+	if sizeGB > 0 {
 		requirements[v1beta1.LabelSKUStorageEphemeralOSMaxSize].Insert(fmt.Sprint(sizeGB))
 	}
 }

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -359,6 +359,11 @@ func FindMaxEphemeralSizeGBAndPlacement(sku *skewer.SKU) (sizeGB int64, placemen
 	if sku == nil {
 		return 0, nil
 	}
+
+	if !sku.IsEphemeralOSDiskSupported() {
+		return 0, nil // ephemeral disk is not supported by this SKU
+	}
+
 	maxNVMeMiB, _ := nvmeDiskSizeInMiB(sku)
 
 	// Check NVMe disk first (highest priority)
@@ -453,10 +458,6 @@ func supportsNVMeEphemeralOSDisk(sku *skewer.SKU) bool {
 }
 
 func UseEphemeralDisk(sku *skewer.SKU, nodeClass *v1beta1.AKSNodeClass) bool {
-	if !sku.IsEphemeralOSDiskSupported() {
-		return false // ephemeral disk is not supported by this SKU
-	}
-
 	sizeGB, _ := FindMaxEphemeralSizeGBAndPlacement(sku)
 	return int64(*nodeClass.Spec.OSDiskSizeGB) <= sizeGB // use ephemeral disk if it is large enough
 }

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -453,6 +453,10 @@ func supportsNVMeEphemeralOSDisk(sku *skewer.SKU) bool {
 }
 
 func UseEphemeralDisk(sku *skewer.SKU, nodeClass *v1beta1.AKSNodeClass) bool {
+	if !sku.IsEphemeralOSDiskSupported() {
+		return false // ephemeral disk is not supported by this SKU
+	}
+
 	sizeGB, _ := FindMaxEphemeralSizeGBAndPlacement(sku)
 	return int64(*nodeClass.Spec.OSDiskSizeGB) <= sizeGB // use ephemeral disk if it is large enough
 }

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -361,7 +361,7 @@ func FindMaxEphemeralSizeGBAndPlacement(sku *skewer.SKU) (sizeGB int64, placemen
 	}
 
 	if !sku.IsEphemeralOSDiskSupported() {
-		return 0, nil // ephemeral disk is not supported by this SKU
+		return 0, nil // ephemeral OS disk is not supported by this SKU
 	}
 
 	maxNVMeMiB, _ := nvmeDiskSizeInMiB(sku)

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -634,22 +634,23 @@ var _ = Describe("InstanceType Provider", func() {
 			// Standard_A0
 			// NvmeDiskSizeInMiB == 0
 			// CacheDiskBytes == 0, this is zero
-			// MaxResourceVolumeMB == 20480 Mib -> 21.474836 GB. Note that this sku doesnt support ephemeral os disk,
-			// but we do filtering in another function for this, so we should just return 21 and resource disk placement, even though we cannot set it to that
-			// other places will filter out this sku, we just need the sku to test NVME 0, Cache 0, MaxResourceVolumeMB > 0
+			// MaxResourceVolumeMB == 20480 Mib -> 21.474836 GB. Note that this sku doesnt support ephemeral os disk
 			DescribeTable("should return the max ephemeral disk size in GB for a given instance type",
 				func(sku *skewer.SKU, expectedSize int64, expectedPlacement *armcompute.DiffDiskPlacement) {
 					sizeGB, placement := instancetype.FindMaxEphemeralSizeGBAndPlacement(sku)
 					Expect(sizeGB).To(Equal(expectedSize))
 					Expect(placement).To(Equal(expectedPlacement))
-
 				}, Entry("Standard_B20ms", SkewerSKU("Standard_B20ms"), int64(32), lo.ToPtr(armcompute.DiffDiskPlacementCacheDisk)),
 				Entry("Standard_D128ds_v6", SkewerSKU("Standard_D128ds_v6"), int64(7559), lo.ToPtr(armcompute.DiffDiskPlacementNvmeDisk)),
 				Entry("Standard_D16plds_v5", SkewerSKU("Standard_D16plds_v5"), int64(429), lo.ToPtr(armcompute.DiffDiskPlacementCacheDisk)),
-				Entry("Standard_D2as_v6", SkewerSKU("Standard_D2as_v6"), int64(0), nil),
+				Entry("Standard_D2as_v6", SkewerSKU("Standard_D2as_v6"), int64(0), nil), // does not support ephemeral
 				Entry("Standard_NC24ads_A100_v4", SkewerSKU("Standard_NC24ads_A100_v4"), int64(274), lo.ToPtr(armcompute.DiffDiskPlacementCacheDisk)),
 				Entry("Standard_D64s_v3", SkewerSKU("Standard_D64s_v3"), int64(1717), lo.ToPtr(armcompute.DiffDiskPlacementCacheDisk)),
-				Entry("Standard_A0", SkewerSKU("Standard_A0"), int64(21), lo.ToPtr(armcompute.DiffDiskPlacementResourceDisk)),
+				Entry("Standard_A0", SkewerSKU("Standard_A0"), int64(0), nil),       // does not support ephemeral
+				Entry("Standard_D2_v2", SkewerSKU("Standard_D2_v2"), int64(0), nil), // does not support ephemeral
+				// TODO: codegen
+				// Entry("Standard_D2pls_v5", SkewerSKU("Standard_D2pls_v5"), int64(0), nil), // does not support ephemeral
+				// Entry("Standard_D2lds_v5", SkewerSKU("Standard_D2lds_v5"), int64(80), armcompute.DiffDiskPlacementResourceDisk),
 				Entry("Nil SKU", nil, int64(0), nil),
 			)
 		})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Follow-up to #940 

**Description**

Check whether SKU supports ephemeral disk. Fixes regression in provisioning of selected SKUs that don't support ephemeral OS disk, but might have cache or temp disk that is larger than OS disk (such as Standard_D8pls_v5) - a combination that would cause attempted use of ephemeral OS disk and fail the provisioning.

* Add the check for ephemeral disk support
* Use the same exact logic for ephemeral OS disk size requirement population
* Drop outdated restriction on `Dlds_v5` (which was likely in place due to lack of placement support); tested
* Update unit tests & add E2E tests

There are some additional refactoring, SKU codegen, and cleanup of comments possible and desirable; keeping changes in this PR to the minimum to focus on fixing the regression and facilitate easy review

**How was this change tested?**

* `make presubmit`
* manual testing of Standard_D8pls_v5 (original failure) & Dlds_v5 (removed restriction)
* E2E: https://github.com/Azure/karpenter-provider-azure/actions/runs/15945735374

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
