### PR TITLE
fix: devcontainer `features/kubectl-helm-minikube` install

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -70,7 +70,7 @@
 		// custom
 		"ghcr.io/devcontainers/features/sshd:1": {},
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
-		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1.2.1": {}, // 1.2.2 seems to be broken
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": { "version": "v1.33.2" }, // sometimes fails to determine the stable version, so just specify it
 		"ghcr.io/devcontainers/features/azure-cli:1": {},
 		"ghcr.io/devcontainers-extra/features/pre-commit:2": {},
 		"ghcr.io/froazin/devcontainer-features/shellcheck:0": {},


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->


**Description**

"features/kubectl-helm-minikube" sometimes fails to determine the stable version of kubectl (curl simply fails, see https://github.com/devcontainers/features/issues/1410), breaking devcontainer/codespace rebuild, so specify the version explicitly

**How was this change tested?**

* rebuilding devcontainer / codespace

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
