### PR TITLE
fix: bug with pricing provider not being launched

### DIFF
--- a/pkg/auth/environment.go
+++ b/pkg/auth/environment.go
@@ -130,6 +130,16 @@ func EnvironmentFromName(cloudName string) (*Environment, error) {
 	}, nil
 }
 
+// IsPublic returns if the specified configuration is public.
+// This takes the track2 format rather than being a method on Environment because
+// usage in api/sdk contexts use the track2 format and may not have access to the
+// auth.Environment struct.
+func IsPublic(env cloud.Configuration) bool {
+	endpointA := strings.TrimRight(env.Services[cloud.ResourceManager].Endpoint, "/")
+	endpointB := strings.TrimRight(cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint, "/")
+	return strings.EqualFold(endpointA, endpointB) // Shouldn't differ by case but let's be safe
+}
+
 // ResolveCloudEnvironment resolves the cloud environment using the following precedence:
 // 1. File-based environment (AZURE_ENVIRONMENT_FILEPATH)
 // 2. Known cloud names (ARM_CLOUD)

--- a/pkg/providers/pricing/client/pricingapi.go
+++ b/pkg/providers/pricing/client/pricingapi.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/karpenter-provider-azure/pkg/auth"
 )
 
 const (
@@ -48,7 +49,7 @@ func New(cloud cloud.Configuration) PricingAPI {
 func (papi *pricingAPI) GetProductsPricePages(_ context.Context, filters []*Filter, pageHandler func(output *ProductsPricePage)) error {
 	nextURL := pricingURL
 
-	if papi.cloud.Services[cloud.ResourceManager].Endpoint != cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint {
+	if !auth.IsPublic(papi.cloud) {
 		// If the cloud is not Azure Public, the pricing API isn't supported and we return an error
 		return fmt.Errorf("pricing API is not supported in non-public clouds")
 	}

--- a/pkg/providers/pricing/pricing.go
+++ b/pkg/providers/pricing/pricing.go
@@ -94,8 +94,9 @@ func NewProvider(
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithName("pricing").WithValues("region", region))
 
 	// Only poll in public cloud. Other clouds aren't supported currently
-	if env.Cloud.Services[cloud.ResourceManager].Endpoint == cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint {
+	if auth.IsPublic(env.Cloud) {
 		go func() {
+			log.FromContext(ctx).V(0).Info("starting pricing update loop")
 			// perform an initial price update at startup
 			p.updatePricing(ctx)
 

--- a/pkg/providers/pricing/suite_test.go
+++ b/pkg/providers/pricing/suite_test.go
@@ -49,9 +49,9 @@ func TestAzure(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	fakePricingAPI = &fake.PricingAPI{}
-	env = &auth.Environment{
-		Cloud: cloud.AzurePublic,
-	}
+	var err error
+	env, err = auth.EnvironmentFromName("AzurePublicCloud")
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = BeforeEach(func() {


### PR DESCRIPTION
**How was this change tested?**

* Ran the E2E locally it passed
* Fixed UT to test this case too and ran locally (also passed)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
