### PR TITLE
chore: clean up skuclient

### DIFF
--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -21,8 +21,6 @@ import (
 	"os"
 	"strings"
 
-	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
-
 	"github.com/Azure/go-autorest/autorest"
 )
 
@@ -65,18 +63,6 @@ func BuildAzureConfig() (*Config, error) {
 	}
 
 	return cfg, nil
-}
-
-func (cfg *Config) GetAzureClientConfig(authorizer autorest.Authorizer, env *azclient.Environment) *ClientConfig {
-	azClientConfig := &ClientConfig{
-		Location:                cfg.Location,
-		SubscriptionID:          cfg.SubscriptionID,
-		ResourceManagerEndpoint: env.ResourceManagerEndpoint,
-		Authorizer:              authorizer,
-		UserAgent:               GetUserAgentExtension(),
-	}
-
-	return azClientConfig
 }
 
 func (cfg *Config) Build() error {

--- a/pkg/fake/resourceskuapi.go
+++ b/pkg/fake/resourceskuapi.go
@@ -29,18 +29,6 @@ import (
 // ResourceSkus is a map of location to resource skus
 var ResourceSkus = make(map[string][]compute.ResourceSku)
 
-type MockSkuClientSingleton struct {
-	SKUClient *ResourceSKUsAPI
-}
-
-func (sc *MockSkuClientSingleton) GetInstance() skewer.ResourceClient {
-	return sc.SKUClient
-}
-
-func (sc *MockSkuClientSingleton) Reset() {
-	sc.SKUClient.Reset()
-}
-
 // assert that the fake implements the interface
 var _ skewer.ResourceClient = &ResourceSKUsAPI{}
 

--- a/pkg/providers/instance/azure_client.go
+++ b/pkg/providers/instance/azure_client.go
@@ -37,6 +37,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/networksecuritygroup"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/zone"
+	"github.com/Azure/skewer"
 
 	armopts "github.com/Azure/karpenter-provider-azure/pkg/utils/opts"
 )
@@ -80,7 +81,7 @@ type AZClient struct {
 	ImageVersionsClient     imagefamilytypes.CommunityGalleryImageVersionsAPI
 	NodeBootstrappingClient imagefamilytypes.NodeBootstrappingAPI
 	// SKU CLIENT is still using track 1 because skewer does not support the track 2 path. We need to refactor this once skewer supports track 2
-	SKUClient                   skuclient.SkuClient
+	SKUClient                   skewer.ResourceClient
 	LoadBalancersClient         loadbalancer.LoadBalancersAPI
 	NetworkSecurityGroupsClient networksecuritygroup.API
 	SubscriptionsClient         zone.SubscriptionsAPI
@@ -101,7 +102,7 @@ func NewAZClientFromAPI(
 	imageVersionsClient imagefamilytypes.CommunityGalleryImageVersionsAPI,
 	nodeImageVersionsClient imagefamilytypes.NodeImageVersionsAPI,
 	nodeBootstrappingClient imagefamilytypes.NodeBootstrappingAPI,
-	skuClient skuclient.SkuClient,
+	skuClient skewer.ResourceClient,
 	subscriptionsClient zone.SubscriptionsAPI,
 ) *AZClient {
 	return &AZClient{
@@ -193,7 +194,7 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *azclient.Environmen
 
 	// TODO: this one is not enabled for rate limiting / throttling ...
 	// TODO Move this over to track 2 when skewer is migrated
-	skuClient := skuclient.NewSkuClient(ctx, cfg, env)
+	skuClient := skuclient.NewSkuClient(cfg.SubscriptionID, cred, env)
 
 	var nodeBootstrappingClient imagefamilytypes.NodeBootstrappingAPI = nil
 	if o.ProvisionMode == consts.ProvisionModeBootstrappingClient {

--- a/pkg/providers/instance/skuclient/skuclient.go
+++ b/pkg/providers/instance/skuclient/skuclient.go
@@ -17,79 +17,17 @@ limitations under the License.
 package skuclient
 
 import (
-	"context"
-	"sync"
-	"time"
-
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/karpenter-provider-azure/pkg/auth"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/skewer"
 	"github.com/jongio/azidext/go/azidext"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const (
-	refreshClient = 12 * time.Hour
-)
-
-type SkuClient interface {
-	GetInstance() skewer.ResourceClient
-}
-
-type skuClient struct {
-	cfg *auth.Config
-	env *azclient.Environment
-
-	mu       sync.RWMutex
-	instance compute.ResourceSkusClient
-}
-
-func (sc *skuClient) updateInstance(ctx context.Context) {
-	sc.mu.RLock()
-	defer sc.mu.RUnlock()
-
-	// Create a new authorizer for the sku client
-	// TODO (charliedmcb): need to get track 2 support for the skewer API
-	cred, err := azidentity.NewDefaultAzureCredential(nil)
-	if err != nil {
-		log.FromContext(ctx).Error(err, "error creating authorizer for sku client", "credentialType", "default")
-		return
-	}
+func NewSkuClient(subscriptionID string, cred azcore.TokenCredential, env *azclient.Environment) skewer.ResourceClient {
 	authorizer := azidext.NewTokenCredentialAdapter(cred, []string{azidext.DefaultManagementScope})
-
-	azClientConfig := sc.cfg.GetAzureClientConfig(authorizer, sc.env)
-
-	skuClient := compute.NewResourceSkusClient(sc.cfg.SubscriptionID)
-	skuClient.Authorizer = azClientConfig.Authorizer
-
-	sc.instance = skuClient
-}
-
-func NewSkuClient(ctx context.Context, cfg *auth.Config, env *azclient.Environment) SkuClient {
-	sc := &skuClient{
-		cfg: cfg,
-		env: env,
-	}
-	sc.updateInstance(ctx)
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(refreshClient):
-				sc.updateInstance(ctx)
-			}
-		}
-	}()
-	return sc
-}
-
-func (sc *skuClient) GetInstance() skewer.ResourceClient {
-	sc.mu.RLock()
-	defer sc.mu.RUnlock()
-	return sc.instance
+	skuClient := compute.NewResourceSkusClient(subscriptionID)
+	skuClient.Authorizer = authorizer
+	return skuClient
 }

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -42,7 +42,6 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 
-	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance/skuclient"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing"
 
 	"github.com/Azure/skewer"
@@ -72,7 +71,7 @@ var _ Provider = (*DefaultProvider)(nil)
 
 type DefaultProvider struct {
 	region               string
-	skuClient            skuclient.SkuClient
+	skuClient            skewer.ResourceClient
 	pricingProvider      *pricing.Provider
 	unavailableOfferings *kcache.UnavailableOfferings
 
@@ -91,7 +90,7 @@ type DefaultProvider struct {
 func NewDefaultProvider(
 	region string,
 	cache *cache.Cache,
-	skuClient skuclient.SkuClient,
+	skuClient skewer.ResourceClient,
 	pricingProvider *pricing.Provider,
 	offeringsCache *kcache.UnavailableOfferings,
 ) *DefaultProvider {
@@ -283,7 +282,7 @@ func (p *DefaultProvider) getInstanceTypes(ctx context.Context) (map[string]*ske
 	}
 	instanceTypes := map[string]*skewer.SKU{}
 
-	cache, err := skewer.NewCache(ctx, skewer.WithLocation(p.region), skewer.WithResourceClient(p.skuClient.GetInstance()))
+	cache, err := skewer.NewCache(ctx, skewer.WithLocation(p.region), skewer.WithResourceClient(p.skuClient))
 	if err != nil {
 		return nil, fmt.Errorf("fetching SKUs using skewer, %w", err)
 	}

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -2020,7 +2020,7 @@ var _ = Describe("InstanceType Provider", func() {
 			// Reconcile the NodeClass to ensure status is updated
 			ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
 
-			azureEnv.MockSkuClientSingleton.SKUClient.Error = fmt.Errorf("failed to list SKUs")
+			azureEnv.SKUsAPI.Error = fmt.Errorf("failed to list SKUs")
 
 			nodeClaim := coretest.NodeClaim(karpv1.NodeClaim{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -62,7 +62,7 @@ type Environment struct {
 	VirtualMachineExtensionsAPI *fake.VirtualMachineExtensionsAPI
 	NetworkInterfacesAPI        *fake.NetworkInterfacesAPI
 	CommunityImageVersionsAPI   *fake.CommunityGalleryImageVersionsAPI
-	MockSkuClientSingleton      *fake.MockSkuClientSingleton
+	SKUsAPI                     *fake.ResourceSKUsAPI
 	PricingAPI                  *fake.PricingAPI
 	LoadBalancersAPI            *fake.LoadBalancersAPI
 	NetworkSecurityGroupAPI     *fake.NetworkSecurityGroupAPI
@@ -116,7 +116,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 	networkInterfacesAPI := &fake.NetworkInterfacesAPI{}
 	virtualMachinesExtensionsAPI := &fake.VirtualMachineExtensionsAPI{}
 	pricingAPI := &fake.PricingAPI{}
-	skuClientSingleton := &fake.MockSkuClientSingleton{SKUClient: &fake.ResourceSKUsAPI{Location: region}}
+	skusAPI := &fake.ResourceSKUsAPI{Location: region}
 	communityImageVersionsAPI := &fake.CommunityGalleryImageVersionsAPI{}
 	loadBalancersAPI := &fake.LoadBalancersAPI{}
 	networkSecurityGroupAPI := &fake.NetworkSecurityGroupAPI{}
@@ -139,7 +139,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 	instanceTypesProvider := instancetype.NewDefaultProvider(
 		region,
 		instanceTypeCache,
-		skuClientSingleton,
+		skusAPI,
 		pricingProvider,
 		unavailableOfferingsCache)
 	imageFamilyResolver := imagefamily.NewDefaultResolver(env.Client, imageFamilyProvider, instanceTypesProvider, nodeBootstrappingAPI)
@@ -179,7 +179,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		communityImageVersionsAPI,
 		nodeImageVersionsAPI,
 		nodeBootstrappingAPI,
-		skuClientSingleton,
+		skusAPI,
 		subscriptionAPI,
 	)
 	instanceProvider := instance.NewDefaultProvider(
@@ -205,7 +205,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		LoadBalancersAPI:            loadBalancersAPI,
 		NetworkSecurityGroupAPI:     networkSecurityGroupAPI,
 		SubnetsAPI:                  subnetsAPI,
-		MockSkuClientSingleton:      skuClientSingleton,
+		SKUsAPI:                     skusAPI,
 		PricingAPI:                  pricingAPI,
 		SubscriptionAPI:             subscriptionAPI,
 
@@ -242,10 +242,9 @@ func (env *Environment) Reset() {
 	env.NetworkSecurityGroupAPI.Reset()
 	env.SubnetsAPI.Reset()
 	env.CommunityImageVersionsAPI.Reset()
-	env.MockSkuClientSingleton.Reset()
+	env.SKUsAPI.Reset()
 	env.PricingAPI.Reset()
 	env.PricingProvider.Reset()
-	env.MockSkuClientSingleton.SKUClient.Reset()
 
 	env.KubernetesVersionCache.Flush()
 	env.NodeImagesCache.Flush()


### PR DESCRIPTION
Now that we're using the Track2 SDK for authentication, we don't need to periodically refresh the client.

We know this is true because other clients using the same credential do not hit issues with token refresh. Additionally if we examine the ServicePrincipal credential we can see that it does support refresh:
[ClientSecretCredential](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azidentity/client_secret_credential.go#L73) calls [GetToken()](https://github.com/Azure/azure-sdk-for-go/blob/f0871996d2bc4f9ebb97fb94cb00285f8df8437d/sdk/azidentity/confidential_client.go#L104) which calls [AcquireTokenSilent](https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/main/apps/confidential/confidential.go#L589) which handles refresh/expiry at [this line](https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/main/apps/internal/base/base.go#L354)

**How was this change tested?**

* Unit tests
* End to end tests: https://github.com/Azure/karpenter-provider-azure/actions/runs/17162604216
* Manual test w/ pod older than 24h

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
