### PR TITLE
fix: pin `setup-envtest` version

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -16,7 +16,6 @@ tools() {
     go install github.com/google/ko@v0.17.1
     go install github.com/mikefarah/yq/v4@v4.45.1
     go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
-    go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
     go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
     go install github.com/sigstore/cosign/v2/cmd/cosign@v2.4.1
 #   go install -tags extended github.com/gohugoio/hugo@v0.110.0
@@ -38,6 +37,10 @@ kubebuilder() {
     sudo mkdir -p "${KUBEBUILDER_ASSETS}"
     sudo chown "${USER}" "${KUBEBUILDER_ASSETS}"
     arch=$(go env GOARCH)
+    os=$(go env GOOS)
+    sudo curl -sL "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.22.3/setup-envtest-${os}-${arch}" --output /usr/local/bin/setup-envtest
+    sudo chmod +x /usr/local/bin/setup-envtest
+
     ln -sf "$(setup-envtest use -p path "${K8S_VERSION}" --arch="${arch}" --bin-dir="${KUBEBUILDER_ASSETS}")"/* "${KUBEBUILDER_ASSETS}"
     find "$KUBEBUILDER_ASSETS"
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Pin `setup-envtest` version since `@latest` requires Go 1.25

**How was this change tested?**

* `make toolchain`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
