### PR TITLE
chore: switch to dario.cat/mergo (fixes dependabot)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Azure/karpenter-provider-azure
 go 1.24.11
 
 require (
+	dario.cat/mergo v1.0.2
 	github.com/Azure/aks-middleware v0.0.41
 	github.com/Azure/azure-kusto-go v0.16.1
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
@@ -35,7 +36,6 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/imdario/mergo v0.3.16
 	github.com/jongio/azidext/go/azidext v0.5.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo/v2 v2.27.2
@@ -118,6 +118,7 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6 // indirect
+	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
+dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 github.com/Azure/aks-middleware v0.0.41 h1:knynFiyQd5P0Dqdy6/9NPLbGjPj0VesykA2bWFXok8o=
 github.com/Azure/aks-middleware v0.0.41/go.mod h1:7Y+wxZmS7p1K0FPreiO3+6Wr8YhYjWz9c50YohDQIQ4=
 github.com/Azure/azure-kusto-go v0.16.1 h1:vCBWcQghmC1qIErUUgVNWHxGhZVStu1U/hki6iBA14k=

--- a/pkg/apis/v1alpha2/aksnodeclass_hash_test.go
+++ b/pkg/apis/v1alpha2/aksnodeclass_hash_test.go
@@ -19,8 +19,8 @@ package v1alpha2_test
 import (
 	"time"
 
+	"dario.cat/mergo"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
-	"github.com/imdario/mergo"
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/karpenter/pkg/test"

--- a/pkg/apis/v1beta1/aksnodeclass_hash_test.go
+++ b/pkg/apis/v1beta1/aksnodeclass_hash_test.go
@@ -19,8 +19,8 @@ package v1beta1_test
 import (
 	"time"
 
+	"dario.cat/mergo"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
-	"github.com/imdario/mergo"
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/karpenter/pkg/test"

--- a/pkg/controllers/nodeclass/hash/suite_test.go
+++ b/pkg/controllers/nodeclass/hash/suite_test.go
@@ -22,8 +22,8 @@ import (
 
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
 
+	"dario.cat/mergo"
 	"github.com/awslabs/operatorpkg/object"
-	"github.com/imdario/mergo"
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"

--- a/pkg/test/networkinterfaces.go
+++ b/pkg/test/networkinterfaces.go
@@ -19,9 +19,9 @@ package test
 import (
 	"fmt"
 
+	"dario.cat/mergo"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/karpenter-provider-azure/pkg/fake"
-	"github.com/imdario/mergo"
 	"github.com/samber/lo"
 )
 

--- a/pkg/test/nodeclass.go
+++ b/pkg/test/nodeclass.go
@@ -21,12 +21,12 @@ import (
 	"fmt"
 	"sort"
 
+	"dario.cat/mergo"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
 	imagefamilytypes "github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/types"
 	opstatus "github.com/awslabs/operatorpkg/status"
 	"github.com/blang/semver/v4"
-	"github.com/imdario/mergo"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -19,7 +19,7 @@ package test
 import (
 	"fmt"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"github.com/samber/lo"
 
 	azoptions "github.com/Azure/karpenter-provider-azure/pkg/operator/options"

--- a/pkg/test/virtualmachines.go
+++ b/pkg/test/virtualmachines.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"time"
 
+	"dario.cat/mergo"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/Azure/karpenter-provider-azure/pkg/fake"
-	"github.com/imdario/mergo"
 	"github.com/samber/lo"
 )
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

`github.com/imdario/mergo` [moved](https://github.com/darccio/mergo?tab=readme-ov-file#100) to `dario.cat/mergo` a while ago; now this started to break dependabot (example failing [run](https://github.com/Azure/karpenter-provider-azure/actions/runs/20018361118/job/57400236178)). Update to use the new URL.

Edit: successful run post-merge: https://github.com/Azure/karpenter-provider-azure/actions/runs/20041055953/job/57474952506

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
