### PR TITLE
fix: using polling options for extensions to change delay from 30s to 3s 

### DIFF
--- a/pkg/providers/instance/azureresourcemanagerutils.go
+++ b/pkg/providers/instance/azureresourcemanagerutils.go
@@ -18,8 +18,10 @@ package instance
 
 import (
 	"context"
+	"time"
 
 	sdkerrors "github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/samber/lo"
@@ -69,7 +71,9 @@ func createVirtualMachineExtension(ctx context.Context, client VirtualMachineExt
 	if err != nil {
 		return nil, err
 	}
-	res, err := poller.PollUntilDone(ctx, nil)
+	res, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
+		Frequency: 3 * time.Second,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/instance/vminstance.go
+++ b/pkg/providers/instance/vminstance.go
@@ -279,7 +279,9 @@ func (p *DefaultVMProvider) Update(ctx context.Context, vmName string, update ar
 		}
 
 		for extName, poller := range pollers {
-			_, err := poller.PollUntilDone(ctx, nil)
+			_, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
+				Frequency: 3 * time.Second,
+			})
 			if err != nil {
 				return fmt.Errorf("polling VM extension %q for VM %q: %w", extName, vmName, err)
 			}


### PR DESCRIPTION
… 3s note vm + nic honor retry-after headers set by crp so modifying their polling wont do anything

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
<TODO>
**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
