### PR TITLE
feat: add UpdateTags/Update to nic and extensions APIs

### DIFF
--- a/pkg/fake/networkinterfaceapi.go
+++ b/pkg/fake/networkinterfaceapi.go
@@ -19,6 +19,7 @@ package fake
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/samber/lo"
@@ -41,9 +42,17 @@ type NetworkInterfaceDeleteInput struct {
 	ResourceGroupName, InterfaceName string
 }
 
+type NetworkInterfaceUpdateTagsInput struct {
+	ResourceGroupName string
+	InterfaceName     string
+	Tags              armnetwork.TagsObject
+	Options           *armnetwork.InterfacesClientUpdateTagsOptions
+}
+
 type NetworkInterfacesBehavior struct {
 	NetworkInterfacesCreateOrUpdateBehavior MockedLRO[NetworkInterfaceCreateOrUpdateInput, armnetwork.InterfacesClientCreateOrUpdateResponse]
 	NetworkInterfacesDeleteBehavior         MockedLRO[NetworkInterfaceDeleteInput, armnetwork.InterfacesClientDeleteResponse]
+	NetworkInterfacesUpdateTagsBehavior     MockedFunction[NetworkInterfaceUpdateTagsInput, armnetwork.InterfacesClientUpdateTagsResponse]
 	NetworkInterfaces                       sync.Map
 }
 
@@ -58,6 +67,8 @@ type NetworkInterfacesAPI struct {
 // Reset must be called between tests otherwise tests will pollute each other.
 func (c *NetworkInterfacesAPI) Reset() {
 	c.NetworkInterfacesCreateOrUpdateBehavior.Reset()
+	c.NetworkInterfacesDeleteBehavior.Reset()
+	c.NetworkInterfacesUpdateTagsBehavior.Reset()
 	c.NetworkInterfaces.Range(func(k, v any) bool {
 		c.NetworkInterfaces.Delete(k)
 		return true
@@ -75,7 +86,7 @@ func (c *NetworkInterfacesAPI) BeginCreateOrUpdate(_ context.Context, resourceGr
 	return c.NetworkInterfacesCreateOrUpdateBehavior.Invoke(input, func(input *NetworkInterfaceCreateOrUpdateInput) (*armnetwork.InterfacesClientCreateOrUpdateResponse, error) {
 		iface := input.Interface
 		iface.Name = lo.ToPtr(input.InterfaceName)
-		id := mkNetworkInterfaceID(input.ResourceGroupName, input.InterfaceName)
+		id := MakeNetworkInterfaceID(input.ResourceGroupName, input.InterfaceName)
 		iface.ID = lo.ToPtr(id)
 		c.NetworkInterfaces.Store(id, iface)
 		return &armnetwork.InterfacesClientCreateOrUpdateResponse{
@@ -85,7 +96,7 @@ func (c *NetworkInterfacesAPI) BeginCreateOrUpdate(_ context.Context, resourceGr
 }
 
 func (c *NetworkInterfacesAPI) Get(_ context.Context, resourceGroupName string, interfaceName string, _ *armnetwork.InterfacesClientGetOptions) (armnetwork.InterfacesClientGetResponse, error) {
-	id := mkNetworkInterfaceID(resourceGroupName, interfaceName)
+	id := MakeNetworkInterfaceID(resourceGroupName, interfaceName)
 	iface, ok := c.NetworkInterfaces.Load(id)
 	if !ok {
 		return armnetwork.InterfacesClientGetResponse{}, &azcore.ResponseError{ErrorCode: errors.ResourceNotFound}
@@ -101,13 +112,48 @@ func (c *NetworkInterfacesAPI) BeginDelete(_ context.Context, resourceGroupName 
 		InterfaceName:     interfaceName,
 	}
 	return c.NetworkInterfacesDeleteBehavior.Invoke(input, func(input *NetworkInterfaceDeleteInput) (*armnetwork.InterfacesClientDeleteResponse, error) {
-		id := mkNetworkInterfaceID(input.ResourceGroupName, input.InterfaceName)
+		id := MakeNetworkInterfaceID(input.ResourceGroupName, input.InterfaceName)
 		c.NetworkInterfaces.Delete(id)
 		return &armnetwork.InterfacesClientDeleteResponse{}, nil
 	})
 }
 
-func mkNetworkInterfaceID(resourceGroupName, interfaceName string) string {
+func (c *NetworkInterfacesAPI) UpdateTags(
+	ctx context.Context,
+	resourceGroupName string,
+	interfaceName string,
+	tags armnetwork.TagsObject,
+	options *armnetwork.InterfacesClientUpdateTagsOptions,
+) (armnetwork.InterfacesClientUpdateTagsResponse, error) {
+	input := &NetworkInterfaceUpdateTagsInput{
+		ResourceGroupName: resourceGroupName,
+		InterfaceName:     interfaceName,
+		Tags:              tags,
+		Options:           options,
+	}
+	return c.NetworkInterfacesUpdateTagsBehavior.Invoke(input, func(input *NetworkInterfaceUpdateTagsInput) (armnetwork.InterfacesClientUpdateTagsResponse, error) {
+		id := MakeNetworkInterfaceID(resourceGroupName, interfaceName)
+		instance, ok := c.NetworkInterfaces.Load(id)
+		if !ok {
+			return armnetwork.InterfacesClientUpdateTagsResponse{}, &azcore.ResponseError{ErrorCode: errors.ResourceNotFound}
+		}
+
+		iface := instance.(armnetwork.Interface)
+
+		if input.Tags.Tags != nil {
+			// Tags are full-replace if they're specified
+			iface.Tags = maps.Clone(input.Tags.Tags)
+		}
+
+		c.NetworkInterfaces.Store(id, iface)
+
+		return armnetwork.InterfacesClientUpdateTagsResponse{
+			Interface: iface,
+		}, nil
+	})
+}
+
+func MakeNetworkInterfaceID(resourceGroupName, interfaceName string) string {
 	const subscriptionID = "subscriptionID" // not important for fake
 	const idFormat = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkInterfaces/%s"
 	return fmt.Sprintf(idFormat, subscriptionID, resourceGroupName, interfaceName)

--- a/pkg/fake/virtualmachineextensionsapi.go
+++ b/pkg/fake/virtualmachineextensionsapi.go
@@ -19,10 +19,13 @@ package fake
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/samber/lo"
 
+	"github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
@@ -36,8 +39,17 @@ type VirtualMachineExtensionCreateOrUpdateInput struct {
 	Options                     *armcompute.VirtualMachineExtensionsClientBeginCreateOrUpdateOptions
 }
 
+type VirtualMachineExtensionUpdateInput struct {
+	ResourceGroupName             string
+	VirtualMachineName            string
+	VirtualMachineExtensionName   string
+	VirtualMachineExtensionUpdate armcompute.VirtualMachineExtensionUpdate
+	Options                       *armcompute.VirtualMachineExtensionsClientBeginUpdateOptions
+}
+
 type VirtualMachineExtensionsBehavior struct {
 	VirtualMachineExtensionsCreateOrUpdateBehavior MockedLRO[VirtualMachineExtensionCreateOrUpdateInput, armcompute.VirtualMachineExtensionsClientCreateOrUpdateResponse]
+	VirtualMachineExtensionsUpdateBehavior         MockedLRO[VirtualMachineExtensionUpdateInput, armcompute.VirtualMachineExtensionsClientUpdateResponse]
 	Extensions                                     sync.Map
 }
 
@@ -52,6 +64,7 @@ type VirtualMachineExtensionsAPI struct {
 // Reset must be called between tests otherwise tests will pollute each other.
 func (c *VirtualMachineExtensionsAPI) Reset() {
 	c.VirtualMachineExtensionsCreateOrUpdateBehavior.Reset()
+	c.VirtualMachineExtensionsUpdateBehavior.Reset()
 	c.Extensions.Range(func(k, v any) bool {
 		c.Extensions.Delete(k)
 		return true
@@ -69,7 +82,7 @@ func (c *VirtualMachineExtensionsAPI) BeginCreateOrUpdate(_ context.Context, res
 
 	return c.VirtualMachineExtensionsCreateOrUpdateBehavior.Invoke(input, func(input *VirtualMachineExtensionCreateOrUpdateInput) (*armcompute.VirtualMachineExtensionsClientCreateOrUpdateResponse, error) {
 		result := input.VirtualMachineExtension
-		result.ID = lo.ToPtr(mkVMExtensionID(input.ResourceGroupName, input.VirtualMachineName, input.VirtualMachineExtensionName))
+		result.ID = lo.ToPtr(MakeVMExtensionID(input.ResourceGroupName, input.VirtualMachineName, input.VirtualMachineExtensionName))
 		c.Extensions.Store(input.VirtualMachineExtensionName, result) // only store latest, but could be improved
 		return &armcompute.VirtualMachineExtensionsClientCreateOrUpdateResponse{
 			VirtualMachineExtension: result,
@@ -77,7 +90,39 @@ func (c *VirtualMachineExtensionsAPI) BeginCreateOrUpdate(_ context.Context, res
 	})
 }
 
-func mkVMExtensionID(resourceGroupName, vmName, extensionName string) string {
+func (c *VirtualMachineExtensionsAPI) BeginUpdate(_ context.Context, resourceGroupName string, vmName string, extensionName string, updates armcompute.VirtualMachineExtensionUpdate, options *armcompute.VirtualMachineExtensionsClientBeginUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineExtensionsClientUpdateResponse], error) {
+	input := &VirtualMachineExtensionUpdateInput{
+		ResourceGroupName:             resourceGroupName,
+		VirtualMachineName:            vmName,
+		VirtualMachineExtensionName:   extensionName,
+		VirtualMachineExtensionUpdate: updates,
+		Options:                       options,
+	}
+
+	return c.VirtualMachineExtensionsUpdateBehavior.Invoke(input, func(input *VirtualMachineExtensionUpdateInput) (*armcompute.VirtualMachineExtensionsClientUpdateResponse, error) {
+		result := input.VirtualMachineExtensionUpdate
+
+		id := MakeVMExtensionID(input.ResourceGroupName, input.VirtualMachineName, input.VirtualMachineExtensionName)
+
+		instance, ok := c.Extensions.Load(id)
+		if !ok {
+			return nil, &azcore.ResponseError{ErrorCode: errors.ResourceNotFound}
+		}
+		ext := instance.(armcompute.VirtualMachineExtension)
+
+		if updates.Tags != nil {
+			// VM tags are full-replace if they're specified
+			ext.Tags = maps.Clone(updates.Tags)
+		}
+
+		c.Extensions.Store(input.VirtualMachineExtensionName, result)
+		return &armcompute.VirtualMachineExtensionsClientUpdateResponse{
+			VirtualMachineExtension: ext,
+		}, nil
+	})
+}
+
+func MakeVMExtensionID(resourceGroupName, vmName, extensionName string) string {
 	const idFormat = "/subscriptions/subscriptionID/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s/extensions/%s"
 	return fmt.Sprintf(idFormat, resourceGroupName, vmName, extensionName)
 }

--- a/pkg/providers/instance/azure_client.go
+++ b/pkg/providers/instance/azure_client.go
@@ -52,12 +52,14 @@ type AzureResourceGraphAPI interface {
 
 type VirtualMachineExtensionsAPI interface {
 	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters armcompute.VirtualMachineExtension, options *armcompute.VirtualMachineExtensionsClientBeginCreateOrUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineExtensionsClientCreateOrUpdateResponse], error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters armcompute.VirtualMachineExtensionUpdate, options *armcompute.VirtualMachineExtensionsClientBeginUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineExtensionsClientUpdateResponse], error)
 }
 
 type NetworkInterfacesAPI interface {
 	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters armnetwork.Interface, options *armnetwork.InterfacesClientBeginCreateOrUpdateOptions) (*runtime.Poller[armnetwork.InterfacesClientCreateOrUpdateResponse], error)
 	BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *armnetwork.InterfacesClientBeginDeleteOptions) (*runtime.Poller[armnetwork.InterfacesClientDeleteResponse], error)
 	Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *armnetwork.InterfacesClientGetOptions) (armnetwork.InterfacesClientGetResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, networkInterfaceName string, tags armnetwork.TagsObject, options *armnetwork.InterfacesClientUpdateTagsOptions) (armnetwork.InterfacesClientUpdateTagsResponse, error)
 }
 
 // TODO: Move this to another package that more correctly reflects its usage across multiple providers

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -115,3 +115,31 @@ func ExpectCleanUp(ctx context.Context, c client.Client) {
 	}
 	wg.Wait()
 }
+
+func ExpectInstanceResourcesHaveTags(ctx context.Context, name string, azureEnv *test.Environment, tags map[string]*string) *armcompute.VirtualMachine {
+	GinkgoHelper()
+
+	// The VM should be updated
+	updatedVM, err := azureEnv.InstanceProvider.Get(ctx, name)
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect(updatedVM.Tags).To(Equal(tags), "Expected VM tags to match")
+	// Expect the identities to remain unchanged
+	Expect(updatedVM.Identity).To(BeNil())
+
+	// The NIC should be updated
+	updatedNIC, err := azureEnv.NetworkInterfacesAPI.Get(ctx, azureEnv.AzureResourceGraphAPI.ResourceGroup, name, nil)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(updatedNIC.Tags).To(Equal(tags), "Expected NIC tags to match")
+
+	// The extensions should be updated
+	Expect(azureEnv.VirtualMachineExtensionsAPI.VirtualMachineExtensionsUpdateBehavior.CalledWithInput.Len()).To(Equal(2))
+	for i := 0; i < 2; i++ {
+		extUpdate := azureEnv.VirtualMachineExtensionsAPI.VirtualMachineExtensionsUpdateBehavior.CalledWithInput.Pop().VirtualMachineExtensionUpdate
+		Expect(extUpdate).ToNot(BeNil())
+		Expect(extUpdate.Tags).ToNot(BeNil())
+		Expect(extUpdate.Tags).To(Equal(tags), "Expected VM extension tags to match")
+	}
+
+	return updatedVM
+}


### PR DESCRIPTION
This is in preparation for supporting in-place tags updates.

 * Added tests.
 * Added fakes.
 * Updated instance provider Update() function to propagate tags updates of the VM to the other resources (NIC, Extensions, etc).

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
