### PR TITLE
refactor: export ResolveNodeImage (FromNodeClass) from imagefamily module

### DIFF
--- a/pkg/providers/imagefamily/resolver.go
+++ b/pkg/providers/imagefamily/resolver.go
@@ -49,6 +49,7 @@ type Resolver interface {
 		nodeClaim *karpv1.NodeClaim,
 		instanceType *cloudprovider.InstanceType,
 		staticParameters *template.StaticParameters) (*template.Parameters, error)
+	ResolveNodeImageFromNodeClass(nodeClass *v1beta1.AKSNodeClass, instanceType *cloudprovider.InstanceType) (string, error)
 }
 
 // assert that defaultResolver implements Resolver interface
@@ -98,7 +99,9 @@ func NewDefaultResolver(_ client.Client, imageProvider *provider, instanceTypePr
 	}
 }
 
-// Resolve fills in dynamic launch template parameters
+// Resolve fills in dynamic launch template parameters.
+// The name "imageFamilyResolver.Resolve()" is potentially misleading here.
+// Suggestion: refactor would help, but this won't be used by PROVISION_MODE=aksmachineapi anyway. May not be worth it.
 func (r *defaultResolver) Resolve(
 	ctx context.Context,
 	nodeClass *v1beta1.AKSNodeClass,
@@ -106,17 +109,13 @@ func (r *defaultResolver) Resolve(
 	instanceType *cloudprovider.InstanceType,
 	staticParameters *template.StaticParameters,
 ) (*template.Parameters, error) {
-	nodeImages, err := nodeClass.GetImages()
-	if err != nil {
-		return nil, err
-	}
 	kubernetesVersion, err := nodeClass.GetKubernetesVersion()
 	if err != nil {
 		return nil, err
 	}
 
 	imageFamily := GetImageFamily(nodeClass.Spec.ImageFamily, nodeClass.Spec.FIPSMode, kubernetesVersion, staticParameters)
-	imageID, err := r.resolveNodeImage(nodeImages, instanceType)
+	imageID, err := r.ResolveNodeImageFromNodeClass(nodeClass, instanceType)
 	if err != nil {
 		metrics.ImageSelectionErrorCount.WithLabelValues(imageFamily.Name()).Inc()
 		return nil, err
@@ -263,12 +262,13 @@ func defaultUbuntu(fipsMode *v1beta1.FIPSMode, kubernetesVersion string, paramet
 	return &Ubuntu2204{Options: parameters}
 }
 
-// resolveNodeImage returns Distro and Image ID for the given instance type. Images may vary due to architecture, accelerator, etc
-//
-// Preconditions:
-// - nodeImages is sorted by priority order
-func (r *defaultResolver) resolveNodeImage(nodeImages []v1beta1.NodeImage, instanceType *cloudprovider.InstanceType) (string, error) {
-	// nodeImages are sorted by priority order, so we can return the first one that matches
+// ResolveNodeImageFromNodeClass resolves Distro and image ID for the given node class and instance type. Images may vary due to architecture, accelerator, etc
+func (r *defaultResolver) ResolveNodeImageFromNodeClass(nodeClass *v1beta1.AKSNodeClass, instanceType *cloudprovider.InstanceType) (string, error) {
+	// ASSUMPTION: nodeImages in a NodeClass are always sorted by priority order.
+	nodeImages, err := nodeClass.GetImages()
+	if err != nil {
+		return "", err
+	}
 	for _, availableImage := range nodeImages {
 		if err := instanceType.Requirements.Compatible(
 			scheduling.NewNodeSelectorRequirements(availableImage.Requirements...),


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

As of today, `imagefamily.Resolve(...)` is not actually just resolving image family, but rather responsible for processing launch template. Although, the direction of the codebase is to move away from launch template being tied to imagefamily module, while keeping imagefamily module to its original responsibility: handling image matters.
This separation will be further demonstrated in [Machine API integration](https://github.com/Azure/karpenter-provider-azure/pull/1102). For now, this PR is a small refactor to this module to export a method to resolve node image, which is the first step of the separation.

**How was this change tested?**

* 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
