### PR TITLE
docs: warning comments for VM vs AKS machine code paths

### DIFF
--- a/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
@@ -94,6 +94,8 @@ func (p ProvisionClientBootstrap) GetCustomDataAndCSE(ctx context.Context) (stri
 }
 
 // nolint: gocyclo
+// ATTENTION!!!: changes here may NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+// Refactoring for code unification is not being invested immediately.
 func (p *ProvisionClientBootstrap) ConstructProvisionValues(ctx context.Context) (*models.ProvisionValues, error) {
 	if p.IsWindows {
 		// TODO(Windows)

--- a/pkg/providers/imagefamily/resolver.go
+++ b/pkg/providers/imagefamily/resolver.go
@@ -56,6 +56,8 @@ type Resolver interface {
 var _ Resolver = &defaultResolver{}
 
 // defaultResolver is able to fill-in dynamic launch template parameters
+// ATTENTION!!!: changes here may NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+// Refactoring for code unification is not being invested immediately.
 type defaultResolver struct {
 	nodeBootstrappingProvider types.NodeBootstrappingAPI
 	imageProvider             *provider
@@ -63,6 +65,8 @@ type defaultResolver struct {
 }
 
 // ImageFamily can be implemented to override the default logic for generating dynamic launch template parameters
+// ATTENTION!!!: changes here may NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+// Refactoring for code unification is not being invested immediately.
 type ImageFamily interface {
 	ScriptlessCustomData(
 		kubeletConfig *bootstrap.KubeletConfiguration,
@@ -102,6 +106,8 @@ func NewDefaultResolver(_ client.Client, imageProvider *provider, instanceTypePr
 // Resolve fills in dynamic launch template parameters.
 // The name "imageFamilyResolver.Resolve()" is potentially misleading here.
 // Suggestion: refactor would help, but this won't be used by PROVISION_MODE=aksmachineapi anyway. May not be worth it.
+// ATTENTION!!!: changes here may NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+// Refactoring for code unification is not being invested immediately.
 func (r *defaultResolver) Resolve(
 	ctx context.Context,
 	nodeClass *v1beta1.AKSNodeClass,
@@ -153,6 +159,8 @@ func (r *defaultResolver) Resolve(
 		return nil, err
 	}
 
+	// ATTENTION!!!: changes here will NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+	// Refactoring for code unification is not being invested immediately.
 	template := &template.Parameters{
 		StaticParameters: staticParameters,
 		ScriptlessCustomData: imageFamily.ScriptlessCustomData(
@@ -212,6 +220,8 @@ func mapToImageDistro(imageID string, fipsMode *v1beta1.FIPSMode, imageFamily Im
 	return "", fmt.Errorf("no distro found for image id %s", imageID)
 }
 
+// ATTENTION!!!: changes here may NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+// Refactoring for code unification is not being invested immediately.
 func prepareKubeletConfiguration(ctx context.Context, instanceType *cloudprovider.InstanceType, nodeClass *v1beta1.AKSNodeClass) *bootstrap.KubeletConfiguration {
 	kubeletConfig := &bootstrap.KubeletConfiguration{}
 

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -46,6 +46,8 @@ var (
 	networkStatelessCNILabel = v1beta1.AKSLabelDomain + "/network-stateless-cni"
 )
 
+// ATTENTION!!!: changes here may NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+// Refactoring for code unification is not being invested immediately.
 type Template struct {
 	ScriptlessCustomData      string
 	ImageID                   string
@@ -77,6 +79,8 @@ type Provider struct {
 
 // TODO: add caching of launch templates
 
+// ATTENTION!!!: changes here may NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+// Refactoring for code unification is not being invested immediately.
 func NewProvider(_ context.Context, imageFamily imagefamily.Resolver, imageProvider imagefamily.NodeImageProvider, caBundle *string, clusterEndpoint string,
 	tenantID, subscriptionID, clusterResourceGroup string, kubeletIdentityClientID, resourceGroup, location, vnetGUID, provisionMode string,
 ) *Provider {
@@ -96,6 +100,8 @@ func NewProvider(_ context.Context, imageFamily imagefamily.Resolver, imageProvi
 	}
 }
 
+// ATTENTION!!!: changes here may NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+// Refactoring for code unification is not being invested immediately.
 func (p *Provider) GetTemplate(
 	ctx context.Context,
 	nodeClass *v1beta1.AKSNodeClass,
@@ -128,6 +134,8 @@ func (p *Provider) GetTemplate(
 	return launchTemplate, nil
 }
 
+// ATTENTION!!!: changes here may NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+// Refactoring for code unification is not being invested immediately.
 func (p *Provider) getStaticParameters(
 	ctx context.Context,
 	instanceType *cloudprovider.InstanceType,
@@ -165,6 +173,8 @@ func (p *Provider) getStaticParameters(
 		labels[dataplaneLabel] = consts.NetworkDataplaneCilium
 	}
 
+	// ATTENTION!!!: changes here will NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+	// Refactoring for code unification is not being invested immediately.
 	return &parameters.StaticParameters{
 		ClusterName:                    options.FromContext(ctx).ClusterName,
 		ClusterEndpoint:                p.clusterEndpoint,
@@ -209,6 +219,8 @@ func isAzureCNIOverlay(ctx context.Context) bool {
 	return options.FromContext(ctx).NetworkPlugin == consts.NetworkPluginAzure && options.FromContext(ctx).NetworkPluginMode == consts.NetworkPluginModeOverlay
 }
 
+// ATTENTION!!!: changes here may NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+// Refactoring for code unification is not being invested immediately.
 func (p *Provider) createLaunchTemplate(ctx context.Context, params *parameters.Parameters) (*Template, error) {
 	template := &Template{
 		ImageID:                   params.ImageID,

--- a/pkg/providers/launchtemplate/parameters/types.go
+++ b/pkg/providers/launchtemplate/parameters/types.go
@@ -22,6 +22,8 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/customscriptsbootstrap"
 )
 
+// ATTENTION!!!: changes here may NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+// Refactoring for code unification is not being invested immediately.
 // StaticParameters define the static launch template parameters
 type StaticParameters struct {
 	ClusterName                    string
@@ -49,6 +51,8 @@ type StaticParameters struct {
 	Labels map[string]string
 }
 
+// ATTENTION!!!: changes here may NOT be effective on AKS machine nodes (ProvisionModeAKSMachineAPI); See aksmachineinstance.go/aksmachineinstancehelpers.go.
+// Refactoring for code unification is not being invested immediately.
 // Parameters adds the dynamically generated launch template parameters
 type Parameters struct {
 	*StaticParameters


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Within AKS machine API provision mode from [Machine API integration](https://github.com/Azure/karpenter-provider-azure/pull/1102), the existing VM provisioning code path will not be used, primarily due to different assumptions, and the new direction on the codebase (e.g., split provisioning/image handling concerns). 
This PR adds comments on the old code path for the engineers to be advised that their changes may not reflect in the new provision mode.
Refactor of the existing code path to adhere to the new philosophy is currently not being invested on, and not worth it in general, IMO.

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
