### PR TITLE
chore(dev): have VSCode GitHub Pull Requests extension filter PRs by this repo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,19 +12,19 @@
         "queries": [
             {
                 "label": "Waiting For My Review",
-                "query": "is:open review-requested:${user}"
+                "query": "repo:${owner}/${repository} is:open review-requested:${user}"
             },
             {
                 "label": "Assigned To Me",
-                "query": "is:open assignee:${user}"
+                "query": "repo:${owner}/${repository} is:open assignee:${user}"
             },
             {
                 "label": "Created By Me",
-                "query": "is:open author:${user}"
+                "query": "repo:${owner}/${repository} is:open author:${user}"
             },
             {
                 "label": "All Open (-dependabot)",
-                "query": "is:open -label:dependencies"
+                "query": "repo:${owner}/${repository} is:open -label:dependencies"
             }
         ]
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Have VSCode GitHub Pull Requests extension filter PRs by this repo only

**How was this change tested?**

* Local dev

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
