### PR TITLE
feat: exclude AKS machine VMs/NICs from respective ARG list queries

### DIFF
--- a/pkg/fake/azureresourcegraphapi.go
+++ b/pkg/fake/azureresourcegraphapi.go
@@ -85,7 +85,8 @@ func (c *AzureResourceGraphAPI) getResourceList(query string) []interface{} {
 	switch query {
 	case c.vmListQuery:
 		vmList := lo.Filter(c.loadVMObjects(), func(vm armcompute.VirtualMachine, _ int) bool {
-			return vm.Tags != nil && vm.Tags[launchtemplate.NodePoolTagKey] != nil
+			return vm.Tags != nil && vm.Tags[launchtemplate.NodePoolTagKey] != nil &&
+				vm.Tags[launchtemplate.KarpenterAKSMachineNodeClaimTagKey] == nil
 		})
 		resourceList := lo.Map(vmList, func(vm armcompute.VirtualMachine, _ int) interface{} {
 			b, _ := json.Marshal(vm)
@@ -94,7 +95,8 @@ func (c *AzureResourceGraphAPI) getResourceList(query string) []interface{} {
 		return resourceList
 	case c.nicListQuery:
 		nicList := lo.Filter(c.loadNicObjects(), func(nic armnetwork.Interface, _ int) bool {
-			return nic.Tags != nil && nic.Tags[launchtemplate.NodePoolTagKey] != nil
+			return nic.Tags != nil && nic.Tags[launchtemplate.NodePoolTagKey] != nil &&
+				nic.Tags[launchtemplate.KarpenterAKSMachineNodeClaimTagKey] == nil
 		})
 		resourceList := lo.Map(nicList, func(nic armnetwork.Interface, _ int) interface{} {
 			b, _ := json.Marshal(nic)

--- a/pkg/fake/azureresourcegraphapi_test.go
+++ b/pkg/fake/azureresourcegraphapi_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/launchtemplate"
 	"github.com/samber/lo"
@@ -115,4 +116,278 @@ func checkVM(vm instance.Resource, rg string) error {
 		return fmt.Errorf("VM is missing timeCreated property")
 	}
 	return nil
+}
+
+func TestAzureResourceGraphAPI_Resources_VM_WithKarpenterAKSMachineTagFiltering(t *testing.T) {
+	resourceGroup := "test_managed_cluster_rg"
+	subscriptionID := "test_sub"
+	virtualMachinesAPI := &VirtualMachinesAPI{}
+	azureResourceGraphAPI := NewAzureResourceGraphAPI(resourceGroup, virtualMachinesAPI, nil)
+
+	cases := []struct {
+		testName        string
+		vmConfigs       []vmConfig
+		expectedVMNames []string
+		expectedError   string
+	}{
+		{
+			testName: "exclude VMs with KarpenterAKSMachine tag",
+			vmConfigs: []vmConfig{
+				{
+					name: "karpenter-vm",
+					tags: map[string]*string{
+						launchtemplate.NodePoolTagKey: lo.ToPtr("default"),
+					},
+				},
+				{
+					name: "aks-machine-vm",
+					tags: map[string]*string{
+						launchtemplate.NodePoolTagKey:                     lo.ToPtr("default"),
+						launchtemplate.KarpenterAKSMachineNodeClaimTagKey: lo.ToPtr("test-claim"),
+					},
+				},
+			},
+			expectedVMNames: []string{"karpenter-vm"},
+			expectedError:   "",
+		},
+		{
+			testName: "include all VMs when none have KarpenterAKSMachine tag",
+			vmConfigs: []vmConfig{
+				{
+					name: "vm1",
+					tags: map[string]*string{
+						launchtemplate.NodePoolTagKey: lo.ToPtr("default"),
+					},
+				},
+				{
+					name: "vm2",
+					tags: map[string]*string{
+						launchtemplate.NodePoolTagKey: lo.ToPtr("default"),
+					},
+				},
+			},
+			expectedVMNames: []string{"vm1", "vm2"},
+			expectedError:   "",
+		},
+		{
+			testName: "exclude all VMs when all have KarpenterAKSMachine tag",
+			vmConfigs: []vmConfig{
+				{
+					name: "aks-vm1",
+					tags: map[string]*string{
+						launchtemplate.NodePoolTagKey:                     lo.ToPtr("default"),
+						launchtemplate.KarpenterAKSMachineNodeClaimTagKey: lo.ToPtr("claim1"),
+					},
+				},
+				{
+					name: "aks-vm2",
+					tags: map[string]*string{
+						launchtemplate.NodePoolTagKey:                     lo.ToPtr("default"),
+						launchtemplate.KarpenterAKSMachineNodeClaimTagKey: lo.ToPtr("claim2"),
+					},
+				},
+			},
+			expectedVMNames: []string{},
+			expectedError:   "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.testName, func(t *testing.T) {
+			// Create VMs with different tag configurations
+			for _, vmConfig := range c.vmConfigs {
+				_, err := instance.CreateVirtualMachine(context.Background(), virtualMachinesAPI, resourceGroup, vmConfig.name, armcompute.VirtualMachine{
+					Tags:  vmConfig.tags,
+					Zones: []*string{lo.ToPtr("1")},
+				})
+				if err != nil {
+					t.Errorf("Unexpected error creating VM %s: %v", vmConfig.name, err)
+					return
+				}
+			}
+
+			// Query for VMs
+			queryRequest := instance.NewQueryRequest(&subscriptionID, instance.GetVMListQueryBuilder(resourceGroup).String())
+			data, err := instance.GetResourceData(context.Background(), azureResourceGraphAPI, *queryRequest)
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if c.expectedError != "" {
+				assert.Equal(t, c.expectedError, "Unexpected nil resource data")
+			} else {
+				assert.Equal(t, len(c.expectedVMNames), len(data), "Unexpected number of VMs returned")
+
+				// Verify the correct VMs are returned
+				returnedNames := make([]string, 0, len(data))
+				for _, vm := range data {
+					name, ok := vm["name"]
+					if !ok {
+						t.Error("VM is missing name")
+						continue
+					}
+					returnedNames = append(returnedNames, name.(string))
+				}
+
+				for _, expectedName := range c.expectedVMNames {
+					assert.Contains(t, returnedNames, expectedName, "Expected VM not found in results")
+				}
+			}
+
+			virtualMachinesAPI.Reset()
+		})
+	}
+}
+
+func TestAzureResourceGraphAPI_Resources_NIC_WithKarpenterAKSMachineTagFiltering(t *testing.T) {
+	resourceGroup := "test_managed_cluster_rg"
+	subscriptionID := "test_sub"
+	networkInterfacesAPI := &NetworkInterfacesAPI{}
+	azureResourceGraphAPI := NewAzureResourceGraphAPI(resourceGroup, nil, networkInterfacesAPI)
+
+	cases := []struct {
+		testName         string
+		nicConfigs       []nicConfig
+		expectedNICNames []string
+		expectedError    string
+	}{
+		{
+			testName: "exclude NICs with KarpenterAKSMachine tag",
+			nicConfigs: []nicConfig{
+				{
+					name: "karpenter-nic",
+					tags: map[string]*string{
+						launchtemplate.NodePoolTagKey: lo.ToPtr("default"),
+					},
+				},
+				{
+					name: "aks-machine-nic",
+					tags: map[string]*string{
+						launchtemplate.NodePoolTagKey:                     lo.ToPtr("default"),
+						launchtemplate.KarpenterAKSMachineNodeClaimTagKey: lo.ToPtr("test-claim"),
+					},
+				},
+			},
+			expectedNICNames: []string{"karpenter-nic"},
+			expectedError:    "",
+		},
+		{
+			testName: "exclude NICs without tags",
+			nicConfigs: []nicConfig{
+				{
+					name: "karpenter-nic",
+					tags: map[string]*string{
+						launchtemplate.NodePoolTagKey: lo.ToPtr("default"),
+					},
+				},
+				{
+					name: "aks-machine-nic-no-tags",
+					tags: map[string]*string{},
+				},
+			},
+			expectedNICNames: []string{"karpenter-nic"},
+			expectedError:    "",
+		},
+		{
+			testName: "include all NICs when none have KarpenterAKSMachine tag",
+			nicConfigs: []nicConfig{
+				{
+					name: "nic1",
+					tags: map[string]*string{
+						launchtemplate.NodePoolTagKey: lo.ToPtr("default"),
+					},
+				},
+				{
+					name: "nic2",
+					tags: map[string]*string{
+						launchtemplate.NodePoolTagKey: lo.ToPtr("default"),
+					},
+				},
+			},
+			expectedNICNames: []string{"nic1", "nic2"},
+			expectedError:    "",
+		},
+		{
+			testName: "exclude all NICs when all have KarpenterAKSMachine tag",
+			nicConfigs: []nicConfig{
+				{
+					name: "aks-nic1",
+					tags: map[string]*string{
+						launchtemplate.NodePoolTagKey:                     lo.ToPtr("default"),
+						launchtemplate.KarpenterAKSMachineNodeClaimTagKey: lo.ToPtr("claim1"),
+					},
+				},
+				{
+					name: "aks-nic2",
+					tags: map[string]*string{
+						launchtemplate.NodePoolTagKey:                     lo.ToPtr("default"),
+						launchtemplate.KarpenterAKSMachineNodeClaimTagKey: lo.ToPtr("claim2"),
+					},
+				},
+			},
+			expectedNICNames: []string{},
+			expectedError:    "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.testName, func(t *testing.T) {
+			// Create NICs with different tag configurations
+			for _, nicConfig := range c.nicConfigs {
+				nic := armnetwork.Interface{
+					Tags: nicConfig.tags,
+				}
+				_, err := networkInterfacesAPI.BeginCreateOrUpdate(context.Background(), resourceGroup, nicConfig.name, nic, nil)
+				if err != nil {
+					t.Errorf("Unexpected error creating NIC %s: %v", nicConfig.name, err)
+					return
+				}
+			}
+
+			// Query for NICs
+			queryRequest := instance.NewQueryRequest(&subscriptionID, instance.GetNICListQueryBuilder(resourceGroup).String())
+			data, err := instance.GetResourceData(context.Background(), azureResourceGraphAPI, *queryRequest)
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if c.expectedError != "" {
+				assert.Equal(t, c.expectedError, "Unexpected nil resource data")
+			} else {
+				assert.Equal(t, len(c.expectedNICNames), len(data), "Unexpected number of NICs returned")
+
+				// Verify the correct NICs are returned
+				returnedNames := make([]string, 0, len(data))
+				for _, nic := range data {
+					name, ok := nic["name"]
+					if !ok {
+						t.Error("NIC is missing name")
+						continue
+					}
+					returnedNames = append(returnedNames, name.(string))
+				}
+
+				for _, expectedName := range c.expectedNICNames {
+					assert.Contains(t, returnedNames, expectedName, "Expected NIC not found in results")
+				}
+			}
+
+			networkInterfacesAPI.Reset()
+		})
+	}
+}
+
+// Helper types for test configuration
+type vmConfig struct {
+	name string
+	tags map[string]*string
+}
+
+type nicConfig struct {
+	name string
+	tags map[string]*string
 }

--- a/pkg/providers/instance/azureresourcegraphlist.go
+++ b/pkg/providers/instance/azureresourcegraphlist.go
@@ -34,11 +34,13 @@ const (
 )
 
 // getResourceListQueryBuilder returns a KQL query builder for listing resources with nodepool tags
+// but excluding AKS machine-created resources
 func getResourceListQueryBuilder(rg string, resourceType string) *kql.Builder {
 	return kql.New(`Resources`).
 		AddLiteral(` | where type == `).AddString(resourceType).
 		AddLiteral(` | where resourceGroup == `).AddString(strings.ToLower(rg)). // ARG resources appear to have lowercase RG
-		AddLiteral(` | where tags has_cs `).AddString(launchtemplate.NodePoolTagKey)
+		AddLiteral(` | where tags has_cs `).AddString(launchtemplate.NodePoolTagKey).
+		AddLiteral(` | where not(tags has_cs `).AddString(launchtemplate.KarpenterAKSMachineNodeClaimTagKey).AddLiteral(`)`)
 }
 
 // GetVMListQueryBuilder returns a KQL query builder for listing VMs with nodepool tags

--- a/pkg/providers/launchtemplate/tags.go
+++ b/pkg/providers/launchtemplate/tags.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	NodePoolTagKey = strings.ReplaceAll(karpv1.NodePoolLabelKey, "/", "_")
+	NodePoolTagKey                     = strings.ReplaceAll(karpv1.NodePoolLabelKey, "/", "_")
+	KarpenterAKSMachineNodeClaimTagKey = "karpenter.azure.com_aksmachine_nodeclaim"
 )
 
 // TODO: Would like to refactor this out of launchtemplate at some point


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

With the new abstraction in [Machine API integration](https://github.com/Azure/karpenter-provider-azure/pull/1102), their VMs and NICs will be included in current ARG queries given they may have Karpenter NodePool tags like the ones from VM instances. That is not desirable, as it is AKS machine instance that will takes care of that, especially not by accessing the VM/NIC instances directly, which breaks the new machine abstraction per design.

This PR modifies the ARG query to exclude these instances from the queries, under the assumption that no valid instances have this tag as of today.
Note that there is no validation in CEL to prevent users from setting system tags (incl. NodePool) as of today. This shall be a follow-up.

**How was this change tested?**

* TODO

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
