### PR TITLE
Support for OS Disk Type in AKSNodeClass

### DIFF
--- a/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
@@ -539,6 +539,17 @@ spec:
                 maximum: 2048
                 minimum: 30
                 type: integer
+              osDiskType:
+                default: Premium_LRS
+                description: osDiskType is the type of the OS disk. If not specified,
+                  defaulted to Premium_LRS.
+                enum:
+                - Premium_LRS
+                - Premium_ZRS
+                - Standard_LRS
+                - StandardSSD_LRS
+                - StandardSSD_ZRS
+                type: string
               security:
                 description: Collection of security related karpenter fields
                 properties:

--- a/pkg/apis/v1beta1/aksnodeclass.go
+++ b/pkg/apis/v1beta1/aksnodeclass.go
@@ -45,6 +45,10 @@ type AKSNodeClassSpec struct {
 	// +kubebuilder:validation:Maximum=2048
 	// osDiskSizeGB is the size of the OS disk in GB.
 	OSDiskSizeGB *int32 `json:"osDiskSizeGB,omitempty"`
+	// osDiskType is the type of the OS disk. If not specified, defaulted to Premium_LRS.
+	// +kubebuilder:default=Premium_LRS
+	// +kubebuilder:validation:Enum:={Premium_LRS,Premium_ZRS,Standard_LRS,StandardSSD_LRS,StandardSSD_ZRS}
+	OSDiskType *string `json:"osDiskType,omitempty"`
 	// ImageID is the ID of the image that instances use.
 	// Not exposed in the API yet
 	ImageID *string `json:"-"`

--- a/pkg/apis/v1beta1/crd_validation_cel_test.go
+++ b/pkg/apis/v1beta1/crd_validation_cel_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1beta1_test
 
 import (
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+	"k8s.io/utils/ptr"
+	"slices"
 	"strings"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
@@ -94,6 +97,30 @@ var _ = Describe("CEL/Validation", func() {
 			Entry("invalid resource group name with invalid character 'invalid#character'", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/invalid#character/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", false),
 			Entry("invalid resource group name with unsupported chars 'name@with*unsupported&chars'", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/name@with*unsupported&chars/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", false),
 		)
+	})
+
+	Context("OSDiskType", func() {
+		It("should reject invalid OSDiskType", func() {
+			allowedOSDiskTypes := []armcompute.StorageAccountTypes{armcompute.StorageAccountTypesPremiumLRS,
+				armcompute.StorageAccountTypesPremiumZRS,
+				armcompute.StorageAccountTypesStandardLRS,
+				armcompute.StorageAccountTypesStandardSSDLRS,
+				armcompute.StorageAccountTypesStandardSSDZRS}
+
+			for _, diskType := range armcompute.PossibleStorageAccountTypesValues() {
+				nodeClass := &v1beta1.AKSNodeClass{
+					ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+					Spec: v1beta1.AKSNodeClassSpec{
+						OSDiskType: ptr.To(string(diskType)),
+					},
+				}
+				if slices.Contains(allowedOSDiskTypes, diskType) {
+					Expect(env.Client.Create(ctx, nodeClass)).To(Succeed())
+				} else {
+					Expect(env.Client.Create(ctx, nodeClass)).ToNot(Succeed())
+				}
+			}
+		})
 	})
 
 	Context("ImageFamily", func() {

--- a/pkg/apis/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1beta1/zz_generated.deepcopy.go
@@ -98,6 +98,11 @@ func (in *AKSNodeClassSpec) DeepCopyInto(out *AKSNodeClassSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.OSDiskType != nil {
+		in, out := &in.OSDiskType, &out.OSDiskType
+		*out = new(string)
+		**out = **in
+	}
 	if in.ImageID != nil {
 		in, out := &in.ImageID, &out.ImageID
 		*out = new(string)

--- a/pkg/providers/instance/vminstance.go
+++ b/pkg/providers/instance/vminstance.go
@@ -509,6 +509,8 @@ func newVMObject(opts *createVMOptions) *armcompute.VirtualMachine {
 		return &armcompute.VirtualMachine{} // TODO(Windows)
 	}
 
+	diskType := lo.FromPtrOr(opts.NodeClass.Spec.OSDiskType, "Premium_LRS")
+
 	vm := &armcompute.VirtualMachine{
 		Name:     lo.ToPtr(opts.VMName), // TODO: I think it's safe to set this, even though it's read only
 		Location: lo.ToPtr(opts.Location),
@@ -520,8 +522,11 @@ func newVMObject(opts *createVMOptions) *armcompute.VirtualMachine {
 
 			StorageProfile: &armcompute.StorageProfile{
 				OSDisk: &armcompute.OSDisk{
-					Name:         lo.ToPtr(opts.VMName),
-					DiskSizeGB:   opts.NodeClass.Spec.OSDiskSizeGB,
+					Name:       lo.ToPtr(opts.VMName),
+					DiskSizeGB: opts.NodeClass.Spec.OSDiskSizeGB,
+					ManagedDisk: &armcompute.ManagedDiskParameters{
+						StorageAccountType: lo.ToPtr(armcompute.StorageAccountTypes(diskType)),
+					},
 					CreateOption: lo.ToPtr(armcompute.DiskCreateOptionTypesFromImage),
 					DeleteOption: lo.ToPtr(armcompute.DiskDeleteOptionTypesDelete),
 				},


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #801

**Description**

This change adds a new option to AKSNodeClass to specify the required OS disk type.

**How was this change tested?**
- Ran `make az-all`, created an AKS with non-default OS disk type, which worked fine.
- Added new unit test to verify both validation of this new option as well as verify that the value is properly used when provisioning a VM.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
New feature: support for OS Disk Type in AKSNodeClass
```
