### PR TITLE
fix: disable artifact streaming

### DIFF
--- a/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
@@ -107,8 +107,11 @@ func (p *ProvisionClientBootstrap) ConstructProvisionValues(ctx context.Context)
 	labels.AddAgentBakerGeneratedLabels(p.ResourceGroup, options.FromContext(ctx).KubeletIdentityClientID, nodeLabels)
 
 	// artifact streaming is not yet supported for Arm64, for Ubuntu 20.04, Ubuntu 24.04, and for Azure Linux v3
-	enableArtifactStreaming := p.Arch == karpv1.ArchitectureAmd64 &&
-		(p.OSSKU == ImageFamilyOSSKUUbuntu2204 || p.OSSKU == ImageFamilyOSSKUAzureLinux2)
+	// enableArtifactStreaming := p.Arch == karpv1.ArchitectureAmd64 &&
+	//		(p.OSSKU == ImageFamilyOSSKUUbuntu2204 || p.OSSKU == ImageFamilyOSSKUAzureLinux2)
+	// Temporarily disable artifact streaming altogether, until node provisioning performance is fixed
+	// (or until we make artifact streaming configurable)
+	enableArtifactStreaming := false
 
 	// unspecified FIPSMode is effectively no FIPS for now
 	enableFIPS := lo.FromPtr(p.FIPSMode) == v1beta1.FIPSModeFIPS

--- a/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap_test.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap_test.go
@@ -333,8 +333,8 @@ func TestConstructProvisionValues(t *testing.T) {
 				// Check system mode
 				assert.Equal(t, models.AgentPoolModeSystem, *profile.Mode)
 
-				// Check artifact streaming is enabled
-				assert.True(t, *profile.ArtifactStreamingProfile.Enabled)
+				// Check artifact streaming is disabled
+				assert.False(t, *profile.ArtifactStreamingProfile.Enabled)
 
 				// Check FIPS enablement (unset/nil FIPSMode is effectively false for now)
 				assert.False(t, *profile.EnableFIPS)
@@ -700,8 +700,8 @@ func TestArtifactStreamingEnablement(t *testing.T) {
 			ossku:                            customscriptsbootstrap.ImageFamilyOSSKUUbuntu2204,
 			kubernetesVersion:                "1.31.0",
 			imageDistro:                      "aks-ubuntu-containerd-22.04-gen2",
-			expectedArtifactStreamingEnabled: true,
-			description:                      "Artifact streaming should be enabled for AMD64 with Ubuntu2204",
+			expectedArtifactStreamingEnabled: false,
+			description:                      "Artifact streaming should be disabled for AMD64 with Ubuntu2204",
 		},
 		{
 			name:                             "AMD64 Ubuntu2404 - Artifact streaming disabled",
@@ -718,8 +718,8 @@ func TestArtifactStreamingEnablement(t *testing.T) {
 			ossku:                            customscriptsbootstrap.ImageFamilyOSSKUAzureLinux2,
 			kubernetesVersion:                "1.31.0",
 			imageDistro:                      "aks-azurelinux-v2-gen2",
-			expectedArtifactStreamingEnabled: true,
-			description:                      "Artifact streaming should be enabled for AMD64 with AzureLinux2",
+			expectedArtifactStreamingEnabled: false,
+			description:                      "Artifact streaming should be disabled for AMD64 with AzureLinux2",
 		},
 		{
 			name:                             "AMD64 AzureLinux3 - Artifact streaming disabled",


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Temporarily disable artifact streaming altogether, until node provisioning performance is fixed (or until we make artifact streaming configurable)

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
