### PR TITLE
feat: add zone provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/Azure/go-autorest/autorest v0.11.30
 	github.com/Azure/skewer v0.0.20
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourceg
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0/go.mod h1:wVEOJfGTj0oPAUGA1JuRAvz/lxXQsWW16axmHPP47Bk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0 h1:wxQx2Bt4xzPIKvW59WQf1tJNx/ZZKPfN+EhPX3Z6CYY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0/go.mod h1:TpiwjwnW/khS0LKs4vW5UmmT9OWcxaveS8U7+tlknzo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0 h1:/g8S6wk65vfC6m3FIxJ+i5QDyN9JWwXI8Hb0Img10hU=

--- a/hack/code/instancetype_testdata_gen/main.go
+++ b/hack/code/instancetype_testdata_gen/main.go
@@ -33,7 +33,7 @@ import (
 
 func main() {
 	fmt.Println("starting generation of sku data...")
-	sub := os.Getenv("SUBSCRIPTION_ID")
+	sub := os.Getenv("AZURE_SUBSCRIPTION_ID")
 	path, region, selectedSkus := os.Args[2], os.Args[3], os.Args[4]
 	skus := strings.Split(selectedSkus, ",")
 	targetSkus := map[string]struct{}{}
@@ -41,7 +41,7 @@ func main() {
 		targetSkus[sku] = struct{}{}
 	}
 	if sub == "" {
-		fmt.Println("SUBSCRIPTION_ID env var is required")
+		fmt.Println("AZURE_SUBSCRIPTION_ID env var is required")
 		os.Exit(1)
 	}
 	cred, err := azidentity.NewDefaultAzureCredential(nil)

--- a/hack/code/locations_gen/main.go
+++ b/hack/code/locations_gen/main.go
@@ -1,0 +1,114 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	"github.com/samber/lo"
+)
+
+func main() {
+	flag.Parse()
+	if flag.NArg() != 1 {
+		log.Fatalf("Usage: %s pkg/fake/locations.json", os.Args[0])
+	}
+
+	generateLocations(flag.Arg(0))
+}
+
+func generateLocations(filePath string) {
+	ctx := context.Background()
+
+	// Get subscription ID from environment variable
+	subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	if subscriptionID == "" {
+		log.Fatalf("AZURE_SUBSCRIPTION_ID environment variable is required")
+	}
+
+	// Create Azure credentials using default credential chain
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		log.Fatalf("Failed to create Azure credentials: %v", err)
+	}
+
+	// Create subscriptions client
+	client, err := armsubscriptions.NewClient(cred, nil)
+	if err != nil {
+		log.Fatalf("Failed to create subscriptions client: %v", err)
+	}
+
+	// Get locations using the pager
+	fmt.Printf("Fetching locations for subscription: %s\n", subscriptionID)
+	pager := client.NewListLocationsPager(subscriptionID, nil)
+
+	var locations []*armsubscriptions.Location
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			log.Fatalf("Failed to get next page of locations: %v", err)
+		}
+
+		locations = append(locations, page.Value...)
+	}
+
+	locations = lo.Filter(locations, func(location *armsubscriptions.Location, _ int) bool {
+		return !strings.Contains(lo.FromPtr(location.Metadata.Geography), "Stage")
+	})
+
+	fmt.Printf("Found %d locations\n", len(locations))
+
+	// Convert to JSON and save to file
+	jsonData, err := json.MarshalIndent(locations, "", "  ")
+	if err != nil {
+		log.Fatalf("Failed to marshal locations to JSON: %v", err)
+	}
+
+	// Redact subscription IDs from the JSON data
+	redactedJSON := redactSubscriptionIDs(string(jsonData))
+	// Append a newline character
+	redactedJSON = redactedJSON + "\n"
+
+	err = os.WriteFile(filePath, []byte(redactedJSON), 0644)
+	if err != nil {
+		log.Fatalf("Failed to write JSON data to file %s: %v", filePath, err)
+	}
+
+	fmt.Printf("Successfully saved locations to %s\n", filePath)
+}
+
+// redactSubscriptionIDs replaces subscription GUIDs in strings
+func redactSubscriptionIDs(jsonContent string) string {
+	// Regex pattern to match subscription GUIDs in paths
+	// Matches: /subscriptions/{GUID}/
+	subscriptionPattern := regexp.MustCompile(`/subscriptions/[0-9a-fA-F\-]+/`)
+
+	// Replace with redacted subscription ID
+	redacted := subscriptionPattern.ReplaceAllString(jsonContent, "/subscriptions/00000000-0000-0000-0000-000000000000/")
+
+	return redacted
+}

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -18,6 +18,17 @@ pricing() {
   checkForUpdates "${GIT_DIFF}" "${NO_UPDATE}" "${SUBJECT} beside timestamps since last update" "${GENERATED_FILE}"
 }
 
+locationsgen() {
+  GENERATED_FILE="pkg/fake/locations.json"
+  NO_UPDATE=$' pkg/fake/locations.json | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)'
+  SUBJECT="Locations"
+
+  go run hack/code/locations_gen/main.go -- "${GENERATED_FILE}"
+
+  GIT_DIFF=$(git diff --stat "${GENERATED_FILE}")
+  checkForUpdates "${GIT_DIFF}" "${NO_UPDATE}" "${SUBJECT} beside timestamps since last update" "${GENERATED_FILE}"
+}
+
 skugen() {
   location=${1:-eastus}
 
@@ -41,9 +52,9 @@ skugen() {
 
 
 skugen-all() {
-  SUBSCRIPTION_ID=$(az account show --query 'id' --output tsv)
-  export SUBSCRIPTION_ID
-  if [ -z "${SUBSCRIPTION_ID}" ]; then
+  AZURE_SUBSCRIPTION_ID=$(az account show --query 'id' --output tsv)
+  export AZURE_SUBSCRIPTION_ID
+  if [ -z "${AZURE_SUBSCRIPTION_ID}" ]; then
     echo "No subscription is set. Please login and set a subscription."
     exit 1
   fi
@@ -95,4 +106,5 @@ fi
 
 # Run all the codegen scripts
 pricing
+locationsgen
 skugen-all

--- a/pkg/fake/locations.json
+++ b/pkg/fake/locations.json
@@ -1,0 +1,2225 @@
+[
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "eastus-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "eastus-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "eastus-az1"
+      }
+    ],
+    "displayName": "East US",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus",
+    "metadata": {
+      "geography": "United States",
+      "geographyGroup": "US",
+      "latitude": "37.3719",
+      "longitude": "-79.8164",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus",
+          "name": "westus"
+        }
+      ],
+      "physicalLocation": "Virginia",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "eastus",
+    "regionalDisplayName": "(US) East US",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "westus2-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "westus2-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "westus2-az1"
+      }
+    ],
+    "displayName": "West US 2",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus2",
+    "metadata": {
+      "geography": "United States",
+      "geographyGroup": "US",
+      "latitude": "47.233",
+      "longitude": "-119.852",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/westcentralus",
+          "name": "westcentralus"
+        }
+      ],
+      "physicalLocation": "Washington",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "westus2",
+    "regionalDisplayName": "(US) West US 2",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "australiaeast-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "australiaeast-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "australiaeast-az1"
+      }
+    ],
+    "displayName": "Australia East",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiaeast",
+    "metadata": {
+      "geography": "Australia",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "-33.86",
+      "longitude": "151.2094",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiasoutheast",
+          "name": "australiasoutheast"
+        }
+      ],
+      "physicalLocation": "New South Wales",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "australiaeast",
+    "regionalDisplayName": "(Asia Pacific) Australia East",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "southeastasia-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "southeastasia-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "southeastasia-az1"
+      }
+    ],
+    "displayName": "Southeast Asia",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southeastasia",
+    "metadata": {
+      "geography": "Asia Pacific",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "1.283",
+      "longitude": "103.833",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastasia",
+          "name": "eastasia"
+        }
+      ],
+      "physicalLocation": "Singapore",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "southeastasia",
+    "regionalDisplayName": "(Asia Pacific) Southeast Asia",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "northeurope-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "northeurope-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "northeurope-az1"
+      }
+    ],
+    "displayName": "North Europe",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/northeurope",
+    "metadata": {
+      "geography": "Europe",
+      "geographyGroup": "Europe",
+      "latitude": "53.3478",
+      "longitude": "-6.2597",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/westeurope",
+          "name": "westeurope"
+        }
+      ],
+      "physicalLocation": "Ireland",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "northeurope",
+    "regionalDisplayName": "(Europe) North Europe",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "swedencentral-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "swedencentral-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "swedencentral-az1"
+      }
+    ],
+    "displayName": "Sweden Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/swedencentral",
+    "metadata": {
+      "geography": "Sweden",
+      "geographyGroup": "Europe",
+      "latitude": "60.67488",
+      "longitude": "17.14127",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/swedensouth",
+          "name": "swedensouth"
+        }
+      ],
+      "physicalLocation": "Gävle",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "swedencentral",
+    "regionalDisplayName": "(Europe) Sweden Central",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "uksouth-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "uksouth-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "uksouth-az1"
+      }
+    ],
+    "displayName": "UK South",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/uksouth",
+    "metadata": {
+      "geography": "United Kingdom",
+      "geographyGroup": "Europe",
+      "latitude": "50.941",
+      "longitude": "-0.799",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/ukwest",
+          "name": "ukwest"
+        }
+      ],
+      "physicalLocation": "London",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "uksouth",
+    "regionalDisplayName": "(Europe) UK South",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "westeurope-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "westeurope-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "westeurope-az1"
+      }
+    ],
+    "displayName": "West Europe",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/westeurope",
+    "metadata": {
+      "geography": "Europe",
+      "geographyGroup": "Europe",
+      "latitude": "52.3667",
+      "longitude": "4.9",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/northeurope",
+          "name": "northeurope"
+        }
+      ],
+      "physicalLocation": "Netherlands",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "westeurope",
+    "regionalDisplayName": "(Europe) West Europe",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "centralus-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "centralus-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "centralus-az1"
+      }
+    ],
+    "displayName": "Central US",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralus",
+    "metadata": {
+      "geography": "United States",
+      "geographyGroup": "US",
+      "latitude": "41.5908",
+      "longitude": "-93.6208",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2",
+          "name": "eastus2"
+        }
+      ],
+      "physicalLocation": "Iowa",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "centralus",
+    "regionalDisplayName": "(US) Central US",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "southafricanorth-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "southafricanorth-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "southafricanorth-az1"
+      }
+    ],
+    "displayName": "South Africa North",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafricanorth",
+    "metadata": {
+      "geography": "South Africa",
+      "geographyGroup": "Africa",
+      "latitude": "-25.73134",
+      "longitude": "28.21837",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafricawest",
+          "name": "southafricawest"
+        }
+      ],
+      "physicalLocation": "Johannesburg",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "southafricanorth",
+    "regionalDisplayName": "(Africa) South Africa North",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "centralindia-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "centralindia-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "centralindia-az1"
+      }
+    ],
+    "displayName": "Central India",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralindia",
+    "metadata": {
+      "geography": "India",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "18.5822",
+      "longitude": "73.9197",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southindia",
+          "name": "southindia"
+        }
+      ],
+      "physicalLocation": "Pune",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "centralindia",
+    "regionalDisplayName": "(Asia Pacific) Central India",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "eastasia-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "eastasia-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "eastasia-az1"
+      }
+    ],
+    "displayName": "East Asia",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastasia",
+    "metadata": {
+      "geography": "Asia Pacific",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "22.267",
+      "longitude": "114.188",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southeastasia",
+          "name": "southeastasia"
+        }
+      ],
+      "physicalLocation": "Hong Kong",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "eastasia",
+    "regionalDisplayName": "(Asia Pacific) East Asia",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "indonesiacentral-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "indonesiacentral-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "indonesiacentral-az1"
+      }
+    ],
+    "displayName": "Indonesia Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/indonesiacentral",
+    "metadata": {
+      "geography": "Indonesia",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "-6.2",
+      "longitude": "106.816666",
+      "pairedRegion": [],
+      "physicalLocation": "Jakarta",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "indonesiacentral",
+    "regionalDisplayName": "(Asia Pacific) Indonesia Central",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "japaneast-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "japaneast-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "japaneast-az1"
+      }
+    ],
+    "displayName": "Japan East",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/japaneast",
+    "metadata": {
+      "geography": "Japan",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "35.68",
+      "longitude": "139.77",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/japanwest",
+          "name": "japanwest"
+        }
+      ],
+      "physicalLocation": "Tokyo, Saitama",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "japaneast",
+    "regionalDisplayName": "(Asia Pacific) Japan East",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "japanwest-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "japanwest-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "japanwest-az1"
+      }
+    ],
+    "displayName": "Japan West",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/japanwest",
+    "metadata": {
+      "geography": "Japan",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "34.6939",
+      "longitude": "135.5022",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/japaneast",
+          "name": "japaneast"
+        }
+      ],
+      "physicalLocation": "Osaka",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "japanwest",
+    "regionalDisplayName": "(Asia Pacific) Japan West",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "koreacentral-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "koreacentral-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "koreacentral-az1"
+      }
+    ],
+    "displayName": "Korea Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreacentral",
+    "metadata": {
+      "geography": "Korea",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "37.5665",
+      "longitude": "126.978",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreasouth",
+          "name": "koreasouth"
+        }
+      ],
+      "physicalLocation": "Seoul",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "koreacentral",
+    "regionalDisplayName": "(Asia Pacific) Korea Central",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "malaysiawest-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "malaysiawest-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "malaysiawest-az1"
+      }
+    ],
+    "displayName": "Malaysia West",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/malaysiawest",
+    "metadata": {
+      "geography": "Malaysia",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "3.140853",
+      "longitude": "101.693207",
+      "pairedRegion": [],
+      "physicalLocation": "Kuala Lumpur",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "malaysiawest",
+    "regionalDisplayName": "(Asia Pacific) Malaysia West",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "newzealandnorth-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "newzealandnorth-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "newzealandnorth-az1"
+      }
+    ],
+    "displayName": "New Zealand North",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/newzealandnorth",
+    "metadata": {
+      "geography": "New Zealand",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "-36.84853",
+      "longitude": "174.76349",
+      "pairedRegion": [],
+      "physicalLocation": "Auckland",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "newzealandnorth",
+    "regionalDisplayName": "(Asia Pacific) New Zealand North",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "canadacentral-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "canadacentral-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "canadacentral-az1"
+      }
+    ],
+    "displayName": "Canada Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadacentral",
+    "metadata": {
+      "geography": "Canada",
+      "geographyGroup": "Canada",
+      "latitude": "43.653",
+      "longitude": "-79.383",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadaeast",
+          "name": "canadaeast"
+        }
+      ],
+      "physicalLocation": "Toronto",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "canadacentral",
+    "regionalDisplayName": "(Canada) Canada Central",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "austriaeast-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "austriaeast-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "austriaeast-az1"
+      }
+    ],
+    "displayName": "Austria East",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/austriaeast",
+    "metadata": {
+      "geography": "Austria",
+      "geographyGroup": "Europe",
+      "latitude": "16.214834",
+      "longitude": "48.2201153",
+      "pairedRegion": [],
+      "physicalLocation": "Vienna",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "austriaeast",
+    "regionalDisplayName": "(Europe) Austria East",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "francecentral-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "francecentral-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "francecentral-az1"
+      }
+    ],
+    "displayName": "France Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/francecentral",
+    "metadata": {
+      "geography": "France",
+      "geographyGroup": "Europe",
+      "latitude": "46.3772",
+      "longitude": "2.373",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/francesouth",
+          "name": "francesouth"
+        }
+      ],
+      "physicalLocation": "Paris",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "francecentral",
+    "regionalDisplayName": "(Europe) France Central",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "germanywestcentral-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "germanywestcentral-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "germanywestcentral-az1"
+      }
+    ],
+    "displayName": "Germany West Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/germanywestcentral",
+    "metadata": {
+      "geography": "Germany",
+      "geographyGroup": "Europe",
+      "latitude": "50.110924",
+      "longitude": "8.682127",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/germanynorth",
+          "name": "germanynorth"
+        }
+      ],
+      "physicalLocation": "Frankfurt",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "germanywestcentral",
+    "regionalDisplayName": "(Europe) Germany West Central",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "italynorth-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "italynorth-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "italynorth-az1"
+      }
+    ],
+    "displayName": "Italy North",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/italynorth",
+    "metadata": {
+      "geography": "Italy",
+      "geographyGroup": "Europe",
+      "latitude": "45.46888",
+      "longitude": "9.18109",
+      "pairedRegion": [],
+      "physicalLocation": "Milan",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "italynorth",
+    "regionalDisplayName": "(Europe) Italy North",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "norwayeast-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "norwayeast-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "norwayeast-az1"
+      }
+    ],
+    "displayName": "Norway East",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/norwayeast",
+    "metadata": {
+      "geography": "Norway",
+      "geographyGroup": "Europe",
+      "latitude": "59.913868",
+      "longitude": "10.752245",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/norwaywest",
+          "name": "norwaywest"
+        }
+      ],
+      "physicalLocation": "Norway",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "norwayeast",
+    "regionalDisplayName": "(Europe) Norway East",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "polandcentral-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "polandcentral-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "polandcentral-az1"
+      }
+    ],
+    "displayName": "Poland Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/polandcentral",
+    "metadata": {
+      "geography": "Poland",
+      "geographyGroup": "Europe",
+      "latitude": "52.23334",
+      "longitude": "21.01666",
+      "pairedRegion": [],
+      "physicalLocation": "Warsaw",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "polandcentral",
+    "regionalDisplayName": "(Europe) Poland Central",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "spaincentral-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "spaincentral-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "spaincentral-az1"
+      }
+    ],
+    "displayName": "Spain Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/spaincentral",
+    "metadata": {
+      "geography": "Spain",
+      "geographyGroup": "Europe",
+      "latitude": "40.4259",
+      "longitude": "3.4209",
+      "pairedRegion": [],
+      "physicalLocation": "Madrid",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "spaincentral",
+    "regionalDisplayName": "(Europe) Spain Central",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "switzerlandnorth-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "switzerlandnorth-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "switzerlandnorth-az1"
+      }
+    ],
+    "displayName": "Switzerland North",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerlandnorth",
+    "metadata": {
+      "geography": "Switzerland",
+      "geographyGroup": "Europe",
+      "latitude": "47.451542",
+      "longitude": "8.564572",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerlandwest",
+          "name": "switzerlandwest"
+        }
+      ],
+      "physicalLocation": "Zurich",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "switzerlandnorth",
+    "regionalDisplayName": "(Europe) Switzerland North",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "mexicocentral-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "mexicocentral-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "mexicocentral-az1"
+      }
+    ],
+    "displayName": "Mexico Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/mexicocentral",
+    "metadata": {
+      "geography": "Mexico",
+      "geographyGroup": "Mexico",
+      "latitude": "20.588818",
+      "longitude": "-100.389888",
+      "pairedRegion": [],
+      "physicalLocation": "Querétaro State",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "mexicocentral",
+    "regionalDisplayName": "(Mexico) Mexico Central",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "uaenorth-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "uaenorth-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "uaenorth-az1"
+      }
+    ],
+    "displayName": "UAE North",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/uaenorth",
+    "metadata": {
+      "geography": "UAE",
+      "geographyGroup": "Middle East",
+      "latitude": "25.266666",
+      "longitude": "55.316666",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/uaecentral",
+          "name": "uaecentral"
+        }
+      ],
+      "physicalLocation": "Dubai",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "uaenorth",
+    "regionalDisplayName": "(Middle East) UAE North",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "brazilsouth-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "brazilsouth-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "brazilsouth-az1"
+      }
+    ],
+    "displayName": "Brazil South",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazilsouth",
+    "metadata": {
+      "geography": "Brazil",
+      "geographyGroup": "South America",
+      "latitude": "-23.55",
+      "longitude": "-46.633",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralus",
+          "name": "southcentralus"
+        }
+      ],
+      "physicalLocation": "Sao Paulo State",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "brazilsouth",
+    "regionalDisplayName": "(South America) Brazil South",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "chilecentral-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "chilecentral-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "chilecentral-az1"
+      }
+    ],
+    "displayName": "Chile Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/chilecentral",
+    "metadata": {
+      "geography": "Chile",
+      "geographyGroup": "South America",
+      "latitude": "-33.447487",
+      "longitude": "-70.673676",
+      "pairedRegion": [],
+      "physicalLocation": "Santiago",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "chilecentral",
+    "regionalDisplayName": "(South America) Chile Central",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "eastus2euap-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "eastus2euap-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "eastus2euap-az1"
+      },
+      {
+        "logicalZone": "4",
+        "physicalZone": "eastus2euap-az4"
+      }
+    ],
+    "displayName": "East US 2 EUAP",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2euap",
+    "metadata": {
+      "geography": "Canary (US)",
+      "geographyGroup": "US",
+      "latitude": "36.6681",
+      "longitude": "-78.3889",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/centraluseuap",
+          "name": "centraluseuap"
+        }
+      ],
+      "physicalLocation": "",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "eastus2euap",
+    "regionalDisplayName": "(US) East US 2 EUAP",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "israelcentral-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "israelcentral-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "israelcentral-az1"
+      }
+    ],
+    "displayName": "Israel Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/israelcentral",
+    "metadata": {
+      "geography": "Israel",
+      "geographyGroup": "Middle East",
+      "latitude": "31.2655698",
+      "longitude": "33.4506633",
+      "pairedRegion": [],
+      "physicalLocation": "Israel",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "israelcentral",
+    "regionalDisplayName": "(Middle East) Israel Central",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "qatarcentral-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "qatarcentral-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "qatarcentral-az1"
+      }
+    ],
+    "displayName": "Qatar Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/qatarcentral",
+    "metadata": {
+      "geography": "Qatar",
+      "geographyGroup": "Middle East",
+      "latitude": "25.551462",
+      "longitude": "51.439327",
+      "pairedRegion": [],
+      "physicalLocation": "Doha",
+      "regionCategory": "Recommended",
+      "regionType": "Physical"
+    },
+    "name": "qatarcentral",
+    "regionalDisplayName": "(Middle East) Qatar Central",
+    "type": "Region"
+  },
+  {
+    "displayName": "Central US (Stage)",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralusstage",
+    "metadata": {
+      "geography": "usa",
+      "geographyGroup": "US",
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "centralusstage",
+    "regionalDisplayName": "(US) Central US (Stage)",
+    "type": "Region"
+  },
+  {
+    "displayName": "East US (Stage)",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastusstage",
+    "metadata": {
+      "geography": "usa",
+      "geographyGroup": "US",
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "eastusstage",
+    "regionalDisplayName": "(US) East US (Stage)",
+    "type": "Region"
+  },
+  {
+    "displayName": "East US 2 (Stage)",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2stage",
+    "metadata": {
+      "geography": "usa",
+      "geographyGroup": "US",
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "eastus2stage",
+    "regionalDisplayName": "(US) East US 2 (Stage)",
+    "type": "Region"
+  },
+  {
+    "displayName": "North Central US (Stage)",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/northcentralusstage",
+    "metadata": {
+      "geography": "usa",
+      "geographyGroup": "US",
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "northcentralusstage",
+    "regionalDisplayName": "(US) North Central US (Stage)",
+    "type": "Region"
+  },
+  {
+    "displayName": "South Central US (Stage)",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralusstage",
+    "metadata": {
+      "geography": "usa",
+      "geographyGroup": "US",
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "southcentralusstage",
+    "regionalDisplayName": "(US) South Central US (Stage)",
+    "type": "Region"
+  },
+  {
+    "displayName": "West US (Stage)",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/westusstage",
+    "metadata": {
+      "geography": "usa",
+      "geographyGroup": "US",
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "westusstage",
+    "regionalDisplayName": "(US) West US (Stage)",
+    "type": "Region"
+  },
+  {
+    "displayName": "West US 2 (Stage)",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus2stage",
+    "metadata": {
+      "geography": "usa",
+      "geographyGroup": "US",
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "westus2stage",
+    "regionalDisplayName": "(US) West US 2 (Stage)",
+    "type": "Region"
+  },
+  {
+    "displayName": "Asia",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/asia",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "asia",
+    "regionalDisplayName": "Asia",
+    "type": "Region"
+  },
+  {
+    "displayName": "Asia Pacific",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/asiapacific",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "asiapacific",
+    "regionalDisplayName": "Asia Pacific",
+    "type": "Region"
+  },
+  {
+    "displayName": "Australia",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/australia",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "australia",
+    "regionalDisplayName": "Australia",
+    "type": "Region"
+  },
+  {
+    "displayName": "Brazil",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazil",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "brazil",
+    "regionalDisplayName": "Brazil",
+    "type": "Region"
+  },
+  {
+    "displayName": "Canada",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/canada",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "canada",
+    "regionalDisplayName": "Canada",
+    "type": "Region"
+  },
+  {
+    "displayName": "Europe",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/europe",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "europe",
+    "regionalDisplayName": "Europe",
+    "type": "Region"
+  },
+  {
+    "displayName": "France",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/france",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "france",
+    "regionalDisplayName": "France",
+    "type": "Region"
+  },
+  {
+    "displayName": "Germany",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/germany",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "germany",
+    "regionalDisplayName": "Germany",
+    "type": "Region"
+  },
+  {
+    "displayName": "Global",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/global",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "global",
+    "regionalDisplayName": "Global",
+    "type": "Region"
+  },
+  {
+    "displayName": "India",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/india",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "india",
+    "regionalDisplayName": "India",
+    "type": "Region"
+  },
+  {
+    "displayName": "Indonesia",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/indonesia",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "indonesia",
+    "regionalDisplayName": "Indonesia",
+    "type": "Region"
+  },
+  {
+    "displayName": "Israel",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/israel",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "israel",
+    "regionalDisplayName": "Israel",
+    "type": "Region"
+  },
+  {
+    "displayName": "Italy",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/italy",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "italy",
+    "regionalDisplayName": "Italy",
+    "type": "Region"
+  },
+  {
+    "displayName": "Japan",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/japan",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "japan",
+    "regionalDisplayName": "Japan",
+    "type": "Region"
+  },
+  {
+    "displayName": "Korea",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/korea",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "korea",
+    "regionalDisplayName": "Korea",
+    "type": "Region"
+  },
+  {
+    "displayName": "Malaysia",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/malaysia",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "malaysia",
+    "regionalDisplayName": "Malaysia",
+    "type": "Region"
+  },
+  {
+    "displayName": "Mexico",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/mexico",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "mexico",
+    "regionalDisplayName": "Mexico",
+    "type": "Region"
+  },
+  {
+    "displayName": "New Zealand",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/newzealand",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "newzealand",
+    "regionalDisplayName": "New Zealand",
+    "type": "Region"
+  },
+  {
+    "displayName": "Norway",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/norway",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "norway",
+    "regionalDisplayName": "Norway",
+    "type": "Region"
+  },
+  {
+    "displayName": "Poland",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/poland",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "poland",
+    "regionalDisplayName": "Poland",
+    "type": "Region"
+  },
+  {
+    "displayName": "Qatar",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/qatar",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "qatar",
+    "regionalDisplayName": "Qatar",
+    "type": "Region"
+  },
+  {
+    "displayName": "Singapore",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/singapore",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "singapore",
+    "regionalDisplayName": "Singapore",
+    "type": "Region"
+  },
+  {
+    "displayName": "South Africa",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafrica",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "southafrica",
+    "regionalDisplayName": "South Africa",
+    "type": "Region"
+  },
+  {
+    "displayName": "Spain",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/spain",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "spain",
+    "regionalDisplayName": "Spain",
+    "type": "Region"
+  },
+  {
+    "displayName": "Sweden",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/sweden",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "sweden",
+    "regionalDisplayName": "Sweden",
+    "type": "Region"
+  },
+  {
+    "displayName": "Switzerland",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerland",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "switzerland",
+    "regionalDisplayName": "Switzerland",
+    "type": "Region"
+  },
+  {
+    "displayName": "Taiwan",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/taiwan",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "taiwan",
+    "regionalDisplayName": "Taiwan",
+    "type": "Region"
+  },
+  {
+    "displayName": "United Arab Emirates",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/uae",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "uae",
+    "regionalDisplayName": "United Arab Emirates",
+    "type": "Region"
+  },
+  {
+    "displayName": "United Kingdom",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/uk",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "uk",
+    "regionalDisplayName": "United Kingdom",
+    "type": "Region"
+  },
+  {
+    "displayName": "United States",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/unitedstates",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "unitedstates",
+    "regionalDisplayName": "United States",
+    "type": "Region"
+  },
+  {
+    "displayName": "United States EUAP",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/unitedstateseuap",
+    "metadata": {
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "unitedstateseuap",
+    "regionalDisplayName": "United States EUAP",
+    "type": "Region"
+  },
+  {
+    "displayName": "East Asia (Stage)",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastasiastage",
+    "metadata": {
+      "geography": "asia",
+      "geographyGroup": "Asia Pacific",
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "eastasiastage",
+    "regionalDisplayName": "(Asia Pacific) East Asia (Stage)",
+    "type": "Region"
+  },
+  {
+    "displayName": "Southeast Asia (Stage)",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southeastasiastage",
+    "metadata": {
+      "geography": "asia",
+      "geographyGroup": "Asia Pacific",
+      "regionCategory": "Other",
+      "regionType": "Logical"
+    },
+    "name": "southeastasiastage",
+    "regionalDisplayName": "(Asia Pacific) Southeast Asia (Stage)",
+    "type": "Region"
+  },
+  {
+    "displayName": "Brazil US",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazilus",
+    "metadata": {
+      "geography": "Brazil",
+      "geographyGroup": "South America",
+      "latitude": "0",
+      "longitude": "0",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazilsoutheast",
+          "name": "brazilsoutheast"
+        }
+      ],
+      "physicalLocation": "",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "brazilus",
+    "regionalDisplayName": "(South America) Brazil US",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "eastus2-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "eastus2-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "eastus2-az1"
+      }
+    ],
+    "displayName": "East US 2",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2",
+    "metadata": {
+      "geography": "United States",
+      "geographyGroup": "US",
+      "latitude": "36.6681",
+      "longitude": "-78.3889",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralus",
+          "name": "centralus"
+        }
+      ],
+      "physicalLocation": "Virginia",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "eastus2",
+    "regionalDisplayName": "(US) East US 2",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "southcentralus-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "southcentralus-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "southcentralus-az1"
+      }
+    ],
+    "displayName": "South Central US",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralus",
+    "metadata": {
+      "geography": "United States",
+      "geographyGroup": "US",
+      "latitude": "29.4167",
+      "longitude": "-98.5",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/northcentralus",
+          "name": "northcentralus"
+        }
+      ],
+      "physicalLocation": "Texas",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "southcentralus",
+    "regionalDisplayName": "(US) South Central US",
+    "type": "Region"
+  },
+  {
+    "availabilityZoneMappings": [
+      {
+        "logicalZone": "1",
+        "physicalZone": "westus3-az2"
+      },
+      {
+        "logicalZone": "2",
+        "physicalZone": "westus3-az3"
+      },
+      {
+        "logicalZone": "3",
+        "physicalZone": "westus3-az1"
+      }
+    ],
+    "displayName": "West US 3",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus3",
+    "metadata": {
+      "geography": "United States",
+      "geographyGroup": "US",
+      "latitude": "33.448376",
+      "longitude": "-112.074036",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus",
+          "name": "eastus"
+        }
+      ],
+      "physicalLocation": "Phoenix",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "westus3",
+    "regionalDisplayName": "(US) West US 3",
+    "type": "Region"
+  },
+  {
+    "displayName": "North Central US",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/northcentralus",
+    "metadata": {
+      "geography": "United States",
+      "geographyGroup": "US",
+      "latitude": "41.8819",
+      "longitude": "-87.6278",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southcentralus",
+          "name": "southcentralus"
+        }
+      ],
+      "physicalLocation": "Illinois",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "northcentralus",
+    "regionalDisplayName": "(US) North Central US",
+    "type": "Region"
+  },
+  {
+    "displayName": "West US",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus",
+    "metadata": {
+      "geography": "United States",
+      "geographyGroup": "US",
+      "latitude": "37.783",
+      "longitude": "-122.417",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus",
+          "name": "eastus"
+        }
+      ],
+      "physicalLocation": "California",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "westus",
+    "regionalDisplayName": "(US) West US",
+    "type": "Region"
+  },
+  {
+    "displayName": "Jio India West",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/jioindiawest",
+    "metadata": {
+      "geography": "India",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "22.470701",
+      "longitude": "70.05773",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/jioindiacentral",
+          "name": "jioindiacentral"
+        }
+      ],
+      "physicalLocation": "Jamnagar",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "jioindiawest",
+    "regionalDisplayName": "(Asia Pacific) Jio India West",
+    "type": "Region"
+  },
+  {
+    "displayName": "Central US EUAP",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/centraluseuap",
+    "metadata": {
+      "geography": "Canary (US)",
+      "geographyGroup": "US",
+      "latitude": "41.5908",
+      "longitude": "-93.6208",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/eastus2euap",
+          "name": "eastus2euap"
+        }
+      ],
+      "physicalLocation": "",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "centraluseuap",
+    "regionalDisplayName": "(US) Central US EUAP",
+    "type": "Region"
+  },
+  {
+    "displayName": "West Central US",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/westcentralus",
+    "metadata": {
+      "geography": "United States",
+      "geographyGroup": "US",
+      "latitude": "40.89",
+      "longitude": "-110.234",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/westus2",
+          "name": "westus2"
+        }
+      ],
+      "physicalLocation": "Wyoming",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "westcentralus",
+    "regionalDisplayName": "(US) West Central US",
+    "type": "Region"
+  },
+  {
+    "displayName": "South Africa West",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafricawest",
+    "metadata": {
+      "geography": "South Africa",
+      "geographyGroup": "Africa",
+      "latitude": "-34.075691",
+      "longitude": "18.843266",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southafricanorth",
+          "name": "southafricanorth"
+        }
+      ],
+      "physicalLocation": "Cape Town",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "southafricawest",
+    "regionalDisplayName": "(Africa) South Africa West",
+    "type": "Region"
+  },
+  {
+    "displayName": "Australia Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiacentral",
+    "metadata": {
+      "geography": "Australia",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "-35.3075",
+      "longitude": "149.1244",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiacentral2",
+          "name": "australiacentral2"
+        }
+      ],
+      "physicalLocation": "Canberra",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "australiacentral",
+    "regionalDisplayName": "(Asia Pacific) Australia Central",
+    "type": "Region"
+  },
+  {
+    "displayName": "Australia Central 2",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiacentral2",
+    "metadata": {
+      "geography": "Australia",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "-35.3075",
+      "longitude": "149.1244",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiacentral",
+          "name": "australiacentral"
+        }
+      ],
+      "physicalLocation": "Canberra",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "australiacentral2",
+    "regionalDisplayName": "(Asia Pacific) Australia Central 2",
+    "type": "Region"
+  },
+  {
+    "displayName": "Australia Southeast",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiasoutheast",
+    "metadata": {
+      "geography": "Australia",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "-37.8136",
+      "longitude": "144.9631",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/australiaeast",
+          "name": "australiaeast"
+        }
+      ],
+      "physicalLocation": "Victoria",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "australiasoutheast",
+    "regionalDisplayName": "(Asia Pacific) Australia Southeast",
+    "type": "Region"
+  },
+  {
+    "displayName": "Jio India Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/jioindiacentral",
+    "metadata": {
+      "geography": "India",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "21.146633",
+      "longitude": "79.08886",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/jioindiawest",
+          "name": "jioindiawest"
+        }
+      ],
+      "physicalLocation": "Nagpur",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "jioindiacentral",
+    "regionalDisplayName": "(Asia Pacific) Jio India Central",
+    "type": "Region"
+  },
+  {
+    "displayName": "Korea South",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreasouth",
+    "metadata": {
+      "geography": "Korea",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "35.1796",
+      "longitude": "129.0756",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/koreacentral",
+          "name": "koreacentral"
+        }
+      ],
+      "physicalLocation": "Busan",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "koreasouth",
+    "regionalDisplayName": "(Asia Pacific) Korea South",
+    "type": "Region"
+  },
+  {
+    "displayName": "South India",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southindia",
+    "metadata": {
+      "geography": "India",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "12.9822",
+      "longitude": "80.1636",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/centralindia",
+          "name": "centralindia"
+        }
+      ],
+      "physicalLocation": "Chennai",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "southindia",
+    "regionalDisplayName": "(Asia Pacific) South India",
+    "type": "Region"
+  },
+  {
+    "displayName": "West India",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/westindia",
+    "metadata": {
+      "geography": "India",
+      "geographyGroup": "Asia Pacific",
+      "latitude": "19.088",
+      "longitude": "72.868",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/southindia",
+          "name": "southindia"
+        }
+      ],
+      "physicalLocation": "Mumbai",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "westindia",
+    "regionalDisplayName": "(Asia Pacific) West India",
+    "type": "Region"
+  },
+  {
+    "displayName": "Canada East",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadaeast",
+    "metadata": {
+      "geography": "Canada",
+      "geographyGroup": "Canada",
+      "latitude": "46.817",
+      "longitude": "-71.217",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/canadacentral",
+          "name": "canadacentral"
+        }
+      ],
+      "physicalLocation": "Quebec",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "canadaeast",
+    "regionalDisplayName": "(Canada) Canada East",
+    "type": "Region"
+  },
+  {
+    "displayName": "France South",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/francesouth",
+    "metadata": {
+      "geography": "France",
+      "geographyGroup": "Europe",
+      "latitude": "43.8345",
+      "longitude": "2.1972",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/francecentral",
+          "name": "francecentral"
+        }
+      ],
+      "physicalLocation": "Marseille",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "francesouth",
+    "regionalDisplayName": "(Europe) France South",
+    "type": "Region"
+  },
+  {
+    "displayName": "Germany North",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/germanynorth",
+    "metadata": {
+      "geography": "Germany",
+      "geographyGroup": "Europe",
+      "latitude": "53.073635",
+      "longitude": "8.806422",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/germanywestcentral",
+          "name": "germanywestcentral"
+        }
+      ],
+      "physicalLocation": "Berlin",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "germanynorth",
+    "regionalDisplayName": "(Europe) Germany North",
+    "type": "Region"
+  },
+  {
+    "displayName": "Norway West",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/norwaywest",
+    "metadata": {
+      "geography": "Norway",
+      "geographyGroup": "Europe",
+      "latitude": "58.969975",
+      "longitude": "5.733107",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/norwayeast",
+          "name": "norwayeast"
+        }
+      ],
+      "physicalLocation": "Norway",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "norwaywest",
+    "regionalDisplayName": "(Europe) Norway West",
+    "type": "Region"
+  },
+  {
+    "displayName": "Switzerland West",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerlandwest",
+    "metadata": {
+      "geography": "Switzerland",
+      "geographyGroup": "Europe",
+      "latitude": "46.204391",
+      "longitude": "6.143158",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/switzerlandnorth",
+          "name": "switzerlandnorth"
+        }
+      ],
+      "physicalLocation": "Geneva",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "switzerlandwest",
+    "regionalDisplayName": "(Europe) Switzerland West",
+    "type": "Region"
+  },
+  {
+    "displayName": "UK West",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/ukwest",
+    "metadata": {
+      "geography": "United Kingdom",
+      "geographyGroup": "Europe",
+      "latitude": "53.427",
+      "longitude": "-3.084",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/uksouth",
+          "name": "uksouth"
+        }
+      ],
+      "physicalLocation": "Cardiff",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "ukwest",
+    "regionalDisplayName": "(Europe) UK West",
+    "type": "Region"
+  },
+  {
+    "displayName": "UAE Central",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/uaecentral",
+    "metadata": {
+      "geography": "UAE",
+      "geographyGroup": "Middle East",
+      "latitude": "24.466667",
+      "longitude": "54.366669",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/uaenorth",
+          "name": "uaenorth"
+        }
+      ],
+      "physicalLocation": "Abu Dhabi",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "uaecentral",
+    "regionalDisplayName": "(Middle East) UAE Central",
+    "type": "Region"
+  },
+  {
+    "displayName": "Brazil Southeast",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazilsoutheast",
+    "metadata": {
+      "geography": "Brazil",
+      "geographyGroup": "South America",
+      "latitude": "-22.90278",
+      "longitude": "-43.2075",
+      "pairedRegion": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/locations/brazilsouth",
+          "name": "brazilsouth"
+        }
+      ],
+      "physicalLocation": "Rio",
+      "regionCategory": "Other",
+      "regionType": "Physical"
+    },
+    "name": "brazilsoutheast",
+    "regionalDisplayName": "(South America) Brazil Southeast",
+    "type": "Region"
+  }
+]

--- a/pkg/fake/subscriptionsapi.go
+++ b/pkg/fake/subscriptionsapi.go
@@ -1,0 +1,94 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/zone"
+	"github.com/samber/lo"
+)
+
+type ListLocationsInput struct {
+	SubscriptionID string
+	Options        *armsubscriptions.ClientListLocationsOptions
+}
+
+type SubscriptionsAPIBehavior struct {
+	NewListLocationsPagerBehavior MockedFunction[ListLocationsInput, armsubscriptions.ClientListLocationsResponse]
+	Locations                     sync.Map
+}
+
+var _ zone.SubscriptionsAPI = &SubscriptionsAPI{}
+
+type SubscriptionsAPI struct {
+	SubscriptionsAPIBehavior
+}
+
+func (api *SubscriptionsAPI) Reset() {
+	api.NewListLocationsPagerBehavior.Reset()
+	api.Locations.Range(func(k, v any) bool {
+		api.Locations.Delete(k)
+		return true
+	})
+}
+
+func (api *SubscriptionsAPI) NewListLocationsPager(
+	subscriptionID string,
+	options *armsubscriptions.ClientListLocationsOptions,
+) *runtime.Pager[armsubscriptions.ClientListLocationsResponse] {
+	input := &ListLocationsInput{
+		SubscriptionID: subscriptionID,
+		Options:        options,
+	}
+
+	pagingHandler := runtime.PagingHandler[armsubscriptions.ClientListLocationsResponse]{
+		More: func(page armsubscriptions.ClientListLocationsResponse) bool {
+			return false // TODO: It might be ideal if we had a MockPager which sometimes simulated multiple pages of results to ensure we handle that correctly
+		},
+		Fetcher: func(ctx context.Context, _ *armsubscriptions.ClientListLocationsResponse) (armsubscriptions.ClientListLocationsResponse, error) {
+			return api.NewListLocationsPagerBehavior.Invoke(input, func(input *ListLocationsInput) (armsubscriptions.ClientListLocationsResponse, error) {
+				output := armsubscriptions.LocationListResult{
+					Value: []*armsubscriptions.Location{},
+				}
+
+				api.Locations.Range(func(key, value any) bool {
+					cast := value.(armsubscriptions.Location)
+					output.Value = append(output.Value, &cast)
+					return true
+				})
+
+				// Sort the result according to Name so that we have a stable base to write asserts upon
+				sort.Slice(output.Value, func(i, j int) bool {
+					l := output.Value[i]
+					r := output.Value[j]
+					return lo.FromPtr(l.Name) < lo.FromPtr(r.Name)
+				})
+
+				return armsubscriptions.ClientListLocationsResponse{
+					LocationListResult: output,
+				}, nil
+			})
+		},
+	}
+
+	return runtime.NewPager(pagingHandler)
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -137,6 +138,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	)
 	zoneProvider := zone.NewProvider(
 		azClient.SubscriptionsClient,
+		clock.RealClock{},
 		azConfig.SubscriptionID,
 	)
 	instanceTypeProvider := instancetype.NewDefaultProvider(

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/flowcontrol"
-	"k8s.io/utils/clock"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -62,7 +61,6 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/networksecuritygroup"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing"
-	"github.com/Azure/karpenter-provider-azure/pkg/providers/zone"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 	armopts "github.com/Azure/karpenter-provider-azure/pkg/utils/opts"
 )
@@ -136,17 +134,11 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		cache.New(imagefamily.ImageExpirationInterval,
 			imagefamily.ImageCacheCleaningInterval),
 	)
-	zoneProvider := zone.NewProvider(
-		azClient.SubscriptionsClient,
-		clock.RealClock{},
-		azConfig.SubscriptionID,
-	)
 	instanceTypeProvider := instancetype.NewDefaultProvider(
 		azConfig.Location,
 		cache.New(instancetype.InstanceTypesCacheTTL, azurecache.DefaultCleanupInterval),
 		azClient.SKUClient,
 		pricingProvider,
-		zoneProvider,
 		unavailableOfferingsCache,
 	)
 	imageResolver := imagefamily.NewDefaultResolver(

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -61,6 +61,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/networksecuritygroup"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/zone"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 	armopts "github.com/Azure/karpenter-provider-azure/pkg/utils/opts"
 )
@@ -134,11 +135,16 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		cache.New(imagefamily.ImageExpirationInterval,
 			imagefamily.ImageCacheCleaningInterval),
 	)
+	zoneProvider := zone.NewProvider(
+		azClient.SubscriptionsClient,
+		azConfig.SubscriptionID,
+	)
 	instanceTypeProvider := instancetype.NewDefaultProvider(
 		azConfig.Location,
 		cache.New(instancetype.InstanceTypesCacheTTL, azurecache.DefaultCleanupInterval),
 		azClient.SKUClient,
 		pricingProvider,
+		zoneProvider,
 		unavailableOfferingsCache,
 	)
 	imageResolver := imagefamily.NewDefaultResolver(

--- a/pkg/providers/zone/zone.go
+++ b/pkg/providers/zone/zone.go
@@ -1,0 +1,157 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zone
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const maxFailures = 10
+
+// SubscriptionsAPI defines the interface for Azure Subscriptions client operations
+type SubscriptionsAPI interface {
+	NewListLocationsPager(
+		subscriptionID string,
+		options *armsubscriptions.ClientListLocationsOptions,
+	) *runtime.Pager[armsubscriptions.ClientListLocationsResponse]
+}
+
+// Provider handles zone support detection for Azure regions
+type Provider struct {
+	subscriptionsAPI SubscriptionsAPI
+	subscriptionID   string
+
+	// Cached zone support data - maps region name to zone support boolean
+	zoneSupport map[string]bool
+	hasLoaded   bool
+	// failures is the number of times loading zone support from the Azure API has failed
+	failures int
+	mu       sync.Mutex
+}
+
+// NewProvider creates a new zone provider
+func NewProvider(subscriptionsAPI SubscriptionsAPI, subscriptionID string) *Provider {
+	return &Provider{
+		subscriptionsAPI: subscriptionsAPI,
+		subscriptionID:   subscriptionID,
+		zoneSupport:      lo.Assign(fallbackZonalRegions), // deepcopy
+
+	}
+}
+
+// SupportsZones returns true if the given region supports availability zones
+func (p *Provider) SupportsZones(ctx context.Context, region string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.hasLoaded && p.failures < maxFailures {
+		// Try to load zone support data from Azure API
+		if err := p.loadFromAzure(ctx); err != nil {
+			p.failures++
+			log.FromContext(ctx).Error(err, "failed to load zone support from Azure API, falling back to hardcoded list")
+		} else {
+			p.hasLoaded = true
+		}
+	}
+
+	return p.zoneSupport[region] // if cache doesn't have our region, assume no zone support
+}
+
+// loadFromAzure discovers zone support by calling Azure Subscriptions API
+func (p *Provider) loadFromAzure(ctx context.Context) error {
+	log := log.FromContext(ctx)
+	log.V(1).Info("discovering zone support for regions", "subscriptionID", p.subscriptionID)
+
+	pager := p.subscriptionsAPI.NewListLocationsPager(p.subscriptionID, nil)
+	result := make(map[string]bool)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list Azure locations: %w", err)
+		}
+
+		for _, location := range page.Value {
+			locationName := lo.FromPtr(location.Name)
+			if locationName == "" {
+				continue
+			}
+
+			result[locationName] = len(location.AvailabilityZoneMappings) > 0
+		}
+	}
+
+	log.Info("discovered zone support for regions", "regionCount", len(result))
+	p.zoneSupport = lo.Assign(p.zoneSupport, result) // Merge with existing cache in case some regions are not returned
+	return nil
+}
+
+// TODO: We may be able to remove this fallback entirely if we have data that suggests this API is very reliable
+// Hardcoded fallback list of zonal regions - used when Azure API is unavailable
+// Source: https://learn.microsoft.com/en-us/azure/reliability/regions-list#azure-regions-list-1
+var fallbackZonalRegions = map[string]bool{
+	// Special
+	"centraluseuap": true,
+	"eastus2euap":   true,
+	// Americas
+	"brazilsouth":    true,
+	"canadacentral":  true,
+	"centralus":      true,
+	"eastus":         true,
+	"eastus2":        true,
+	"southcentralus": true,
+	"usgovvirginia":  true,
+	"westus2":        true,
+	"westus3":        true,
+	"chilecentral":   true,
+	"mexicocentral":  true,
+	// Europe
+	"francecentral":      true,
+	"italynorth":         true,
+	"germanywestcentral": true,
+	"norwayeast":         true,
+	"northeurope":        true,
+	"uksouth":            true,
+	"westeurope":         true,
+	"swedencentral":      true,
+	"switzerlandnorth":   true,
+	"polandcentral":      true,
+	"spaincentral":       true,
+	// Middle East
+	"qatarcentral":  true,
+	"uaenorth":      true,
+	"israelcentral": true,
+	// Africa
+	"southafricanorth": true,
+	// Asia Pacific
+	"australiaeast":    true,
+	"centralindia":     true,
+	"japaneast":        true,
+	"koreacentral":     true,
+	"southeastasia":    true,
+	"eastasia":         true,
+	"chinanorth3":      true,
+	"indonesiacentral": true,
+	"japanwest":        true,
+	"newzealandnorth":  true,
+}

--- a/pkg/providers/zone/zone.go
+++ b/pkg/providers/zone/zone.go
@@ -49,6 +49,8 @@ type SubscriptionsAPI interface {
 }
 
 // Provider handles zone support detection for Azure regions
+// TODO: This provider is currently unused. Keeping it around for now though as we will likely want to adapt it
+// to provide physical to logical zone mappings.
 type Provider struct {
 	subscriptionsAPI SubscriptionsAPI
 	subscriptionID   string

--- a/pkg/providers/zone/zone.go
+++ b/pkg/providers/zone/zone.go
@@ -154,8 +154,7 @@ func (p *Provider) shouldTryAgain() bool {
 // Source: https://learn.microsoft.com/en-us/azure/reliability/regions-list#azure-regions-list-1
 var fallbackZonalRegions = map[string]bool{
 	// Special
-	"centraluseuap": true,
-	"eastus2euap":   true,
+	"eastus2euap": true,
 	// Americas
 	"brazilsouth":    true,
 	"canadacentral":  true,
@@ -169,6 +168,7 @@ var fallbackZonalRegions = map[string]bool{
 	"chilecentral":   true,
 	"mexicocentral":  true,
 	// Europe
+	"austriaeast":        true,
 	"francecentral":      true,
 	"italynorth":         true,
 	"germanywestcentral": true,
@@ -197,4 +197,5 @@ var fallbackZonalRegions = map[string]bool{
 	"indonesiacentral": true,
 	"japanwest":        true,
 	"newzealandnorth":  true,
+	"malaysiawest":     true,
 }

--- a/pkg/providers/zone/zone_test.go
+++ b/pkg/providers/zone/zone_test.go
@@ -37,9 +37,8 @@ func TestProvider_SupportsZones_ZonalRegions(t *testing.T) {
 	ctx := context.Background()
 
 	// Setup fake API
-	fakeAPI := &fake.SubscriptionsAPI{}
-	fakeAPI.Locations.Store("eastus", createZonalLocation("eastus", []string{"1"}))
-	fakeAPI.Locations.Store("centralus", createZonalLocation("centralus", []string{"1", "2"}))
+	fakeAPI, err := fake.NewSubscriptionsAPI()
+	g.Expect(err).To(BeNil())
 
 	// Create provider
 	provider := zone.NewProvider(fakeAPI, &clock.FakeClock{}, "test-subscription")
@@ -58,14 +57,14 @@ func TestProvider_SupportsZones_NonZonalRegions(t *testing.T) {
 	ctx := context.Background()
 
 	// Setup fake API
-	fakeAPI := &fake.SubscriptionsAPI{}
-	fakeAPI.Locations.Store("westus", createNonZonalLocation("westus"))
+	fakeAPI, err := fake.NewSubscriptionsAPI()
+	g.Expect(err).To(BeNil())
 
 	// Create provider
 	provider := zone.NewProvider(fakeAPI, &clock.FakeClock{}, "test-subscription")
 
 	// Test regions
-	g.Expect(provider.SupportsZones(ctx, "westus")).To(BeFalse())
+	g.Expect(provider.SupportsZones(ctx, "canadaeast")).To(BeFalse())
 
 	// Test unknown region
 	g.Expect(provider.SupportsZones(ctx, "unknownregion")).To(BeFalse())

--- a/pkg/providers/zone/zone_test.go
+++ b/pkg/providers/zone/zone_test.go
@@ -1,0 +1,192 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zone_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	"github.com/Azure/karpenter-provider-azure/pkg/fake"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/zone"
+)
+
+func TestProvider_SupportsZones_ZonalRegions(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// Setup fake API
+	fakeAPI := &fake.SubscriptionsAPI{}
+	fakeAPI.Locations.Store("eastus", createZonalLocation("eastus", []string{"1"}))
+	fakeAPI.Locations.Store("centralus", createZonalLocation("centralus", []string{"1", "2"}))
+
+	// Create provider
+	provider := zone.NewProvider(fakeAPI, "test-subscription")
+
+	// Test regions
+	g.Expect(provider.SupportsZones(ctx, "eastus")).To(BeTrue())
+	g.Expect(provider.SupportsZones(ctx, "centralus")).To(BeTrue())
+
+	// Test unknown region
+	g.Expect(provider.SupportsZones(ctx, "unknownregion")).To(BeFalse())
+}
+
+func TestProvider_SupportsZones_NonZonalRegions(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// Setup fake API
+	fakeAPI := &fake.SubscriptionsAPI{}
+	fakeAPI.Locations.Store("westus", createNonZonalLocation("westus"))
+
+	// Create provider
+	provider := zone.NewProvider(fakeAPI, "test-subscription")
+
+	// Test regions
+	g.Expect(provider.SupportsZones(ctx, "westus")).To(BeFalse())
+
+	// Test unknown region
+	g.Expect(provider.SupportsZones(ctx, "unknownregion")).To(BeFalse())
+}
+
+func TestProvider_SupportsZones_FallbackToHardcodedListOnError(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// Setup fake API with error
+	fakeAPI := &fake.SubscriptionsAPI{}
+	fakeAPI.NewListLocationsPagerBehavior.Error.Set(errors.New("API error"))
+
+	// Create provider
+	provider := zone.NewProvider(fakeAPI, "test-subscription")
+
+	// Test regions that are in the hardcoded fallback list
+	g.Expect(provider.SupportsZones(ctx, "eastus")).To(BeTrue())
+	g.Expect(provider.SupportsZones(ctx, "westus2")).To(BeTrue())
+	g.Expect(provider.SupportsZones(ctx, "northeurope")).To(BeTrue())
+
+	// Test region not in hardcoded list
+	g.Expect(provider.SupportsZones(ctx, "unknownregion")).To(BeFalse())
+}
+
+func TestProvider_SupportsZones_StopsLoadingAfterMaxFailures(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// Setup fake API with error
+	fakeAPI := &fake.SubscriptionsAPI{}
+	fakeAPI.NewListLocationsPagerBehavior.Error.Set(errors.New("API error"), fake.MaxCalls(50))
+
+	// Create provider
+	provider := zone.NewProvider(fakeAPI, "test-subscription")
+
+	// Test regions that are in the hardcoded fallback list
+	for i := 0; i < 20; i++ {
+		g.Expect(provider.SupportsZones(ctx, "eastus")).To(BeTrue())
+	}
+
+	g.Expect(fakeAPI.NewListLocationsPagerBehavior.FailedCalls()).To(Equal(10))
+}
+
+func TestProvider_SupportsZones_Caching(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// Setup fake API
+	fakeAPI := &fake.SubscriptionsAPI{}
+	fakeAPI.Locations.Store("eastus", createZonalLocation("eastus", []string{"1"}))
+	fakeAPI.Locations.Store("westus2", createZonalLocation("westus2", []string{"1"}))
+	fakeAPI.Locations.Store("northeurope", createZonalLocation("northeurope", []string{"1"}))
+
+	// Create provider
+	provider := zone.NewProvider(fakeAPI, "test-subscription")
+
+	// First call should trigger API call
+	g.Expect(provider.SupportsZones(ctx, "eastus")).To(BeTrue())
+	g.Expect(fakeAPI.NewListLocationsPagerBehavior.Calls()).To(Equal(1))
+
+	// Second call should use cached data
+	g.Expect(provider.SupportsZones(ctx, "eastus")).To(BeTrue())
+	g.Expect(fakeAPI.NewListLocationsPagerBehavior.Calls()).To(Equal(1))
+
+	// Third call with different region should also use cached data
+	g.Expect(provider.SupportsZones(ctx, "unknownregion")).To(BeFalse())
+	g.Expect(fakeAPI.NewListLocationsPagerBehavior.Calls()).To(Equal(1))
+}
+
+func TestProvider_SupportsZones_ThreadSafety(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// Setup fake API
+	fakeAPI := &fake.SubscriptionsAPI{}
+
+	// Add mock location using helper function
+	fakeAPI.Locations.Store("eastus", createZonalLocation("eastus", []string{"1"}))
+
+	provider := zone.NewProvider(fakeAPI, "test-subscription")
+
+	// Test concurrent access
+	done := make(chan bool, 10)
+
+	for i := 0; i < 10; i++ {
+		go func() {
+			g.Expect(provider.SupportsZones(ctx, "eastus")).To(BeTrue())
+			g.Expect(provider.SupportsZones(ctx, "unknownregion")).To(BeFalse())
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}
+
+// createZonalLocation creates a location with availability zone mappings
+func createZonalLocation(name string, zones []string) armsubscriptions.Location {
+	var zoneMappings []*armsubscriptions.AvailabilityZoneMappings
+	for _, zone := range zones {
+		zoneMappings = append(zoneMappings, &armsubscriptions.AvailabilityZoneMappings{
+			LogicalZone:  lo.ToPtr(zone),
+			PhysicalZone: lo.ToPtr(name + "-az" + zone),
+		})
+	}
+
+	return armsubscriptions.Location{
+		Name:                     lo.ToPtr(name),
+		AvailabilityZoneMappings: zoneMappings,
+	}
+}
+
+// createNonZonalLocation creates a location without availability zone mappings
+func createNonZonalLocation(name string) armsubscriptions.Location {
+	return armsubscriptions.Location{
+		Name: lo.ToPtr(name),
+		// No AvailabilityZoneMappings for non-zonal regions
+	}
+}

--- a/pkg/providers/zone/zone_test.go
+++ b/pkg/providers/zone/zone_test.go
@@ -221,11 +221,3 @@ func createZonalLocation(name string, zones []string) armsubscriptions.Location 
 		AvailabilityZoneMappings: zoneMappings,
 	}
 }
-
-// createNonZonalLocation creates a location without availability zone mappings
-func createNonZonalLocation(name string) armsubscriptions.Location {
-	return armsubscriptions.Location{
-		Name: lo.ToPtr(name),
-		// No AvailabilityZoneMappings for non-zonal regions
-	}
-}

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -23,6 +23,7 @@ import (
 	gomegaformat "github.com/onsi/gomega/format"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
 
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
@@ -136,7 +137,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 	pricingProvider := pricing.NewProvider(ctx, pricingAPI, region, make(chan struct{}))
 	kubernetesVersionProvider := kubernetesversion.NewKubernetesVersionProvider(env.KubernetesInterface, kubernetesVersionCache)
 	imageFamilyProvider := imagefamily.NewProvider(communityImageVersionsAPI, region, subscription, nodeImageVersionsAPI, nodeImagesCache)
-	zoneProvider := zone.NewProvider(subscriptionAPI, subscription)
+	zoneProvider := zone.NewProvider(subscriptionAPI, clock.RealClock{}, subscription)
 	instanceTypesProvider := instancetype.NewDefaultProvider(
 		region,
 		instanceTypeCache,

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -23,7 +23,6 @@ import (
 	gomegaformat "github.com/onsi/gomega/format"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/clock"
 
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
@@ -42,7 +41,6 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/networksecuritygroup"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing"
-	"github.com/Azure/karpenter-provider-azure/pkg/providers/zone"
 )
 
 func init() {
@@ -137,13 +135,11 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 	pricingProvider := pricing.NewProvider(ctx, pricingAPI, region, make(chan struct{}))
 	kubernetesVersionProvider := kubernetesversion.NewKubernetesVersionProvider(env.KubernetesInterface, kubernetesVersionCache)
 	imageFamilyProvider := imagefamily.NewProvider(communityImageVersionsAPI, region, subscription, nodeImageVersionsAPI, nodeImagesCache)
-	zoneProvider := zone.NewProvider(subscriptionAPI, clock.RealClock{}, subscription)
 	instanceTypesProvider := instancetype.NewDefaultProvider(
 		region,
 		instanceTypeCache,
 		skuClientSingleton,
 		pricingProvider,
-		zoneProvider,
 		unavailableOfferingsCache)
 	imageFamilyResolver := imagefamily.NewDefaultResolver(env.Client, imageFamilyProvider, instanceTypesProvider, nodeBootstrappingAPI)
 	launchTemplateProvider := launchtemplate.NewProvider(


### PR DESCRIPTION
Calls the list subscriptions API and dynamically determines if a region is zonal or not

Fixes #826.

**Description**

**How was this change tested?**

* Unit tests
* E2E tests: https://github.com/Azure/karpenter-provider-azure/actions/runs/17003024324

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
source region zonal information from API, with fallback to hardcoded list if API is unavailable.
```
