### PR TITLE
fix: NIC error filter catches "ResourceNotFound", but not "NotFound"

### DIFF
--- a/pkg/providers/instance/azureresourcemanagerutils.go
+++ b/pkg/providers/instance/azureresourcemanagerutils.go
@@ -107,7 +107,8 @@ func deleteNic(ctx context.Context, client NetworkInterfacesAPI, rg, nicName str
 func deleteNicIfExists(ctx context.Context, client NetworkInterfacesAPI, rg, nicName string) error {
 	_, err := client.Get(ctx, rg, nicName, nil)
 	if err != nil {
-		if sdkerrors.IsNotFoundErr(err) {
+		azErr := sdkerrors.IsResponseError(err)
+		if azErr != nil && (azErr.ErrorCode == "NotFound" || azErr.ErrorCode == "ResourceNotFound") {
 			return nil
 		}
 		return err


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
NIC not being found from `GET` returns `NotFound` rather than `ResourceNotFound`.
Seems like an issue for `azure-sdk-for-go-extensions`, if we have not been misusing it(?).
```
// IsNotFoundErr is used to determine if we are failing to find a resource within azure.
func IsNotFoundErr(err error) bool {
	azErr := IsResponseError(err)
	return azErr != nil && azErr.ErrorCode == ResourceNotFound
}
```

But `deleteVirtualMachineIfExists()` right below this code already takes this matter into our own hands.
The same problem exists for NIC, in which this the same solution could be applied.

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Fix an issue where NIC "NotFound" during deletion is considered an error
```
