### PR TITLE
test: use --overwrite-existing for az aks get-credentials

### DIFF
--- a/.github/actions/e2e/dump-logs/action.yaml
+++ b/.github/actions/e2e/dump-logs/action.yaml
@@ -37,7 +37,7 @@ runs:
       RESOURCE_GROUP: ${{ inputs.resource_group }}
       CLUSTER_NAME: ${{ inputs.cluster_name }}
     run: |
-      az aks get-credentials --name "$CLUSTER_NAME" --resource-group "$RESOURCE_GROUP"
+      az aks get-credentials --name "$CLUSTER_NAME" --resource-group "$RESOURCE_GROUP" --overwrite-existing
   - name: controller-logs
     shell: bash
     run: |

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -231,7 +231,7 @@ az-build: ## Build the Karpenter controller and webhook images using skaffold bu
 	skaffold build
 
 az-creds: ## Get cluster credentials
-	az aks get-credentials --name $(AZURE_CLUSTER_NAME) --resource-group $(AZURE_RESOURCE_GROUP)
+	az aks get-credentials --name $(AZURE_CLUSTER_NAME) --resource-group $(AZURE_RESOURCE_GROUP) --overwrite-existing
 
 az-run: ## Deploy the controller from the current state of your git repository into your ~/.kube/config cluster using skaffold run
 	az acr login -n $(AZURE_ACR_NAME)


### PR DESCRIPTION
This avoids
Run az aks get-credentials --name "$CLUSTER_NAME" --resource-group "$RESOURCE_GROUP" ERROR: A different object named clusterUser_karpenter-e2e-kubernetesupgrade-2650922641_mc already exists in users in your kubeconfig file.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
