### PR TITLE
refactor: export some independent provisioning utility functions from customscriptsbootstrap

### DIFF
--- a/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
@@ -162,9 +162,9 @@ func (p *ProvisionClientBootstrap) ConstructProvisionValues(ctx context.Context)
 			CPUCfsQuota:           p.KubeletConfig.CPUCFSQuota,
 			ImageGcHighThreshold:  p.KubeletConfig.ImageGCHighThresholdPercent,
 			ImageGcLowThreshold:   p.KubeletConfig.ImageGCLowThresholdPercent,
-			ContainerLogMaxSizeMB: convertContainerLogMaxSizeToMB(p.KubeletConfig.ContainerLogMaxSize),
+			ContainerLogMaxSizeMB: ConvertContainerLogMaxSizeToMB(p.KubeletConfig.ContainerLogMaxSize),
 			ContainerLogMaxFiles:  p.KubeletConfig.ContainerLogMaxFiles,
-			PodMaxPids:            convertPodMaxPids(p.KubeletConfig.PodPidsLimit),
+			PodMaxPids:            ConvertPodMaxPids(p.KubeletConfig.PodPidsLimit),
 		}
 
 		// NodeClaim defaults don't work somehow and keep giving invalid values. Can be improved later.

--- a/pkg/providers/imagefamily/customscriptsbootstrap/utils.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/utils.go
@@ -45,7 +45,7 @@ func reverseVMMemoryOverhead(vmMemoryOverheadPercent float64, adjustedMemory flo
 	return adjustedMemory / (1 - vmMemoryOverheadPercent)
 }
 
-func convertContainerLogMaxSizeToMB(containerLogMaxSize string) *int32 {
+func ConvertContainerLogMaxSizeToMB(containerLogMaxSize string) *int32 {
 	q, err := resource.ParseQuantity(containerLogMaxSize)
 	if err == nil {
 		// This could be improved later
@@ -54,7 +54,7 @@ func convertContainerLogMaxSizeToMB(containerLogMaxSize string) *int32 {
 	return nil
 }
 
-func convertPodMaxPids(podPidsLimit *int64) *int32 {
+func ConvertPodMaxPids(podPidsLimit *int64) *int32 {
 	if podPidsLimit != nil {
 		podPidsLimitInt64 := *podPidsLimit
 		if podPidsLimitInt64 > int64(math.MaxInt32) {

--- a/pkg/providers/imagefamily/customscriptsbootstrap/utils_test.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/utils_test.go
@@ -97,7 +97,7 @@ func TestConvertContainerLogMaxSizeToMB(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := convertContainerLogMaxSizeToMB(tt.containerLogMaxSize)
+			result := ConvertContainerLogMaxSizeToMB(tt.containerLogMaxSize)
 			if tt.expected == nil && result != nil {
 				t.Errorf("Expected nil but got %v", *result)
 			} else if tt.expected != nil && result == nil {
@@ -144,7 +144,7 @@ func TestConvertPodMaxPids(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := convertPodMaxPids(tt.podPidsLimit)
+			result := ConvertPodMaxPids(tt.podPidsLimit)
 			if tt.expected == nil && result != nil {
 				t.Errorf("Expected nil but got %v", *result)
 			} else if tt.expected != nil && result == nil {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

With [Machine API integration](https://github.com/Azure/karpenter-provider-azure/pull/1102), these utils are low hanging fruits to be shared without much refactor or additional testing. A follow-up could be to move this to a module not specific to VM instances provision mode, if not right at AKS machine instance provider itself.

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
