### PR TITLE
refactor: distinguish instance type in inplaceupdate

### DIFF
--- a/pkg/controllers/nodeclaim/inplaceupdate/suite_test.go
+++ b/pkg/controllers/nodeclaim/inplaceupdate/suite_test.go
@@ -189,6 +189,185 @@ var _ = Describe("Unit tests", func() {
 		})
 	})
 
+	Context("CalculateHash", func() {
+		It("should produce deterministic hashes for identical data", func() {
+			data := map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			}
+
+			hash1, err := inplaceupdate.CalculateHash(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash1).ToNot(BeEmpty())
+
+			hash2, err := inplaceupdate.CalculateHash(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash2).ToNot(BeEmpty())
+
+			Expect(hash1).To(Equal(hash2))
+		})
+
+		It("should produce different hashes for different data", func() {
+			data1 := map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			}
+
+			data2 := map[string]string{
+				"key1": "value1",
+				"key2": "different_value",
+			}
+
+			hash1, err := inplaceupdate.CalculateHash(data1)
+			Expect(err).ToNot(HaveOccurred())
+
+			hash2, err := inplaceupdate.CalculateHash(data2)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(hash1).ToNot(Equal(hash2))
+		})
+
+		It("should handle nil interface{}", func() {
+			var data interface{}
+			hash, err := inplaceupdate.CalculateHash(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).ToNot(BeEmpty())
+
+			// Verify it's deterministic by computing again
+			hash2, err := inplaceupdate.CalculateHash(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).To(Equal(hash2))
+		})
+
+		It("should handle empty types", func() {
+			By("handling empty map")
+			emptyMap := map[string]string{}
+			hash, err := inplaceupdate.CalculateHash(emptyMap)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).ToNot(BeEmpty())
+
+			By("handling empty slice")
+			emptySlice := []string{}
+			hash, err = inplaceupdate.CalculateHash(emptySlice)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).ToNot(BeEmpty())
+
+			By("handling nil slice")
+			var nilSlice []string
+			hash, err = inplaceupdate.CalculateHash(nilSlice)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).ToNot(BeEmpty())
+		})
+
+		It("should handle primitive types", func() {
+			primitives := []interface{}{
+				"test-string",
+				42,
+				true,
+				3.14,
+			}
+
+			for _, data := range primitives {
+				hash, err := inplaceupdate.CalculateHash(data)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(hash).ToNot(BeEmpty())
+			}
+		})
+
+		It("should handle struct types", func() {
+			type testStruct struct {
+				Name  string            `json:"name"`
+				Tags  map[string]string `json:"tags,omitempty"`
+				Count int               `json:"count"`
+			}
+
+			data := testStruct{
+				Name: "test",
+				Tags: map[string]string{
+					"env": "test",
+				},
+				Count: 5,
+			}
+
+			hash, err := inplaceupdate.CalculateHash(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).ToNot(BeEmpty())
+
+			// Test that identical structs produce same hash
+			data2 := testStruct{
+				Name: "test",
+				Tags: map[string]string{
+					"env": "test",
+				},
+				Count: 5,
+			}
+
+			hash2, err := inplaceupdate.CalculateHash(data2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).To(Equal(hash2))
+		})
+
+		It("should handle map key ordering", func() {
+			// JSON marshaling is deterministic for maps in Go
+			data1 := map[string]string{
+				"b": "value2",
+				"a": "value1",
+				"c": "value3",
+			}
+
+			data2 := map[string]string{
+				"a": "value1",
+				"b": "value2",
+				"c": "value3",
+			}
+
+			hash1, err := inplaceupdate.CalculateHash(data1)
+			Expect(err).ToNot(HaveOccurred())
+
+			hash2, err := inplaceupdate.CalculateHash(data2)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(hash1).To(Equal(hash2))
+		})
+
+		It("should be sensitive to type differences", func() {
+			// String vs int with same value
+			hash1, err := inplaceupdate.CalculateHash("42")
+			Expect(err).ToNot(HaveOccurred())
+
+			hash2, err := inplaceupdate.CalculateHash(42)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(hash1).ToNot(Equal(hash2))
+		})
+
+		It("should return numeric string format", func() {
+			data := "test"
+			hash, err := inplaceupdate.CalculateHash(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).ToNot(BeEmpty())
+
+			// Verify it's a numeric string (can be parsed as uint64)
+			Expect(hash).To(MatchRegexp(`^\d+$`))
+		})
+
+		It("should handle unmarshalable types gracefully", func() {
+			// Create a type that cannot be marshaled to JSON
+			type unmarshalableStruct struct {
+				Func func() // functions cannot be marshaled to JSON
+			}
+
+			data := unmarshalableStruct{
+				Func: func() {},
+			}
+
+			hash, err := inplaceupdate.CalculateHash(data)
+			Expect(err).To(HaveOccurred())
+			Expect(hash).To(BeEmpty())
+			Expect(err.Error()).To(ContainSubstring("json: unsupported type"))
+		})
+	})
+
 	Context("calculateVMPatch", func() {
 		It("should add missing identities when there are no existing identities", func() {
 			options := test.Options()

--- a/pkg/controllers/nodeclaim/inplaceupdate/utils.go
+++ b/pkg/controllers/nodeclaim/inplaceupdate/utils.go
@@ -36,8 +36,9 @@ type vmInPlaceUpdateFields struct {
 	Tags       map[string]string `json:"tags,omitempty"`
 }
 
-func (i *vmInPlaceUpdateFields) CalculateHash() (string, error) {
-	encoded, err := json.Marshal(i)
+// CalculateHash computes a hash for any JSON-marshalable struct
+func CalculateHash(data interface{}) (string, error) {
+	encoded, err := json.Marshal(data)
 	if err != nil {
 		return "", err
 	}
@@ -51,7 +52,7 @@ func (i *vmInPlaceUpdateFields) CalculateHash() (string, error) {
 }
 
 // HashFromNodeClaim calculates an inplace update hash from the specified options, nodeClaim, and nodeClass
-func HashFromNodeClaim(options *options.Options, _ *karpv1.NodeClaim, nodeClass *v1beta1.AKSNodeClass) (string, error) {
+func HashFromNodeClaim(options *options.Options, nodeClaim *karpv1.NodeClaim, nodeClass *v1beta1.AKSNodeClass) (string, error) {
 	tags := options.AdditionalTags
 	if nodeClass != nil {
 		tags = lo.Assign(options.AdditionalTags, nodeClass.Spec.Tags)
@@ -62,5 +63,5 @@ func HashFromNodeClaim(options *options.Options, _ *karpv1.NodeClaim, nodeClass 
 		Tags:       tags,
 	}
 
-	return hashStruct.CalculateHash()
+	return CalculateHash(hashStruct)
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

`inplaceupdate` module will be used for the upcoming [Machine API integration](https://github.com/Azure/karpenter-provider-azure/pull/1102) as well. Although, the module's implementation currently does not expect to handle more than VM instances. This refactor will designate VM instance code path as a separate path from upcoming AKS machine instances due to different assumptions. See some relevant discussions in the PoC PR.

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
