### PR TITLE
feat: support stateless cni in 1.34+

### DIFF
--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -246,6 +246,34 @@ var _ = Describe("InstanceType Provider", func() {
 				ContainSubstring("kubernetes.azure.com/azure-cni-overlay=true"),
 			))
 		})
+		It("should include stateless CNI label for kubernetes 1.34+", func() {
+			// Set kubernetes version to 1.34.0
+			nodeClass.Status.KubernetesVersion = "1.34.0"
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+			pod := coretest.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
+			ExpectScheduled(ctx, env.Client, pod)
+
+			decodedString := ExpectDecodedCustomData(azureEnv)
+			Expect(decodedString).To(SatisfyAll(
+				ContainSubstring("kubernetes.azure.com/azure-cni-overlay=true"),
+				ContainSubstring("kubernetes.azure.com/network-stateless-cni=true"),
+			))
+		})
+		It("should not include stateless CNI label for kubernetes < 1.34", func() {
+			// Set kubernetes version to 1.33.0
+			nodeClass.Status.KubernetesVersion = "1.33.0"
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+			pod := coretest.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
+			ExpectScheduled(ctx, env.Client, pod)
+
+			decodedString := ExpectDecodedCustomData(azureEnv)
+			Expect(decodedString).To(SatisfyAll(
+				ContainSubstring("kubernetes.azure.com/azure-cni-overlay=true"),
+				Not(ContainSubstring("kubernetes.azure.com/network-stateless-cni")),
+			))
+		})
 		It("should use the subnet specified in the nodeclass", func() {
 			nodeClass.Spec.VNETSubnetID = lo.ToPtr("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpenter/subnets/nodeclassSubnet")
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -246,7 +246,7 @@ var _ = Describe("InstanceType Provider", func() {
 				ContainSubstring("kubernetes.azure.com/azure-cni-overlay=true"),
 			))
 		})
-		It("should include stateless CNI label for kubernetes 1.34+", func() {
+		It("should include stateless CNI label for kubernetes 1.34+ set to true", func() {
 			// Set kubernetes version to 1.34.0
 			nodeClass.Status.KubernetesVersion = "1.34.0"
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
@@ -256,23 +256,21 @@ var _ = Describe("InstanceType Provider", func() {
 
 			decodedString := ExpectDecodedCustomData(azureEnv)
 			Expect(decodedString).To(SatisfyAll(
-				ContainSubstring("kubernetes.azure.com/azure-cni-overlay=true"),
 				ContainSubstring("kubernetes.azure.com/network-stateless-cni=true"),
 			))
 		})
-		It("should not include stateless CNI label for kubernetes < 1.34", func() {
+		It("should include stateless CNI label for kubernetes < 1.34 set to false", func() {
 			// Set kubernetes version to 1.33.0
 			nodeClass.Status.KubernetesVersion = "1.33.0"
 			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			pod := coretest.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
 			ExpectScheduled(ctx, env.Client, pod)
-
 			decodedString := ExpectDecodedCustomData(azureEnv)
 			Expect(decodedString).To(SatisfyAll(
-				ContainSubstring("kubernetes.azure.com/azure-cni-overlay=true"),
-				Not(ContainSubstring("kubernetes.azure.com/network-stateless-cni")),
+				ContainSubstring("kubernetes.azure.com/network-stateless-cni=false"),
 			))
+
 		})
 		It("should use the subnet specified in the nodeclass", func() {
 			nodeClass.Spec.VNETSubnetID = lo.ToPtr("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpenter/subnets/nodeclassSubnet")

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -250,13 +250,8 @@ func (p *Provider) getVnetInfoLabels(subnetID string, kubernetesVersion string) 
 		podNetworkTypeLabel:  consts.NetworkPluginModeOverlay,
 	}
 
-	// Add stateless CNI label for Kubernetes 1.34+
-	if kubernetesVersion != "" {
-		parsedVersion, err := semver.Parse(kubernetesVersion)
-		if err == nil && parsedVersion.Minor >= 34 {
-			vnetLabels[networkStatelessCNILabel] = "true"
-		}
-	}
+	parsedVersion, _ := semver.Parse(kubernetesVersion)
+	vnetLabels[networkStatelessCNILabel] = lo.Ternary(parsedVersion.Minor >= 34, "true", "false")
 
 	return vnetLabels, nil
 }

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -38,7 +38,9 @@ import (
 
 const (
 	karpenterManagedTagKey = v1beta1.Group + "/cluster"
+)
 
+var (
 	dataplaneLabel           = v1beta1.AKSLabelDomain + "/ebpf-dataplane"
 	azureCNIOverlayLabel     = v1beta1.AKSLabelDomain + "/azure-cni-overlay"
 	subnetNameLabel          = v1beta1.AKSLabelDomain + "/network-subnet"

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -36,10 +36,6 @@ import (
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 )
 
-const (
-	karpenterManagedTagKey = v1beta1.Group + "/cluster"
-)
-
 var (
 	dataplaneLabel           = v1beta1.AKSLabelDomain + "/ebpf-dataplane"
 	azureCNIOverlayLabel     = v1beta1.AKSLabelDomain + "/azure-cni-overlay"

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -251,7 +251,7 @@ func (p *Provider) getVnetInfoLabels(subnetID string, kubernetesVersion string) 
 	}
 
 	parsedVersion, _ := semver.Parse(kubernetesVersion)
-	vnetLabels[networkStatelessCNILabel] = lo.Ternary(parsedVersion.Minor >= 34, "true", "false")
+	vnetLabels[networkStatelessCNILabel] = lo.Ternary(parsedVersion.GE(semver.Version{Major: 1, Minor: 34}), "true", "false")
 
 	return vnetLabels, nil
 }

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -37,14 +37,14 @@ import (
 )
 
 const (
-	karpenterManagedTagKey = "karpenter.azure.com/cluster"
+	karpenterManagedTagKey = v1beta1.Group + "/cluster"
 
-	dataplaneLabel           = "kubernetes.azure.com/ebpf-dataplane"
-	azureCNIOverlayLabel     = "kubernetes.azure.com/azure-cni-overlay"
-	subnetNameLabel          = "kubernetes.azure.com/network-subnet"
-	vnetGUIDLabel            = "kubernetes.azure.com/nodenetwork-vnetguid"
-	podNetworkTypeLabel      = "kubernetes.azure.com/podnetwork-type"
-	networkStatelessCNILabel = "kubernetes.azure.com/network-stateless-cni"
+	dataplaneLabel           = v1beta1.AKSLabelDomain + "/ebpf-dataplane"
+	azureCNIOverlayLabel     = v1beta1.AKSLabelDomain + "/azure-cni-overlay"
+	subnetNameLabel          = v1beta1.AKSLabelDomain + "/network-subnet"
+	vnetGUIDLabel            = v1beta1.AKSLabelDomain + "/nodenetwork-vnetguid"
+	podNetworkTypeLabel      = v1beta1.AKSLabelDomain + "/podnetwork-type"
+	networkStatelessCNILabel = v1beta1.AKSLabelDomain + "/network-stateless-cni"
 )
 
 type Template struct {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
1.34 introduces a new pattern with how we target daemonsets for different CNI modes.  This adds a pr to add labels for the new feature
**How was this change tested?**
- make test
- e2e run: https://github.com/Azure/karpenter-provider-azure/actions/runs/16953512983

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
