### PR TITLE
fix: NAP supports nsg provider now, so we can run the nsg provider check in NAP

### DIFF
--- a/test/suites/integration/subnet_test.go
+++ b/test/suites/integration/subnet_test.go
@@ -81,13 +81,9 @@ var _ = Describe("Subnets", func() {
 		Expect(nic.Properties.IPConfigurations[0].Properties.Subnet).ToNot(BeNil())
 		Expect(nic.Properties.IPConfigurations[0].Properties.Subnet.ID).To(Equal(subnet.ID))
 
-		// TODO: Unblock when remote controlplane has the v1.5.0 version which includes the
-		// NSG provider
-		if env.InClusterController {
-			// The NIC should have the right NSG
-			Expect(nic.Properties.NetworkSecurityGroup).ToNot(BeNil())
-			Expect(nic.Properties.NetworkSecurityGroup.ID).ToNot(BeNil())
-			Expect(*nic.Properties.NetworkSecurityGroup.ID).To(MatchRegexp(`aks-agentpool-\d{8}-nsg`))
-		}
+		// The NIC should have the right NSG
+		Expect(nic.Properties.NetworkSecurityGroup).ToNot(BeNil())
+		Expect(nic.Properties.NetworkSecurityGroup.ID).ToNot(BeNil())
+		Expect(*nic.Properties.NetworkSecurityGroup.ID).To(MatchRegexp(`aks-agentpool-\d{8}-nsg`))
 	})
 })


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Now that we pin NAP e2e runs to a particular branch we can change this since v1.5.x will support the nsg provider.
**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
