### PR TITLE
fix: environment not passed to credential details

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -114,11 +114,11 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 
 	log.FromContext(ctx).V(0).Info("Initial AZConfig", "azConfig", azConfig.String())
 
-	cred, err := getCredential()
-	lo.Must0(err, "getting Azure credential")
-
 	env, err := auth.ResolveCloudEnvironment(azConfig)
 	lo.Must0(err, "resolving cloud environment")
+
+	cred, err := getCredential(env)
+	lo.Must0(err, "getting Azure credential")
 
 	// Get a token to ensure we can
 	lo.Must0(ensureToken(cred, env), "ensuring Azure token can be retrieved")
@@ -357,9 +357,13 @@ func ensureToken(cred azcore.TokenCredential, env *auth.Environment) error {
 	return nil
 }
 
-func getCredential() (azcore.TokenCredential, error) {
+func getCredential(env *auth.Environment) (azcore.TokenCredential, error) {
 	// TODO: Don't use NewDefaultAzureCredential
-	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
+		ClientOptions: policy.ClientOptions{
+			Cloud: env.Cloud,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How was this change tested?**

* Unit tests (just regression).
* Manual tests (which I swear passed before?) - possibly I was thrown by the fact that things aren't supposed to work (no image galleries).

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
