### PR TITLE
chore: remove redundant logging in provider layer

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -274,11 +274,7 @@ func (p *DefaultProvider) createAKSIdentifyingExtension(ctx context.Context, vmN
 	log.FromContext(ctx).V(1).Info("creating virtual machine AKS identifying extension", "vmName", vmName)
 	v, err := createVirtualMachineExtension(ctx, p.azClient.virtualMachinesExtensionClient, p.resourceGroup, vmName, vmExtName, *vmExt)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "failed to create VM AKS identifying extension",
-			"vmName", vmName,
-			"extensionName", vmExtName,
-		)
-		return fmt.Errorf("creating VM AKS identifying extension for VM %q, %w failed", vmName, err)
+		return fmt.Errorf("creating VM AKS identifying extension %q for VM %q: %w", vmExtName, vmName, err)
 	}
 	log.FromContext(ctx).V(1).Info("created virtual machine AKS identifying extension",
 		"vmName", vmName,
@@ -293,8 +289,7 @@ func (p *DefaultProvider) createCSExtension(ctx context.Context, vmName string, 
 	log.FromContext(ctx).V(1).Info("creating virtual machine CSE", "vmName", vmName)
 	v, err := createVirtualMachineExtension(ctx, p.azClient.virtualMachinesExtensionClient, p.resourceGroup, vmName, vmExtName, *vmExt)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "failed to create VM CSE", "vmName", vmName)
-		return fmt.Errorf("creating VM CSE for VM %q, %w failed", vmName, err)
+		return fmt.Errorf("creating VM CSE for VM %q: %w", vmName, err)
 	}
 	log.FromContext(ctx).V(1).Info("created virtual machine CSE",
 		"vmName", vmName,
@@ -553,7 +548,6 @@ func (p *DefaultProvider) createVirtualMachine(ctx context.Context, opts *create
 
 	poller, err := p.azClient.virtualMachinesClient.BeginCreateOrUpdate(ctx, p.resourceGroup, opts.VMName, *vm, nil)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "creating virtual machine failed", "vmName", opts.VMName)
 		return nil, fmt.Errorf("virtualMachine.BeginCreateOrUpdate for VM %q failed: %w", opts.VMName, err)
 	}
 	return &createResult{Poller: poller, VM: vm}, nil
@@ -643,8 +637,7 @@ func (p *DefaultProvider) beginLaunchInstance(
 	if err != nil {
 		sku, skuErr := p.instanceTypeProvider.Get(ctx, nodeClass, instanceType.Name)
 		if skuErr != nil {
-			log.FromContext(ctx).Error(err, "failed to get instance type", "instanceType", instanceType.Name)
-			return nil, err
+			return nil, fmt.Errorf("failed to get instance type %q: %w", instanceType.Name, err)
 		}
 		azErr := p.handleResponseErrors(ctx, sku, instanceType, zone, capacityType, err)
 		return nil, azErr
@@ -671,8 +664,7 @@ func (p *DefaultProvider) beginLaunchInstance(
 			if err != nil {
 				sku, skuErr := p.instanceTypeProvider.Get(ctx, nodeClass, instanceType.Name)
 				if skuErr != nil {
-					log.FromContext(ctx).Error(err, "failed to get instance type", "instanceType", instanceType.Name)
-					return err
+					return fmt.Errorf("failed to get instance type %q: %w", instanceType.Name, err)
 				}
 				azErr := p.handleResponseErrors(ctx, sku, instanceType, zone, capacityType, err)
 				return azErr
@@ -703,8 +695,7 @@ func (p *DefaultProvider) handleResponseErrors(ctx context.Context, sku *skewer.
 			return handler.handleResponseError(ctx, p, sku, instanceType, zone, capacityType, responseError)
 		}
 	}
-	// responseError didn't match any of our handlers, so we log details about it and return it as is
-	log.FromContext(ctx).Error(responseError, "Unknown response error")
+	// responseError didn't match any of our handlers, return it as is
 	return responseError
 }
 
@@ -788,13 +779,19 @@ func (p *DefaultProvider) cleanupAzureResources(ctx context.Context, resourceNam
 	// then we attempt to delete the nic.
 
 	nicErr := deleteNicIfExists(ctx, p.azClient.networkInterfacesClient, p.resourceGroup, resourceName)
-	if nicErr != nil {
-		log.FromContext(ctx).Error(nicErr, "networkinterface.Delete failed", "nicName", resourceName)
-	}
 
 	if mustDeleteNic {
+		// Don't log NIC error here since mustDeleteNic is true (critical cleanup scenario).
+		// Both VM and NIC errors are returned to the caller for proper handling and logging.
+		// Logging here would create duplicate logs when the caller processes the joined error.
 		return errors.Join(vmErr, nicErr)
 	} else {
+		// Log NIC error here since mustDeleteNic is false (best-effort cleanup scenario).
+		// Because we're not returning nicErr to the caller we need to log here.
+		// Without this log, NIC deletion failures would be silently ignored.
+		if nicErr != nil {
+			log.FromContext(ctx).Error(nicErr, "networkinterface.Delete failed", "nicName", resourceName)
+		}
 		return vmErr
 	}
 }

--- a/pkg/providers/instance/resperrorhandlers.go
+++ b/pkg/providers/instance/resperrorhandlers.go
@@ -24,7 +24,6 @@ import (
 
 	sdkerrors "github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
 	"github.com/Azure/skewer"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
 )
@@ -98,14 +97,12 @@ func defaultResponseErrorHandlers() []responseErrorHandler {
 func handleLowPriorityQuotaError(ctx context.Context, provider *DefaultProvider, sku *skewer.SKU, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
 	// Mark in cache that spot quota has been reached for this subscription
 	provider.unavailableOfferings.MarkSpotUnavailableWithTTL(ctx, SubscriptionQuotaReachedTTL)
-	log.FromContext(ctx).Error(err, "low priority quota reached", "instance-type", instanceType.Name, "capacity-type", capacityType)
 	return fmt.Errorf("this subscription has reached the regional vCPU quota for spot (LowPriorityQuota). To scale beyond this limit, please review the quota increase process here: https://docs.microsoft.com/en-us/azure/azure-portal/supportability/low-priority-quota")
 }
 
 func handleSKUFamilyQuotaError(ctx context.Context, provider *DefaultProvider, sku *skewer.SKU, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
 	// Subscription quota has been reached for this VM SKU, mark the instance type as unavailable in all zones available to the offering
 	// This will also update the TTL for an existing offering in the cache that is already unavailable
-	log.FromContext(ctx).Error(err, "SKU family quota reached", "instance-type", instanceType.Name, "capacity-type", capacityType)
 
 	for _, offering := range instanceType.Offerings {
 		if getOfferingCapacityType(offering) != capacityType {
@@ -136,7 +133,6 @@ func handleSKUNotAvailableError(ctx context.Context, provider *DefaultProvider, 
 	// mark the instance type as unavailable for all offerings/zones for the capacity type
 	markOfferingsUnavailableForCapacityType(ctx, provider, instanceType, capacityType, SKUNotAvailableReason, skuNotAvailableTTL)
 
-	log.FromContext(ctx).Error(err, "SKU not available", "instance-type", instanceType.Name, "zone", zone, "capacity-type", capacityType)
 	return fmt.Errorf(
 		"the requested SKU is unavailable for instance type %s in zone %s with capacity type %s, for more details please visit: https://aka.ms/azureskunotavailable",
 		instanceType.Name,
@@ -146,7 +142,6 @@ func handleSKUNotAvailableError(ctx context.Context, provider *DefaultProvider, 
 
 // For zonal allocation failure, we will mark all instance types from this SKU family that have >= CPU count as the one that hit the error in this zone
 func handleZonalAllocationFailureError(ctx context.Context, provider *DefaultProvider, sku *skewer.SKU, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
-	log.FromContext(ctx).Error(err, "zonal allocation failure", "instance-type", instanceType.Name, "zone", zone)
 	vCPU, err := sku.VCPU() // versionedSKUFamily e.g. "N4" for "NV8as_v4"
 	if err != nil {
 		// default to 0 if we can't determine VCPU count, this shouldn't happen as long as data in skewer.SKU is correct
@@ -160,7 +155,6 @@ func handleZonalAllocationFailureError(ctx context.Context, provider *DefaultPro
 
 // AllocationFailure means that VM allocation to the dedicated host has failed. But it can also mean "Allocation failed. We do not have sufficient capacity for the requested VM size in this region."
 func handleAllocationFailureError(ctx context.Context, provider *DefaultProvider, sku *skewer.SKU, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
-	log.FromContext(ctx).Error(err, "allocation failure", "instance-type", instanceType.Name)
 	markAllZonesUnavailableForBothCapacityTypes(ctx, provider, instanceType, AllocationFailureReason, AllocationFailureTTL)
 
 	return fmt.Errorf("unable to allocate resources with selected VM size (%s). (will try a different VM size to fulfill your request)", instanceType.Name)
@@ -169,7 +163,6 @@ func handleAllocationFailureError(ctx context.Context, provider *DefaultProvider
 // OverconstrainedZonalAllocationFailure means that specific zone cannot accommodate the selected size and capacity combination.
 func handleOverconstrainedZonalAllocationFailureError(ctx context.Context, provider *DefaultProvider, sku *skewer.SKU, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
 	// OverconstrainedZonalAllocationFailure means that specific zone cannot accommodate the selected size and capacity combination.
-	log.FromContext(ctx).Error(err, "overconstrained zonal allocation failure", "instance-type", instanceType.Name, "zone", zone, "capacity-type", capacityType)
 	provider.unavailableOfferings.MarkUnavailableWithTTL(ctx, OverconstrainedZonalAllocationFailureReason, instanceType.Name, zone, capacityType, AllocationFailureTTL)
 
 	return fmt.Errorf("unable to allocate resources in the selected zone (%s) with %s capacity type and %s VM size. (will try a different zone, capacity type or VM size to fulfill your request)", zone, capacityType, instanceType.Name)
@@ -177,14 +170,12 @@ func handleOverconstrainedZonalAllocationFailureError(ctx context.Context, provi
 
 // OverconstrainedAllocationFailure means that all zones cannot accommodate the selected size and capacity combination.
 func handleOverconstrainedAllocationFailureError(ctx context.Context, provider *DefaultProvider, sku *skewer.SKU, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
-	log.FromContext(ctx).Error(err, "overconstrained allocation failure", "instance-type", instanceType.Name, "capacity-type", capacityType)
 	markOfferingsUnavailableForCapacityType(ctx, provider, instanceType, capacityType, OverconstrainedAllocationFailureReason, AllocationFailureTTL)
 
 	return fmt.Errorf("unable to allocate resources in all zones with %s capacity type and %s VM size. (will try a different capacity type or VM size to fulfill your request)", capacityType, instanceType.Name)
 }
 
 func handleRegionalQuotaError(ctx context.Context, provider *DefaultProvider, sku *skewer.SKU, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
-	log.FromContext(ctx).Error(err, "regional quota reached", "instance-type", instanceType.Name, "capacity-type", capacityType)
 	// InsufficientCapacityError is appropriate here because trying any other instance type will not help
 	return corecloudprovider.NewInsufficientCapacityError(
 		fmt.Errorf(

--- a/pkg/providers/instance/resperrorhandlers.go
+++ b/pkg/providers/instance/resperrorhandlers.go
@@ -125,9 +125,7 @@ func handleSKUNotAvailableError(ctx context.Context, provider *DefaultProvider, 
 	// - SKUs with location restriction are already filtered out via sku.HasLocationRestriction
 	// - zonal restrictions are filtered out internally by sku.AvailabilityZones, and don't get offerings
 	skuNotAvailableTTL := SKUNotAvailableSpotTTL
-	err = fmt.Errorf("out of spot capacity for %s: %w", instanceType.Name, err)
 	if capacityType == karpv1.CapacityTypeOnDemand { // should not happen, defensive check
-		err = fmt.Errorf("unexpected SkuNotAvailable error for %s (on-demand): %w", instanceType.Name, err)
 		skuNotAvailableTTL = SKUNotAvailableOnDemandTTL // still mark all offerings as unavailable, but with a longer TTL
 	}
 	// mark the instance type as unavailable for all offerings/zones for the capacity type
@@ -142,8 +140,8 @@ func handleSKUNotAvailableError(ctx context.Context, provider *DefaultProvider, 
 
 // For zonal allocation failure, we will mark all instance types from this SKU family that have >= CPU count as the one that hit the error in this zone
 func handleZonalAllocationFailureError(ctx context.Context, provider *DefaultProvider, sku *skewer.SKU, instanceType *corecloudprovider.InstanceType, zone, capacityType string, err error) error {
-	vCPU, err := sku.VCPU() // versionedSKUFamily e.g. "N4" for "NV8as_v4"
-	if err != nil {
+	vCPU, vCPUErr := sku.VCPU() // versionedSKUFamily e.g. "N4" for "NV8as_v4"
+	if vCPUErr != nil {
 		// default to 0 if we can't determine VCPU count, this shouldn't happen as long as data in skewer.SKU is correct
 		vCPU = 0
 	}


### PR DESCRIPTION

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Contributes to #833

**Description**
Remove unnecessary logging in places where error is returned and would be logged later (e.g. by controller) 

**How was this change tested?**
Viewing logs through `make az-debug` and VSCodes Kubernetes extension.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Removed and restructured redundant provider layer logs.
```
