### PR TITLE
DO-NOT-MERGE: Staging testing ground for E2E work, on top of Machine API POC branch

### DIFF
--- a/test/pkg/environment/azure/environment.go
+++ b/test/pkg/environment/azure/environment.go
@@ -18,19 +18,26 @@ package azure
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	containerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
 	"github.com/Azure/karpenter-provider-azure/pkg/test/azure"
 	"github.com/Azure/karpenter-provider-azure/test/pkg/environment/common"
@@ -55,7 +62,9 @@ type Environment struct {
 	VNETResourceGroup    string
 	ACRName              string
 	ClusterName          string
+	MachineAgentPoolName string
 	ClusterResourceGroup string
+	ProvisionMode        string
 
 	tracker *azure.Tracker
 
@@ -67,15 +76,30 @@ type Environment struct {
 	subnetClient         *armnetwork.SubnetsClient
 	interfacesClient     *armnetwork.InterfacesClient
 	managedClusterClient *containerservice.ManagedClustersClient
+	agentpoolsClient     *containerservice.AgentPoolsClient
+	machinesClient       *containerservice.MachinesClient
+
+	// Public Clients
+	KeyVaultClient          *armkeyvault.VaultsClient
+	DiskEncryptionSetClient *armcompute.DiskEncryptionSetsClient
+
+	defaultCredential azcore.TokenCredential
+
+	RBACManager *RBACManager
 }
 
-func readEnv(name string) string {
+func readEnv(name string, required bool) string {
 	value, exists := os.LookupEnv(name)
 	if !exists {
-		panic(fmt.Sprintf("Environment variable %s is not set", name))
+		if required {
+			panic(fmt.Sprintf("Environment variable %s is not set", name))
+		}
+		return ""
 	}
 	if value == "" {
-		panic(fmt.Sprintf("Environment variable %s is set to an empty string", name))
+		if required {
+			panic(fmt.Sprintf("Environment variable %s is set to an empty string", name))
+		}
 	}
 	return value
 }
@@ -83,10 +107,11 @@ func readEnv(name string) string {
 func NewEnvironment(t *testing.T) *Environment {
 	azureEnv := &Environment{
 		Environment:          common.NewEnvironment(t),
-		SubscriptionID:       readEnv("AZURE_SUBSCRIPTION_ID"),
-		ClusterName:          readEnv("AZURE_CLUSTER_NAME"),
-		ClusterResourceGroup: readEnv("AZURE_RESOURCE_GROUP"),
-		ACRName:              readEnv("AZURE_ACR_NAME"),
+		SubscriptionID:       readEnv("AZURE_SUBSCRIPTION_ID", true),
+		ClusterName:          readEnv("AZURE_CLUSTER_NAME", true),
+		ClusterResourceGroup: readEnv("AZURE_RESOURCE_GROUP", true),
+		ACRName:              readEnv("AZURE_ACR_NAME", true),
+		ProvisionMode:        readEnv("PROVISION_MODE", false),
 		Region:               lo.Ternary(os.Getenv("AZURE_LOCATION") == "", "westus2", os.Getenv("AZURE_LOCATION")),
 		tracker:              azure.NewTracker(),
 	}
@@ -96,12 +121,51 @@ func NewEnvironment(t *testing.T) *Environment {
 	azureEnv.NodeResourceGroup = defaultNodeRG
 
 	cred := lo.Must(azidentity.NewDefaultAzureCredential(nil))
+	azureEnv.defaultCredential = cred
+	byokRetryOptions := azureEnv.ClientOptionsForRBACPropagation()
 	azureEnv.vmClient = lo.Must(armcompute.NewVirtualMachinesClient(azureEnv.SubscriptionID, cred, nil))
 	azureEnv.vnetClient = lo.Must(armnetwork.NewVirtualNetworksClient(azureEnv.SubscriptionID, cred, nil))
 	azureEnv.subnetClient = lo.Must(armnetwork.NewSubnetsClient(azureEnv.SubscriptionID, cred, nil))
 	azureEnv.interfacesClient = lo.Must(armnetwork.NewInterfacesClient(azureEnv.SubscriptionID, cred, nil))
 	azureEnv.managedClusterClient = lo.Must(containerservice.NewManagedClustersClient(azureEnv.SubscriptionID, cred, nil))
+	azureEnv.agentpoolsClient = lo.Must(containerservice.NewAgentPoolsClient(azureEnv.SubscriptionID, cred, nil))
+	azureEnv.machinesClient = lo.Must(containerservice.NewMachinesClient(azureEnv.SubscriptionID, cred, nil))
+	azureEnv.KeyVaultClient = lo.Must(armkeyvault.NewVaultsClient(azureEnv.SubscriptionID, cred, byokRetryOptions))
+	azureEnv.DiskEncryptionSetClient = lo.Must(armcompute.NewDiskEncryptionSetsClient(azureEnv.SubscriptionID, cred, byokRetryOptions))
+	azureEnv.RBACManager = lo.Must(NewRBACManager(azureEnv.SubscriptionID, cred))
+	// Default to reserved managed machine agentpool name for NAP
+	azureEnv.MachineAgentPoolName = "aksmanagedap"
+	if !azureEnv.Environment.InClusterController {
+		azureEnv.MachineAgentPoolName = "karp-e2e-byo-machine-ap"
+	}
+	// Create our BYO testing Machine Pool, if running self-hosted, with machine mode specified
+	// > Note: this only has to occur once per test, since its just a container for the machines
+	// > meaning that there is no risk of the tests modifying the Machine Pool itself.
+	if azureEnv.InClusterController && azureEnv.ProvisionMode == consts.ProvisionModeAKSMachineAPI {
+		azureEnv.ExpectRunInClusterControllerWithMachineMode()
+	}
 	return azureEnv
+}
+
+func (env *Environment) GetDefaultCredential() azcore.TokenCredential {
+	return env.defaultCredential
+}
+
+// Retry options for BYOK-related clients that may encounter RBAC propagation delays
+// RBAC assignments can take time to propagate, resulting in 403 Forbidden errors
+// With 15 retries at 5 second intervals = 75 seconds total retry time
+func (env *Environment) ClientOptionsForRBACPropagation() *arm.ClientOptions {
+	return &arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Retry: policy.RetryOptions{
+				MaxRetries: 15,
+				RetryDelay: time.Second * 5,
+				StatusCodes: []int{
+					http.StatusForbidden, // RBAC assignments haven't propagated yet
+				},
+			},
+		},
+	}
 }
 
 func (env *Environment) DefaultAKSNodeClass() *v1beta1.AKSNodeClass {

--- a/test/pkg/environment/azure/expectations_agentpools.go
+++ b/test/pkg/environment/azure/expectations_agentpools.go
@@ -1,0 +1,39 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+
+	containerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
+)
+
+func (env *Environment) ExpectCreatedMachineAgentPool() containerservice.AgentPool {
+	GinkgoHelper()
+	byoTestMachineAP := containerservice.AgentPool{
+		Properties: &containerservice.ManagedClusterAgentPoolProfileProperties{
+			Mode: lo.ToPtr(containerservice.AgentPoolModeMachines),
+		},
+	}
+	poller, err := env.agentpoolsClient.BeginCreateOrUpdate(env.Context, env.ClusterResourceGroup, env.ClusterName, env.MachineAgentPoolName, byoTestMachineAP, nil)
+	Expect(err).ToNot(HaveOccurred())
+	res, err := poller.PollUntilDone(env.Context, nil)
+	Expect(err).ToNot(HaveOccurred())
+	return res.AgentPool
+}

--- a/test/pkg/environment/azure/expectations_machines.go
+++ b/test/pkg/environment/azure/expectations_machines.go
@@ -1,0 +1,59 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	containerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
+)
+
+// NOTE: Not under current usage, as scaledown should ensure the machines are deleted
+// func (env *Environment) ExpectMachinesEventuallyDeleted(machines []*containerservice.Machine) {
+// 	GinkgoHelper()
+// 	var machineNames []*string
+// 	for _, machine := range machines {
+// 		machineNames = append(machineNames, machine.Name)
+// 	}
+// 	aksMachines := containerservice.AgentPoolDeleteMachinesParameter{
+// 		MachineNames: machineNames,
+// 	}
+// 	poller, err := env.agentpoolsClient.BeginDeleteMachines(env.Context, env.ClusterResourceGroup, env.ClusterName, env.MachineAgentPoolName, aksMachines, nil)
+// 	Expect(err).ToNot(HaveOccurred())
+// 	_, err = poller.PollUntilDone(env.Context, nil)
+// 	Expect(err).ToNot(HaveOccurred())
+// }
+
+func (env *Environment) ExpectListMachines() []*containerservice.Machine {
+	GinkgoHelper()
+	var machines []*containerservice.Machine
+	pager := env.machinesClient.NewListPager(env.ClusterResourceGroup, env.ClusterName, env.MachineAgentPoolName, nil)
+	Expect(pager).ToNot(BeNil())
+	for pager.More() {
+		page, err := pager.NextPage(env.Context)
+		Expect(err).ToNot(HaveOccurred())
+		machines = append(machines, page.Value...)
+	}
+
+	return machines
+}
+
+func (env *Environment) ExpectNoMachines() {
+	GinkgoHelper()
+	Expect(len(env.ExpectListMachines())).To(Equal(0))
+}

--- a/test/pkg/environment/azure/identity.go
+++ b/test/pkg/environment/azure/identity.go
@@ -1,0 +1,67 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	containerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
+	"github.com/golang-jwt/jwt/v5"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+)
+
+func (env *Environment) GetClusterIdentity(ctx context.Context) *containerservice.ManagedClusterIdentity {
+	cluster, err := env.managedClusterClient.Get(ctx, env.ClusterResourceGroup, env.ClusterName, nil)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cluster.Identity).ToNot(BeNil())
+	return cluster.Identity
+}
+
+func (env *Environment) GetKarpenterWorkloadIdentity(ctx context.Context) string {
+	karpenterMSIName := "karpentermsi" // matches AZURE_KARPENTER_USER_ASSIGNED_IDENTITY_NAME
+	msiClient, err := armmsi.NewUserAssignedIdentitiesClient(env.SubscriptionID, env.GetDefaultCredential(), nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	identity, err := msiClient.Get(ctx, env.ClusterResourceGroup, karpenterMSIName, nil)
+	Expect(err).ToNot(HaveOccurred())
+	return lo.FromPtr(identity.Properties.PrincipalID)
+}
+
+// getCurrentUserPrincipalID gets the principal ID of the current authenticated identity
+func (env *Environment) GetCurrentUserPrincipalID(ctx context.Context, cred azcore.TokenCredential) string {
+	token, err := cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{"https://management.azure.com/.default"},
+	})
+	Expect(err).ToNot(HaveOccurred(), "failed to get token from Azure credential")
+
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	parsedToken, _, err := parser.ParseUnverified(token.Token, jwt.MapClaims{})
+	Expect(err).ToNot(HaveOccurred(), "failed to parse JWT token")
+
+	claims, ok := parsedToken.Claims.(jwt.MapClaims)
+	Expect(ok).To(BeTrue(), "failed to extract claims from JWT token")
+
+	oid, ok := claims["oid"].(string)
+	Expect(ok).To(BeTrue(), "oid claim not found or not a string in JWT token")
+	Expect(oid).ToNot(BeEmpty(), "oid claim is empty")
+
+	return oid
+}

--- a/test/pkg/environment/azure/rbac_manager.go
+++ b/test/pkg/environment/azure/rbac_manager.go
@@ -1,0 +1,87 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	"github.com/google/uuid"
+)
+
+type RBACManager struct {
+	subscriptionID string
+	client         *armauthorization.RoleAssignmentsClient
+}
+
+// NewRBACManager builds a client with the provided TokenCredential.
+func NewRBACManager(subscriptionID string, cred azcore.TokenCredential) (*RBACManager, error) {
+	c, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, cred, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &RBACManager{subscriptionID: subscriptionID, client: c}, nil
+}
+
+// EnsureRole assigns roleDefinitionID to principalID at scope if not already present.
+// It lists for the scope and returns nil if a matching assignment exists.
+func (r *RBACManager) EnsureRole(ctx context.Context, scope, roleDefinitionID, principalID string) error {
+	return r.EnsureRoleWithPrincipalType(ctx, scope, roleDefinitionID, principalID, "")
+}
+
+// EnsureRoleWithPrincipalType assigns roleDefinitionID to principalID at scope with optional principalType.
+// Setting principalType helps handle replication delays when creating principals and immediately assigning roles.
+// See https://aka.ms/docs-principaltype for more information.
+func (r *RBACManager) EnsureRoleWithPrincipalType(ctx context.Context, scope, roleDefinitionID, principalID, principalType string) error {
+	// Quick scan to avoid duplicates
+	pager := r.client.NewListForScopePager(scope, &armauthorization.RoleAssignmentsClientListForScopeOptions{
+		Filter: to.Ptr(fmt.Sprintf("assignedTo('%s')", principalID)),
+	})
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return err
+		}
+		for _, ra := range page.Value {
+			if ra.Properties != nil &&
+				ra.Properties.PrincipalID != nil &&
+				ra.Properties.RoleDefinitionID != nil &&
+				*ra.Properties.PrincipalID == principalID &&
+				*ra.Properties.RoleDefinitionID == roleDefinitionID {
+				// Already assigned
+				return nil
+			}
+		}
+	}
+	name := uuid.New().String()
+	properties := &armauthorization.RoleAssignmentProperties{
+		PrincipalID:      to.Ptr(principalID),
+		RoleDefinitionID: to.Ptr(roleDefinitionID),
+	}
+
+	if principalType != "" {
+		properties.PrincipalType = to.Ptr(armauthorization.PrincipalType(principalType))
+	}
+
+	_, err := r.client.Create(ctx, scope, name, armauthorization.RoleAssignmentCreateParameters{
+		Properties: properties,
+	}, nil)
+	return err
+}

--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -44,6 +44,7 @@ import (
 )
 
 var env *azure.Environment
+var nodeClass *v1beta1.AKSNodeClass
 
 func TestConsolidation(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -55,8 +56,6 @@ func TestConsolidation(t *testing.T) {
 	})
 	RunSpecs(t, "Consolidation")
 }
-
-var nodeClass *v1beta1.AKSNodeClass
 
 var _ = BeforeEach(func() {
 	nodeClass = env.DefaultAKSNodeClass()

--- a/test/suites/machines/suite_test.go
+++ b/test/suites/machines/suite_test.go
@@ -1,0 +1,60 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machines_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/test/pkg/environment/azure"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+)
+
+var env *azure.Environment
+var nodeClass *v1beta1.AKSNodeClass
+var nodePool *karpv1.NodePool
+
+func TestMachines(t *testing.T) {
+	RegisterFailHandler(Fail)
+	BeforeSuite(func() {
+		env = azure.NewEnvironment(t)
+		// > Note: we want to run this test case in Machine Mode regardless of what the config is,
+		// > so only check for the condition of InClusterController for machine pool creation, and usage
+		if env.InClusterController {
+			env.ExpectRunInClusterControllerWithMachineMode()
+		}
+	})
+	AfterSuite(func() {
+		env.Stop()
+	})
+	RunSpecs(t, "Machines")
+}
+
+var _ = BeforeSuite(func() {
+
+})
+
+var _ = BeforeEach(func() {
+	env.BeforeEach()
+	nodeClass = env.DefaultAKSNodeClass()
+	nodePool = env.DefaultNodePool(nodeClass)
+})
+var _ = AfterEach(func() { env.Cleanup() })
+var _ = AfterEach(func() { env.AfterEach() })


### PR DESCRIPTION
- Add base structure for BYO machine pool testing on E2E OSS
- Add machine test case and helpers for cleanup of machines
- Add expectations for agent pools and machines
- Add identity utilities and RBAC manager
- Update consolidation suite test
- Add new machine test suite

Cherry-picked changes from:
- charliedmcb/addBYOMachinePoolE2EBaseStructure
- charliedmcb/addMachineTestSuiteAndExpectedMachineCleanup

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
