### PR TITLE
test(e2e+machine): add in machine tests

### DIFF
--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -32,6 +32,10 @@ inputs:
   provisionmode:
     description: "The karpenter provisioning mode to run the e2e test in"
     default: "aksscriptless"
+  identity_type:
+    description: "The type of managed identity for the cluster (SystemAssigned or UserAssigned)"
+    required: false
+    default: "SystemAssigned"
 runs:
   using: "composite"
   steps:
@@ -60,7 +64,14 @@ runs:
         AZURE_RESOURCE_GROUP: ${{ inputs.resource_group }}
         AZURE_ACR_NAME: ${{ inputs.acr_name }}
         AZURE_LOCATION: ${{ inputs.location }}
-      run: make az-mkaks-cilium
+      run: |
+        if [ "${{ inputs.identity_type }}" = "UserAssigned" ]; then
+          echo "Creating cluster with user-assigned managed identity"
+          make az-mkaks-cilium-userassigned
+        else
+          echo "Creating cluster with system-assigned managed identity"
+          make az-mkaks-cilium
+        fi
     - name: az login 2
       uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
       with:

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [ACR, BYOK, Chaos, Consolidation, Drift, GPU, InPlaceUpdate, Integration, KubernetesUpgrade, NodeClaim, Scheduling, Spot, Subnet, Utilization]
+        suite: [ACR, BYOK, Chaos, Consolidation, Drift, GPU, InPlaceUpdate, Integration, KubernetesUpgrade, NodeClaim, Scheduling, Spot, Subnet, Utilization, Machines]
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -149,6 +149,7 @@ jobs:
           git_ref: ${{ inputs.git_ref }}
           location: ${{ inputs.location }}
           provisionmode: ${{ inputs.provisionmode }}
+          identity_type: ${{ inputs.suite == 'Machines' && 'UserAssigned' || 'SystemAssigned' }}
       - name: build and publish karpenter
         shell: bash
         run: AZURE_ACR_NAME=${{ env.ACR_NAME }} make az-build

--- a/test/pkg/environment/azure/identity.go
+++ b/test/pkg/environment/azure/identity.go
@@ -18,12 +18,16 @@ package azure
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	containerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/golang-jwt/jwt/v5"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 )
@@ -64,4 +68,107 @@ func (env *Environment) GetCurrentUserPrincipalID(ctx context.Context, cred azco
 	Expect(oid).ToNot(BeEmpty(), "oid claim is empty")
 
 	return oid
+}
+
+// ExpectCreatedManagedIdentity creates a new user-assigned managed identity
+func (env *Environment) ExpectCreatedManagedIdentity(ctx context.Context, identityName string) *armmsi.Identity {
+	GinkgoHelper()
+	msiClient, err := armmsi.NewUserAssignedIdentitiesClient(env.SubscriptionID, env.GetDefaultCredential(), nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	By(fmt.Sprintf("creating managed identity %s in node resource group %s", identityName, env.NodeResourceGroup))
+
+	identity := armmsi.Identity{
+		Location: to.Ptr(env.Region),
+		Tags: map[string]*string{
+			"test": to.Ptr("karpenter-e2e"),
+		},
+	}
+
+	resp, err := msiClient.CreateOrUpdate(ctx, env.NodeResourceGroup, identityName, identity, nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Note: we don't register for cleanup in the env.tracker, in case there are more tests to run. We don't want to break the cluster by deleting the kubelet identity
+	return &resp.Identity
+}
+
+// ExpectUpdatedManagedClusterKubeletIdentityAsync updates the kubelet identity of a managed cluster asynchronously
+// Returns the poller so the caller can control when to wait for completion
+func (env *Environment) ExpectUpdatedManagedClusterKubeletIdentityAsync(ctx context.Context, newIdentity *armmsi.Identity) *runtime.Poller[containerservice.ManagedClustersClientCreateOrUpdateResponse] {
+	GinkgoHelper()
+
+	By("getting current managed cluster configuration")
+	mc := env.ExpectGetManagedCluster()
+
+	By("updating kubelet identity")
+
+	// Update the kubelet identity in the identity profile
+	if mc.Properties.IdentityProfile == nil {
+		mc.Properties.IdentityProfile = make(map[string]*containerservice.UserAssignedIdentity)
+	}
+
+	mc.Properties.IdentityProfile["kubeletidentity"] = &containerservice.UserAssignedIdentity{
+		ClientID:   newIdentity.Properties.ClientID,
+		ObjectID:   newIdentity.Properties.PrincipalID,
+		ResourceID: newIdentity.ID,
+	}
+
+	// Update the cluster and return the poller
+	poller, err := env.managedClusterClient.BeginCreateOrUpdate(ctx, env.ClusterResourceGroup, env.ClusterName, mc, nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	return poller
+}
+
+// ExpectGrantedACRAccess grants the specified identity access to pull from the ACR
+func (env *Environment) ExpectGrantedACRAccess(ctx context.Context, identity *armmsi.Identity) {
+	GinkgoHelper()
+
+	By("granting ACR pull access to identity")
+
+	// Get the ACR resource ID
+	acrResourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerRegistry/registries/%s",
+		env.SubscriptionID, env.ClusterResourceGroup, env.ACRName)
+
+	// AcrPull role definition ID: 7f951dda-4ed3-4680-a7ca-43fe172d538d
+	acrPullRoleID := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/7f951dda-4ed3-4680-a7ca-43fe172d538d", env.SubscriptionID)
+
+	identityPrincipalID := lo.FromPtr(identity.Properties.PrincipalID)
+
+	err := env.RBACManager.EnsureRoleWithPrincipalType(ctx, acrResourceID, acrPullRoleID, identityPrincipalID, "ServicePrincipal")
+	Expect(err).ToNot(HaveOccurred())
+}
+
+// CheckClusterIdentityType returns the type of managed identity used by the cluster
+func (env *Environment) CheckClusterIdentityType(ctx context.Context) string {
+	mc := env.ExpectGetManagedCluster()
+	if mc.Identity == nil {
+		return "none"
+	}
+	if mc.Identity.Type == nil {
+		return "unknown"
+	}
+	return string(*mc.Identity.Type)
+}
+
+// IsClusterUserAssignedIdentity checks if the cluster uses user-assigned managed identity
+func (env *Environment) IsClusterUserAssignedIdentity(ctx context.Context) bool {
+	identityType := env.CheckClusterIdentityType(ctx)
+	return identityType == "UserAssigned"
+}
+
+// GetKubeletIdentityResourceID returns the current kubelet identity resource ID
+func (env *Environment) GetKubeletIdentityResourceID(ctx context.Context) string {
+	mc := env.ExpectGetManagedCluster()
+	Expect(mc.Properties.IdentityProfile).ToNot(BeNil())
+	Expect(mc.Properties.IdentityProfile["kubeletidentity"]).ToNot(BeNil())
+	return lo.FromPtr(mc.Properties.IdentityProfile["kubeletidentity"].ResourceID)
+}
+
+// GetKubeletIdentityClientID returns the current kubelet identity client ID
+func (env *Environment) GetKubeletIdentityClientID(ctx context.Context) string {
+	mc := env.ExpectGetManagedCluster()
+	Expect(mc.Properties.IdentityProfile).ToNot(BeNil())
+	Expect(mc.Properties.IdentityProfile["kubeletidentity"]).ToNot(BeNil())
+	return lo.FromPtr(mc.Properties.IdentityProfile["kubeletidentity"].ClientID)
 }

--- a/test/suites/machines/machines_test.go
+++ b/test/suites/machines/machines_test.go
@@ -1,0 +1,251 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machines_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	coretest "sigs.k8s.io/karpenter/pkg/test"
+
+	containerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v7"
+	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
+	"github.com/Azure/karpenter-provider-azure/pkg/test"
+	"github.com/blang/semver/v4"
+	"github.com/samber/lo"
+)
+
+var _ = Describe("Machine Tests", func() {
+	var dep *appsv1.Deployment
+	var selector labels.Selector
+	var numPods int32
+	BeforeEach(func() {
+		numPods = 1
+		// Add pods with a do-not-disrupt annotation so that we can check node metadata before we disrupt
+		dep = coretest.Deployment(coretest.DeploymentOptions{
+			Replicas: numPods,
+			PodOptions: coretest.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "my-app",
+					},
+					Annotations: map[string]string{
+						karpv1.DoNotDisruptAnnotationKey: "true",
+					},
+				},
+				// Each node has 8 cpus, so should fit 2 pods.
+				ResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("3"),
+					},
+				},
+				TerminationGracePeriodSeconds: lo.ToPtr[int64](0),
+			},
+		})
+		selector = labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
+	})
+
+	It("should have networking labels applied by machine api", func() {
+		// Check if networking settings are compatible with this test
+		// NETWORK_PLUGIN_MODE must be overlay, but NETWORK_PLUGIN and NETWORK_DATAPLANE
+		// can be unset (using defaults) or set to expected values (but not set to different values)
+		settings := env.ExpectSettings()
+
+		// Helper function to check if env var is unset or set to expected value
+		checkEnvVar := func(envName, expectedValue string) bool {
+			for _, env := range settings {
+				if env.Name == envName {
+					return env.Value == expectedValue
+				}
+			}
+			return true // Not set is acceptable
+		}
+
+		usingCompatiblePlugin := checkEnvVar("NETWORK_PLUGIN", consts.NetworkPluginAzure)
+		usingExpectedPluginMode := lo.Contains(settings, corev1.EnvVar{Name: "NETWORK_PLUGIN_MODE", Value: consts.NetworkPluginModeOverlay})
+		usingCompatibleDataplane := checkEnvVar("NETWORK_DATAPLANE", consts.NetworkDataplaneCilium)
+
+		if !(usingCompatiblePlugin && usingExpectedPluginMode && usingCompatibleDataplane) {
+			Skip("TODO: generalize test for any networking configuration. Skipping as not in expected config for the test")
+		}
+
+		env.ExpectCreated(nodeClass, nodePool, dep)
+
+		node := env.EventuallyExpectCreatedNodeCount("==", 1)[0]
+		env.EventuallyExpectRegisteredNodeClaimCount("==", 1)
+		env.EventuallyExpectCreatedMachineCount("==", 1)
+		env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+
+		// Check that the node has the expected networking labels
+		Expect(node.Labels).To(HaveKeyWithValue("kubernetes.azure.com/ebpf-dataplane", consts.NetworkDataplaneCilium))
+		Expect(node.Labels).To(HaveKeyWithValue("kubernetes.azure.com/azure-cni-overlay", "true"))
+		Expect(node.Labels).To(HaveKeyWithValue("kubernetes.azure.com/podnetwork-type", consts.NetworkPluginModeOverlay))
+
+		// Note: these labels we only check their keys since, the values are dynamic
+		// TODO: improve E2E test to be dynamic, reusing the same provisioning logic we have for labels creation.
+		Expect(lo.Keys(node.Labels)).To(ContainElements([]string{
+			"kubernetes.azure.com/network-subnet",
+			"kubernetes.azure.com/nodenetwork-vnetguid",
+			"kubernetes.azure.com/network-stateless-cni",
+		}))
+	})
+
+	// NOTE: ClusterTests modify the actual cluster itself, which means that preforming tests after a cluster test
+	// might not have a clean environment, and might produce unexpected results. Ordering of cluster tests is important
+	Context("ClusterTests", func() {
+		BeforeEach(func() {
+			// Add labels to nodepool to ensure pods land on Karpenter nodes
+			nodePool.Spec.Template.Labels = map[string]string{
+				"test-name": "karpenter-machine-test",
+			}
+			// Add nodeSelector to deployment to target Karpenter nodes
+			dep.Spec.Template.Spec.NodeSelector = map[string]string{
+				"test-name": "karpenter-machine-test",
+			}
+		})
+
+		It("use the DriftAction to drift nodes that have had their kubeletidentity updated", func() {
+			// Check if cluster supports custom kubelet identity (requires user-assigned managed identity)
+			if !env.IsClusterUserAssignedIdentity(env.Context) {
+				Skip(fmt.Sprintf("Cluster uses %s identity type, but custom kubelet identity requires UserAssigned identity type",
+					env.CheckClusterIdentityType(env.Context)))
+			}
+
+			numPods = 6
+			dep.Spec.Replicas = &numPods
+			nodePool = coretest.ReplaceRequirements(nodePool,
+				karpv1.NodeSelectorRequirementWithMinValues{
+					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+						Key:      v1beta1.LabelSKUCPU,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"8"},
+					},
+				},
+			)
+			env.ExpectCreated(nodeClass, nodePool, dep)
+
+			nodes := env.EventuallyExpectCreatedNodeCount("==", 3)
+			nodeClaims := env.EventuallyExpectRegisteredNodeClaimCount("==", 3)
+			machines := env.EventuallyExpectCreatedMachineCount("==", 3)
+			pods := env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+
+			for _, machine := range machines {
+				if machine.Properties.Status.DriftAction != nil {
+					Expect(*machine.Properties.Status.DriftAction).ToNot(Equal(containerservice.DriftActionRecreate))
+				}
+			}
+
+			By("getting the original kubelet identity")
+			// originalKubeletIdentityResourceID := env.GetKubeletIdentityResourceID(env.Context)
+
+			By("creating a new managed identity for testing")
+			newIdentityName := test.RandomName("karpenter-test-identity")
+			newIdentity := env.ExpectCreatedManagedIdentity(env.Context, newIdentityName)
+
+			By("updating the kubelet identity on the managed cluster")
+			env.ExpectUpdatedManagedClusterKubeletIdentityAsync(env.Context, newIdentity)
+
+			By("granting ACR access to the new kubelet identity")
+			env.ExpectGrantedACRAccess(env.Context, newIdentity)
+
+			By("verifying the kubelet identity was updated")
+			// updatedKubeletIdentityResourceID := env.GetKubeletIdentityResourceID(env.Context)
+
+			// TODO: check if we want to have this possibly logged
+			// Expect(updatedKubeletIdentityResourceID).To(Equal(lo.FromPtr(newIdentity.ID)), "Expected updatedKubeletIdentityResourceID to match new kubelet resource id")
+			// Expect(updatedKubeletIdentityResourceID).ToNot(Equal(originalKubeletIdentityResourceID), "Expected updatedKubeletIdentityResourceID to not match old kubelet resource id")
+
+			By("expect machines to have a DriftAction")
+			Eventually(func(g Gomega) {
+				machines := env.EventuallyExpectCreatedMachineCount("==", 3)
+				for _, machine := range machines {
+					g.Expect(machine.Properties.Status.DriftAction).ToNot(BeNil())
+					g.Expect(*machine.Properties.Status.DriftAction).To(Equal(containerservice.DriftActionRecreate))
+				}
+			}).WithTimeout(3 * time.Minute).Should(Succeed())
+
+			By("expecting nodes to drift")
+			env.EventuallyExpectDriftedWithTimeout(15*time.Minute, nodeClaims...)
+
+			for _, pod := range pods {
+				delete(pod.Annotations, karpv1.DoNotDisruptAnnotationKey)
+				env.ExpectUpdated(pod)
+			}
+
+			env.EventuallyExpectNotFound(lo.Map(pods, func(p *corev1.Pod, _ int) client.Object { return p })...)
+			env.EventuallyExpectNotFound(lo.Map(nodes, func(n *corev1.Node, _ int) client.Object { return n })...)
+			env.EventuallyExpectNotFound(lo.Map(nodeClaims, func(n *karpv1.NodeClaim, _ int) client.Object { return n })...)
+			env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+			env.EventuallyExpectCreatedNodeCount("==", 3)
+			env.EventuallyExpectRegisteredNodeClaimCount("==", 3)
+			env.EventuallyExpectCreatedMachineCount("==", 3)
+		})
+
+		It("should be able to provision machines during an ongoing managed cluster operation", func() {
+			numPods = 2
+			dep.Spec.Replicas = &numPods
+			nodePool = coretest.ReplaceRequirements(nodePool,
+				karpv1.NodeSelectorRequirementWithMinValues{
+					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+						Key:      v1beta1.LabelSKUCPU,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"8"},
+					},
+				},
+			)
+			env.ExpectCreated(nodeClass, nodePool, dep)
+
+			env.EventuallyExpectCreatedNodeCount("==", 1)
+			env.EventuallyExpectRegisteredNodeClaimCount("==", 1)
+			env.EventuallyExpectCreatedMachineCount("==", 1)
+			env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+
+			By("Preforming a K8s upgrade")
+			availableKubernetesUpgrades := env.ExpectSuccessfulGetOfAvailableKubernetesVersionUpgradesForManagedCluster()
+			kubernetesUpgradeVersion := *lo.MaxBy(availableKubernetesUpgrades, func(a, b *containerservice.ManagedClusterPoolUpgradeProfileUpgradesItem) bool {
+				aK8sVersion := lo.Must(semver.Parse(*a.KubernetesVersion))
+				bK8sVersion := lo.Must(semver.Parse(*b.KubernetesVersion))
+				return aK8sVersion.GT(bK8sVersion)
+			}).KubernetesVersion
+			upgradedMC := env.ExpectSuccessfulUpgradeOfManagedCluster(kubernetesUpgradeVersion)
+			Expect(*upgradedMC.Properties.CurrentKubernetesVersion).To(Equal(kubernetesUpgradeVersion))
+
+			By("Scaling the deployment to create new nodes")
+			numPods = 4
+			dep.Spec.Replicas = &numPods
+			env.ExpectCreated(dep)
+
+			env.EventuallyExpectCreatedNodeCount("==", 2)
+			env.EventuallyExpectRegisteredNodeClaimCount("==", 2)
+			env.EventuallyExpectCreatedMachineCount("==", 2)
+			env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+
+			env.WarnIfClusterNotInExpectedProvisioningState("upgrading")
+		})
+	})
+})

--- a/test/suites/machines/suite_test.go
+++ b/test/suites/machines/suite_test.go
@@ -1,0 +1,56 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machines_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/test/pkg/environment/azure"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+)
+
+var env *azure.Environment
+var nodeClass *v1beta1.AKSNodeClass
+var nodePool *karpv1.NodePool
+
+func TestMachines(t *testing.T) {
+	RegisterFailHandler(Fail)
+	BeforeSuite(func() {
+		env = azure.NewEnvironment(t)
+		// > Note: we want to run this test case in Machine Mode regardless of what the config is,
+		// > so only check for the condition of InClusterController for machine pool creation, and usage
+		if env.InClusterController {
+			env.ExpectRunInClusterControllerWithMachineMode()
+		}
+	})
+	AfterSuite(func() {
+		env.Stop()
+	})
+	RunSpecs(t, "Machines")
+}
+
+var _ = BeforeEach(func() {
+	env.BeforeEach()
+	nodeClass = env.DefaultAKSNodeClass()
+	nodePool = env.DefaultNodePool(nodeClass)
+})
+var _ = AfterEach(func() { env.Cleanup() })
+var _ = AfterEach(func() { env.AfterEach() })


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Built off this underlaying framework:
https://github.com/Azure/karpenter-provider-azure/pull/1200

These tests cover:
- Assignment of post-provisioning networking labels that were previously handled by Karpenter
- Karpenter handling of DriftAction + kubelet causing DriftAction
- PUT machine during PUT MC

**How was this change tested?**

Tested with this PR:
- https://github.com/Azure/karpenter-provider-azure/pull/1204
NOTE: didn't get fully successful runs, and do expect the kubelet test to fail

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
