### PR TITLE
feat: flag to enable/disable middleware logging

### DIFF
--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -1,5 +1,6 @@
 AZURE_LOCATION ?= westus2
 COMMON_NAME ?= karpenter
+ENABLE_AZURE_SDK_LOGGING ?= false
 ifeq ($(CODESPACES),true)
   AZURE_RESOURCE_GROUP ?= $(CODESPACE_NAME)
   AZURE_ACR_NAME ?= $(subst -,,$(CODESPACE_NAME))
@@ -139,6 +140,10 @@ az-rmrg: ## Destroy test ACR and AKS cluster by deleting the resource group (use
 az-configure-values:  ## Generate cluster-related values for Karpenter Helm chart
 	hack/deploy/configure-values.sh $(AZURE_CLUSTER_NAME) $(AZURE_RESOURCE_GROUP) $(KARPENTER_SERVICE_ACCOUNT_NAME) $(AZURE_KARPENTER_USER_ASSIGNED_IDENTITY_NAME)
 
+az-update-logging-flag: ## Update ENABLE_AZURE_SDK_LOGGING flag in karpenter-values.yaml based on environment variable
+	@echo "Setting ENABLE_AZURE_SDK_LOGGING to $(ENABLE_AZURE_SDK_LOGGING)"
+	yq -i '.controller.env[] |= select(.name == "ENABLE_AZURE_SDK_LOGGING").value = "$(ENABLE_AZURE_SDK_LOGGING)"' karpenter-values.yaml
+
 az-mkvmssflex: ## Create VMSS Flex (optional, only if creating VMs referencing this VMSS)
 	az vmss create --name $(AZURE_CLUSTER_NAME)-vmss --resource-group $(AZURE_RESOURCE_GROUP_MC) --location $(AZURE_LOCATION) \
 		--instance-count 0 --orchestration-mode Flexible --platform-fault-domain-count 1 --zones 1 2 3
@@ -189,7 +194,7 @@ az-build: ## Build the Karpenter controller and webhook images using skaffold bu
 az-creds: ## Get cluster credentials
 	az aks get-credentials --name $(AZURE_CLUSTER_NAME) --resource-group $(AZURE_RESOURCE_GROUP)
 
-az-run: ## Deploy the controller from the current state of your git repository into your ~/.kube/config cluster using skaffold run
+az-run: az-update-logging-flag ## Deploy the controller from the current state of your git repository into your ~/.kube/config cluster using skaffold run
 	az acr login -n $(AZURE_ACR_NAME)
 	skaffold run
 
@@ -403,7 +408,7 @@ az-pprof: ## Profile
 az-mkaks-user: az-mkrg ## Create compatible AKS cluster, the way we tell users to
 	hack/deploy/create-cluster.sh $(AZURE_CLUSTER_NAME) $(AZURE_RESOURCE_GROUP) "${KARPENTER_NAMESPACE}"
 
-az-helm-install-snapshot: az-configure-values ## Install Karpenter snapshot release
+az-helm-install-snapshot: az-configure-values az-update-logging-flag ## Install Karpenter snapshot release
 	$(eval SNAPSHOT_VERSION ?= $(shell git rev-parse HEAD)) # guess which, specify explicitly with SNAPSHOT_VERSION=...
 	helm upgrade --install karpenter oci://ksnap.azurecr.io/karpenter/snapshot/karpenter \
 		--version 0-$(SNAPSHOT_VERSION) \

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -102,7 +102,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	azClient, err := instance.CreateAZClient(ctx, azConfig, cred)
 	lo.Must0(err, "creating Azure client")
 	if options.FromContext(ctx).VnetGUID == "" && options.FromContext(ctx).NetworkPluginMode == consts.NetworkPluginModeOverlay {
-		vnetGUID, err := getVnetGUID(cred, azConfig, options.FromContext(ctx).SubnetID)
+		vnetGUID, err := getVnetGUID(ctx, cred, azConfig, options.FromContext(ctx).SubnetID)
 		lo.Must0(err, "getting VNET GUID")
 		options.FromContext(ctx).VnetGUID = vnetGUID
 	}
@@ -223,8 +223,9 @@ func getCABundle(restConfig *rest.Config) (*string, error) {
 	return lo.ToPtr(base64.StdEncoding.EncodeToString(transportConfig.TLS.CAData)), nil
 }
 
-func getVnetGUID(creds azcore.TokenCredential, cfg *auth.Config, subnetID string) (string, error) {
-	opts := armopts.DefaultArmOpts()
+func getVnetGUID(ctx context.Context, creds azcore.TokenCredential, cfg *auth.Config, subnetID string) (string, error) {
+	o := options.FromContext(ctx)
+	opts := armopts.DefaultArmOpts(o.EnableAzureSDKLogging)
 	vnetClient, err := armnetwork.NewVirtualNetworksClient(cfg.SubscriptionID, creds, opts)
 	if err != nil {
 		return "", err

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -88,6 +88,7 @@ type Options struct {
 	SIGAccessTokenScope        string `json:"-"`                // => SIGAccessTokenScope is the scope for the auxiliary token, not set if it is a self-hosted karpenter installation
 	SIGSubscriptionID          string `json:"sigSubscriptionId,omitempty"`
 	NodeResourceGroup          string `json:"nodeResourceGroup,omitempty"`
+	EnableAzureSDKLogging      bool   `json:"enableAzureSDKLogging,omitempty"` // Controls whether Azure SDK middleware logging is enabled
 }
 
 func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
@@ -112,6 +113,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.SIGAccessTokenServerURL, "sig-access-token-server-url", env.WithDefaultString("SIG_ACCESS_TOKEN_SERVER_URL", ""), "The URL for the SIG access token server. Only used for AKS managed karpenter. UseSIG must be set tot true for this to take effect.")
 	fs.StringVar(&o.SIGAccessTokenScope, "sig-access-token-scope", env.WithDefaultString("SIG_ACCESS_TOKEN_SCOPE", ""), "The scope for the SIG access token. Only used for AKS managed karpenter. UseSIG must be set to true for this to take effect.")
 	fs.StringVar(&o.SIGSubscriptionID, "sig-subscription-id", env.WithDefaultString("SIG_SUBSCRIPTION_ID", ""), "The subscription ID of the shared image gallery.")
+	fs.BoolVar(&o.EnableAzureSDKLogging, "enable-azure-sdk-logging", env.WithDefaultBool("ENABLE_AZURE_SDK_LOGGING", false), "If set to true then Azure SDK middleware logging is enabled for debugging, logging all HTTP requests/responses to Azure APIs.")
 }
 
 func (o *Options) GetAPIServerName() string {

--- a/pkg/providers/instance/azure_client.go
+++ b/pkg/providers/instance/azure_client.go
@@ -115,7 +115,7 @@ func CreateAZClient(ctx context.Context, cfg *auth.Config, cred azcore.TokenCred
 // nolint: gocyclo
 func NewAZClient(ctx context.Context, cfg *auth.Config, env *azclient.Environment, cred azcore.TokenCredential) (*AZClient, error) {
 	o := options.FromContext(ctx)
-	opts := armopts.DefaultArmOpts()
+	opts := armopts.DefaultArmOpts(o.EnableAzureSDKLogging)
 
 	extensionsClient, err := armcompute.NewVirtualMachineExtensionsClient(cfg.SubscriptionID, cred, opts)
 	if err != nil {
@@ -175,7 +175,8 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *azclient.Environmen
 			cfg.ResourceGroup,
 			o.ClusterName,
 			cred,
-			o.NodeBootstrappingServerURL)
+			o.NodeBootstrappingServerURL,
+			o.EnableAzureSDKLogging)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/utils/opts/armopts.go
+++ b/pkg/utils/opts/armopts.go
@@ -28,19 +28,21 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/auth"
 )
 
-func DefaultArmOpts() *arm.ClientOptions {
+func DefaultArmOpts(enableLogging bool) *arm.ClientOptions {
 	opts := &arm.ClientOptions{}
 	opts.Telemetry = DefaultTelemetryOpts()
 	opts.Retry = DefaultRetryOpts()
 	opts.Transport = defaultHTTPClient
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	opts.PerCallPolicies = append(opts.PerCallPolicies, shPolicy.NewLoggingPolicy(*logger))
+	if enableLogging {
+		logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+		opts.PerCallPolicies = append(opts.PerCallPolicies, shPolicy.NewLoggingPolicy(*logger))
+	}
 	return opts
 }
 
-func DefaultNICClientOpts() *arm.ClientOptions {
-	opts := DefaultArmOpts()
+func DefaultNICClientOpts(enableLogging bool) *arm.ClientOptions {
+	opts := DefaultArmOpts(enableLogging)
 	return opts
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Contributes to #833 

**Description**
Azure SDK clients are interfacs that allow you to make API calls to Azure's REST APIs without the raw HTTP requests you use client objects with methods like `vmClient.Create(ctx, resourceGroup, vmName, vmParameters)`
Every client can have middleware attached that logs the API request, but this sometimes can be too much information for debugging.

**How was this change tested?**
1.
edit the _karpenter-values.yaml_ file and set `ENABLE_AZURE_SDK_LOGGING: false` or `true` in the controller environment variables, then run `make az-run` to redeploy.
OR
`export ENABLE_AZURE_SDK_LOGGING=true`/`false` and `make az-run` to redeploy
2.
Run `make az-klogs-pretty`
Shows the following type of logs when flag is true
```
{
  "time": "2025-07-09T22:12:45.804104299Z",
  "level": "INFO",
  "msg": "finished call",
  "source": "ApiRequestLog",
  "protocol": "REST",
  "method_type": "unary",
  "component": "client",
  "time_ms": 255,
  "method": "POST https://management.azure.com/providers/Microsoft.ResourceGraph/resources",
  "service": "management.azure.com",
  "url": "https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2021-06-01-preview",
  "headers": {
    "x-ms-correlation-request-id": "c33202cf-77b6-431a-80bd-6f124ebdb497"
  },
  "error": "na",
  "code": 200
}
```
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
