### PR TITLE
test: periodically run self-hosted e2es on main every 24 hours

### DIFF
--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -1,7 +1,7 @@
 name: E2EMatrixTrigger
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 11 * * *'
   workflow_dispatch:
     inputs:
       location:


### PR DESCRIPTION
**Description**
This PR runs these self hosted e2es every 24 hours on top of the merge and manual triggers. 
**How was this change tested?**
- schedule can only be triggered off of main and workflow files in main, so we can't test it, see github workflow docs: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
