### PR TITLE
chore: add fail-fast false to CI-TEST action

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -13,6 +13,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast 
       matrix:
         k8sVersion: ["1.25.x", "1.26.x", "1.27.x", "1.28.x", "1.29.x", "1.30.x", "1.31.x", "1.32.x", "1.33.x"]
     env:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
I constantly end up re-running ci-test due to flake, if it fails in one version it fails it for all tests. That is annoying and often makes deflaking this take a couple additional runs, lets not use fail-fast and try this for a bit. 


The tests are so flakey it was very easy to reproduce this 

<img width="667" alt="image" src="https://github.com/user-attachments/assets/5daf0157-d54e-4602-9d06-396de8e8fd03" />

This shows this change works! And decreases the number of tests we have to rerun :) 

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
