### PR TITLE
chore: set user agent on release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ codegen: ## Auto generate files based on Azure API responses
 snapshot: az-login ## Builds and publishes snapshot release
 	./hack/release/snapshot.sh
 
-release: ## Builds and publishes stable release
+release: az-login ## Builds and publishes stable release
 	./hack/release/release.sh
 
 toolchain: ## Install developer toolchain

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ include Makefile-az.mk
 LDFLAGS ?= -ldflags=-X=sigs.k8s.io/karpenter/pkg/operator.Version=$(shell git describe --tags --always | cut -d"v" -f2)
 
 GOFLAGS ?= $(LDFLAGS)
-WITH_GOFLAGS = GOFLAGS="$(GOFLAGS)"
 
 # # CR for local builds of Karpenter
 KARPENTER_NAMESPACE ?= kube-system
@@ -116,10 +115,10 @@ codegen: ## Auto generate files based on Azure API responses
 	./hack/codegen.sh
 
 snapshot: az-login ## Builds and publishes snapshot release
-	$(WITH_GOFLAGS) ./hack/release/snapshot.sh
+	./hack/release/snapshot.sh
 
-release: az-login ## Builds and publishes stable release
-	$(WITH_GOFLAGS) ./hack/release/release.sh
+release: ## Builds and publishes stable release
+	./hack/release/release.sh
 
 toolchain: ## Install developer toolchain
 	./hack/toolchain.sh

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -70,10 +70,10 @@ buildAndPublish() {
     exit 1
   fi
 
-  img="$(GOFLAGS=${GOFLAGS:-} \
+  img="$(GOFLAGS="${GOFLAGS:-} -ldflags=-X=sigs.k8s.io/karpenter/pkg/operator.Version=${version}" \
     SOURCE_DATE_EPOCH="${date_epoch}" KO_DATA_DATE_EPOCH="${date_epoch}" KO_DOCKER_REPO="${oci_repo}" \
     ko publish -B --sbom none -t "${version}"     ./cmd/controller)"
-  img_nap="$(GOFLAGS="${GOFLAGS:-} -tags=ccp" \
+  img_nap="$(GOFLAGS="${GOFLAGS:-} -ldflags=-X=sigs.k8s.io/karpenter/pkg/operator.Version=${version}-aks -tags=ccp" \
     SOURCE_DATE_EPOCH="${date_epoch}" KO_DATA_DATE_EPOCH="${date_epoch}" KO_DOCKER_REPO="${oci_repo}" \
     ko publish -B --sbom none -t "${version}"-aks ./cmd/controller)"
 

--- a/pkg/auth/util.go
+++ b/pkg/auth/util.go
@@ -23,5 +23,5 @@ import (
 )
 
 func GetUserAgentExtension() string {
-	return fmt.Sprintf("karpenter-aks/v%s", operator.Version)
+	return fmt.Sprintf("karpenter/v%s", operator.Version)
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->


**Description**

Correctly set the user agent on release (and add -aks suffix in CCP images); fixes missing user agent.
* For release & snapshot, set operator.Version in hack/release/common.sh instead of via Makefile
   * LDFLAGS/CFLAGS in Makefile are still used for local builds, but aren't passed into snapshot/release targets
   * Release scripts still respect CFLAGS if ever passed; augment them with their own version of ldflags
* Use different (-aks) user agent for CCP image
* Remove -aks from "karpenter-aks/v" in favor of suffix in the version itself

**How was this change tested?**

* `make snapshot` & examine sigs.k8s.io/karpenter/pkg/operator.Version in the executable

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
