### PR TITLE
fix: Don't block PATCH VM if billing extension is not installed

### DIFF
--- a/pkg/controllers/nodeclaim/inplaceupdate/controller.go
+++ b/pkg/controllers/nodeclaim/inplaceupdate/controller.go
@@ -112,6 +112,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 	if err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
+	log.FromContext(ctx).V(1).Info("successfully saved new in-place update hash", "goalHash", goalHash)
 
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
There are currently cases where a node can join the cluster successfully but not have the billing extension installed. This blocks identity propagation and tags propagation.

We tolerate a missing billing extension since this is currently possible.

**How was this change tested?**

* Unit test

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
