### PR TITLE
fix: bug with CloudProvider list where it never used correct tags key

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -468,7 +468,7 @@ func (c *CloudProvider) resolveInstanceTypeFromInstance(ctx context.Context, ins
 }
 
 func (c *CloudProvider) resolveNodePoolFromInstance(ctx context.Context, instance *armcompute.VirtualMachine) (*karpv1.NodePool, error) {
-	nodePoolName, ok := instance.Tags[karpv1.NodePoolLabelKey]
+	nodePoolName, ok := instance.Tags[launchtemplate.NodePoolTagKey]
 	if ok && *nodePoolName != "" {
 		nodePool := &karpv1.NodePool{}
 		if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: *nodePoolName}, nodePool); err != nil {

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -149,6 +149,7 @@ var _ = Describe("CloudProvider", func() {
 		Expect(*queryRequest.Query).To(Equal(instance.GetVMListQueryBuilder(azureEnv.AzureResourceGraphAPI.ResourceGroup).String()))
 		Expect(nodeClaims).To(HaveLen(1))
 		Expect(nodeClaims[0]).ToNot(BeNil())
+		Expect(nodeClaims[0].Status.Capacity).ToNot(BeEmpty())
 		resp, _ := azureEnv.VirtualMachinesAPI.Get(ctx, azureEnv.AzureResourceGraphAPI.ResourceGroup, nodeClaims[0].Name, nil)
 		Expect(resp.VirtualMachine).ToNot(BeNil())
 	})

--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -249,9 +249,7 @@ var _ = Describe("VirtualMachine Garbage Collection", func() {
 		})
 		It("should not delete an instance if it is within the nodeClaim resolution window (5m)", func() {
 			// Launch time just happened
-			vm.Properties = &armcompute.VirtualMachineProperties{
-				TimeCreated: lo.ToPtr(time.Now()),
-			}
+			vm.Properties.TimeCreated = lo.ToPtr(time.Now())
 			azureEnv.VirtualMachinesAPI.Instances.Store(lo.FromPtr(vm.ID), *vm)
 
 			ExpectSingletonReconciled(ctx, virtualMachineGCController)
@@ -260,9 +258,7 @@ var _ = Describe("VirtualMachine Garbage Collection", func() {
 		})
 		It("should not delete the instance or node if it already has a nodeClaim that matches it", func() {
 			// Launch time was 10m ago
-			vm.Properties = &armcompute.VirtualMachineProperties{
-				TimeCreated: lo.ToPtr(time.Now().Add(-time.Minute * 10)),
-			}
+			vm.Properties.TimeCreated = lo.ToPtr(time.Now().Add(-time.Minute * 10))
 			azureEnv.VirtualMachinesAPI.Instances.Store(lo.FromPtr(vm.ID), *vm)
 
 			nodeClaim := coretest.NodeClaim(karpv1.NodeClaim{


### PR DESCRIPTION
It used the wrong tag key so would never get the InstanceType details

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
