### PR TITLE
refactor: render Scriptless custom data only when necessary

### DIFF
--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -220,14 +220,15 @@ func (p *Provider) createLaunchTemplate(ctx context.Context, params *parameters.
 		StorageProfileSizeGB:      params.StorageProfileSizeGB,
 	}
 
-	if p.provisionMode == consts.ProvisionModeBootstrappingClient {
+	switch p.provisionMode {
+	case consts.ProvisionModeBootstrappingClient:
 		customData, cse, err := params.CustomScriptsNodeBootstrapping.GetCustomDataAndCSE(ctx)
 		if err != nil {
 			return nil, err
 		}
 		template.CustomScriptsCustomData = customData
 		template.CustomScriptsCSE = cse
-	} else {
+	case consts.ProvisionModeAKSScriptless:
 		// render user data
 		userData, err := params.ScriptlessCustomData.Script()
 		if err != nil {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

The current if statement will result in Scriptless custom data being rendered in any mode except bootstrapping client provision mode. That works when only two modes exist. However, the new one is coming with [Machine API integration](https://github.com/Azure/karpenter-provider-azure/pull/1102). Not satisfying preconditions may result in errors during the rendering process, while having to worry about those are completely unnecessary in the first place.

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
