### PR TITLE
chore: pin E2E to specific VM size that we have most quota for

### DIFF
--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -6,13 +6,13 @@ inputs:
   #   required: false
   #   default: "1.27"
   client-id:
-    description: 
+    description:
     required: true
   tenant-id:
-    description: 
+    description:
     required: true
   subscription-id:
-    description: 
+    description:
     required: true
   resource_group:
     description: "Name of the resource group to create the cluster within"
@@ -55,8 +55,9 @@ runs:
       env:
         AZURE_CLUSTER_NAME: ${{ inputs.cluster_name }}
         AZURE_RESOURCE_GROUP: ${{ inputs.resource_group }}
-        AZURE_ACR_NAME: ${{ inputs.acr_name }} 
+        AZURE_ACR_NAME: ${{ inputs.acr_name }}
         AZURE_LOCATION: ${{ inputs.location }}
+        AZURE_VM_SIZE: Standard_D4ds_v5 # We have more quota for this VM size so force it to avoid quota errors
       run: make az-mkaks-cilium
     - name: az login 2
       uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,7 @@ on:
       location:
         type: string
         description: "the azure location to run the e2e test in"
-        default: "southcentralus"
+        default: "westus3"
       provisionmode:
         type: string
         description: "the karpenter provisioning mode to run the e2e test in"

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -1,5 +1,5 @@
 AZURE_LOCATION ?= westus2
-AZURE_VM_SIZE ?= ""
+AZURE_VM_SIZE ?=
 COMMON_NAME ?= karpenter
 ENABLE_AZURE_SDK_LOGGING ?= true
 ifeq ($(CODESPACES),true)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**How was this change tested?**

* E2E test: https://github.com/Azure/karpenter-provider-azure/actions/runs/18668452187

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
