### PR TITLE
chore: remove testify in favor of gomega everywhere

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/samber/lo v1.52.0
-	github.com/stretchr/testify v1.11.1
 	go.uber.org/multierr v1.11.0
 	golang.org/x/sync v0.19.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/pkg/fake/auxiliarytokenserver_test.go
+++ b/pkg/fake/auxiliarytokenserver_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/karpenter-provider-azure/pkg/auth"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/gomega"
 )
 
 func Test_AddAuxiliaryTokenPolicyClientOptions(t *testing.T) {
@@ -52,6 +52,7 @@ func Test_AddAuxiliaryTokenPolicyClientOptions(t *testing.T) {
 	tokenServer := &AuxiliaryTokenServer{Token: defaultToken}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			request := &http.Request{
 				Method: http.MethodGet,
 				URL:    &url.URL{Path: "/"},
@@ -64,7 +65,7 @@ func Test_AddAuxiliaryTokenPolicyClientOptions(t *testing.T) {
 				t.Errorf("Unexpected error %v", err)
 				return
 			}
-			assert.Equal(t, tt.statusCode, resp.StatusCode, "Expected status code %d, got %d", tt.statusCode, resp.StatusCode)
+			g.Expect(resp.StatusCode).To(Equal(tt.statusCode), "Expected status code %d, got %d", tt.statusCode, resp.StatusCode)
 			tokenServer.Reset()
 		})
 	}

--- a/pkg/fake/azureresourcegraphapi_test.go
+++ b/pkg/fake/azureresourcegraphapi_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/launchtemplate"
+	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAzureResourceGraphAPI_Resources_VM(t *testing.T) {
@@ -61,6 +61,7 @@ func TestAzureResourceGraphAPI_Resources_VM(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.testName, func(t *testing.T) {
+			g := NewWithT(t)
 			for _, name := range c.vmNames {
 				_, err := instance.CreateVirtualMachine(context.Background(), virtualMachinesAPI, resourceGroup, name, armcompute.VirtualMachine{Tags: c.tags, Zones: []*string{lo.ToPtr("1")}})
 				if err != nil {
@@ -75,7 +76,7 @@ func TestAzureResourceGraphAPI_Resources_VM(t *testing.T) {
 				return
 			}
 			if data == nil {
-				assert.Equal(t, c.expectedError, "Unexpected nil resource data")
+				g.Expect("Unexpected nil resource data").To(Equal(c.expectedError))
 			}
 			if c.expectedError == "" {
 				if len(data) != len(c.vmNames) {
@@ -194,6 +195,7 @@ func TestAzureResourceGraphAPI_Resources_VM_WithKarpenterAKSMachineTagFiltering(
 
 	for _, c := range cases {
 		t.Run(c.testName, func(t *testing.T) {
+			g := NewWithT(t)
 			// Create VMs with different tag configurations
 			for _, vmConfig := range c.vmConfigs {
 				_, err := instance.CreateVirtualMachine(context.Background(), virtualMachinesAPI, resourceGroup, vmConfig.name, armcompute.VirtualMachine{
@@ -216,9 +218,9 @@ func TestAzureResourceGraphAPI_Resources_VM_WithKarpenterAKSMachineTagFiltering(
 			}
 
 			if c.expectedError != "" {
-				assert.Equal(t, c.expectedError, "Unexpected nil resource data")
+				g.Expect("Unexpected nil resource data").To(Equal(c.expectedError))
 			} else {
-				assert.Equal(t, len(c.expectedVMNames), len(data), "Unexpected number of VMs returned")
+				g.Expect(data).To(HaveLen(len(c.expectedVMNames)), "Unexpected number of VMs returned")
 
 				// Verify the correct VMs are returned
 				returnedNames := make([]string, 0, len(data))
@@ -232,7 +234,7 @@ func TestAzureResourceGraphAPI_Resources_VM_WithKarpenterAKSMachineTagFiltering(
 				}
 
 				for _, expectedName := range c.expectedVMNames {
-					assert.Contains(t, returnedNames, expectedName, "Expected VM not found in results")
+					g.Expect(returnedNames).To(ContainElement(expectedName), "Expected VM not found in results")
 				}
 			}
 
@@ -334,6 +336,7 @@ func TestAzureResourceGraphAPI_Resources_NIC_WithKarpenterAKSMachineTagFiltering
 
 	for _, c := range cases {
 		t.Run(c.testName, func(t *testing.T) {
+			g := NewWithT(t)
 			// Create NICs with different tag configurations
 			for _, nicConfig := range c.nicConfigs {
 				nic := armnetwork.Interface{
@@ -356,9 +359,9 @@ func TestAzureResourceGraphAPI_Resources_NIC_WithKarpenterAKSMachineTagFiltering
 			}
 
 			if c.expectedError != "" {
-				assert.Equal(t, c.expectedError, "Unexpected nil resource data")
+				g.Expect("Unexpected nil resource data").To(Equal(c.expectedError))
 			} else {
-				assert.Equal(t, len(c.expectedNICNames), len(data), "Unexpected number of NICs returned")
+				g.Expect(data).To(HaveLen(len(c.expectedNICNames)), "Unexpected number of NICs returned")
 
 				// Verify the correct NICs are returned
 				returnedNames := make([]string, 0, len(data))
@@ -372,7 +375,7 @@ func TestAzureResourceGraphAPI_Resources_NIC_WithKarpenterAKSMachineTagFiltering
 				}
 
 				for _, expectedName := range c.expectedNICNames {
-					assert.Contains(t, returnedNames, expectedName, "Expected NIC not found in results")
+					g.Expect(returnedNames).To(ContainElement(expectedName), "Expected NIC not found in results")
 				}
 			}
 

--- a/pkg/fake/nodeimageversionsapi_test.go
+++ b/pkg/fake/nodeimageversionsapi_test.go
@@ -21,17 +21,18 @@ import (
 	"testing"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
+	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFilteredNodeImagesGalleryFilter(t *testing.T) {
+	g := NewWithT(t)
 	nodeImageVersionAPI := NodeImageVersionsAPI{}
 	nodeImageVersions, _ := nodeImageVersionAPI.List(context.TODO(), "")
 	filteredNodeImages := imagefamily.FilteredNodeImages(nodeImageVersions)
 	for _, val := range filteredNodeImages {
-		assert.NotEqual(t, lo.FromPtr(val.OS), "AKSWindows")
-		assert.NotEqual(t, lo.FromPtr(val.OS), "AKSUbuntuEdgeZone")
+		g.Expect(lo.FromPtr(val.OS)).ToNot(Equal("AKSWindows"))
+		g.Expect(lo.FromPtr(val.OS)).ToNot(Equal("AKSUbuntuEdgeZone"))
 	}
 }
 
@@ -82,9 +83,10 @@ func TestFilteredNodeImagesMinimalUbuntuEdgeCase(t *testing.T) {
 // similar to the behavior we would see if someone is using the node image versions api call.
 // the fake imports the same clientside filtering so we need to assert that behavior is the same
 func TestFilteredNodeImageVersionsFromProviderList(t *testing.T) {
+	g := NewWithT(t)
 	nodeImageVersionsAPI := NodeImageVersionsAPI{}
 	filteredNodeImages, err := nodeImageVersionsAPI.List(context.TODO(), "")
-	assert.Nil(t, err)
+	g.Expect(err).To(BeNil())
 
 	expectedVersion := "202512.18.0"
 	found := false

--- a/pkg/providers/imagefamily/azlinux3_test.go
+++ b/pkg/providers/imagefamily/azlinux3_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/bootstrap"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/customscriptsbootstrap"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/launchtemplate/parameters"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -79,33 +79,36 @@ func TestAzureLinux3_CustomScriptsNodeBootstrapping(t *testing.T) {
 		localDNS,
 	)
 
+	g := NewWithT(t)
+
 	// Verify the returned bootstrapper is of the correct type
 	provisionBootstrapper, ok := bootstrapper.(customscriptsbootstrap.ProvisionClientBootstrap)
-	assert.True(t, ok, "Expected customscriptsbootstrap.ProvisionClientBootstrap type")
+	g.Expect(ok).To(BeTrue(), "Expected customscriptsbootstrap.ProvisionClientBootstrap type")
 
 	// Verify all fields are properly set
-	assert.Equal(t, "test-cluster", provisionBootstrapper.ClusterName)
-	assert.Equal(t, kubeletConfig, provisionBootstrapper.KubeletConfig)
-	assert.Equal(t, taints, provisionBootstrapper.Taints)
-	assert.Equal(t, startupTaints, provisionBootstrapper.StartupTaints)
-	assert.Equal(t, labels, provisionBootstrapper.Labels)
-	assert.Equal(t, "/subscriptions/test/resourceGroups/test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", provisionBootstrapper.SubnetID)
-	assert.Equal(t, karpv1.ArchitectureAmd64, provisionBootstrapper.Arch)
-	assert.Equal(t, "test-subscription", provisionBootstrapper.SubscriptionID)
-	assert.Equal(t, "test-rg", provisionBootstrapper.ResourceGroup)
-	assert.Equal(t, "test-cluster-rg", provisionBootstrapper.ClusterResourceGroup)
-	assert.Equal(t, "test-token", provisionBootstrapper.KubeletClientTLSBootstrapToken)
-	assert.Equal(t, "1.31.0", provisionBootstrapper.KubernetesVersion)
-	assert.Equal(t, imageDistro, provisionBootstrapper.ImageDistro)
-	assert.Equal(t, instanceType, provisionBootstrapper.InstanceType)
-	assert.Equal(t, storageProfile, provisionBootstrapper.StorageProfile)
-	assert.Equal(t, nodeBootstrappingClient, provisionBootstrapper.NodeBootstrappingProvider)
-	assert.Equal(t, customscriptsbootstrap.ImageFamilyOSSKUAzureLinux3, provisionBootstrapper.OSSKU, "ImageFamily field must be set to prevent unsupported image family errors")
-	assert.Nil(t, provisionBootstrapper.FIPSMode, "FIPSMode should be nil when not specified")
-	assert.Nil(t, provisionBootstrapper.LocalDNSProfile, "LocalDNSProfile should be nil when not specified")
+	g.Expect(provisionBootstrapper.ClusterName).To(Equal("test-cluster"))
+	g.Expect(provisionBootstrapper.KubeletConfig).To(Equal(kubeletConfig))
+	g.Expect(provisionBootstrapper.Taints).To(Equal(taints))
+	g.Expect(provisionBootstrapper.StartupTaints).To(Equal(startupTaints))
+	g.Expect(provisionBootstrapper.Labels).To(Equal(labels))
+	g.Expect(provisionBootstrapper.SubnetID).To(Equal("/subscriptions/test/resourceGroups/test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"))
+	g.Expect(provisionBootstrapper.Arch).To(Equal(karpv1.ArchitectureAmd64))
+	g.Expect(provisionBootstrapper.SubscriptionID).To(Equal("test-subscription"))
+	g.Expect(provisionBootstrapper.ResourceGroup).To(Equal("test-rg"))
+	g.Expect(provisionBootstrapper.ClusterResourceGroup).To(Equal("test-cluster-rg"))
+	g.Expect(provisionBootstrapper.KubeletClientTLSBootstrapToken).To(Equal("test-token"))
+	g.Expect(provisionBootstrapper.KubernetesVersion).To(Equal("1.31.0"))
+	g.Expect(provisionBootstrapper.ImageDistro).To(Equal(imageDistro))
+	g.Expect(provisionBootstrapper.InstanceType).To(Equal(instanceType))
+	g.Expect(provisionBootstrapper.StorageProfile).To(Equal(storageProfile))
+	g.Expect(provisionBootstrapper.NodeBootstrappingProvider).To(Equal(nodeBootstrappingClient))
+	g.Expect(provisionBootstrapper.OSSKU).To(Equal(customscriptsbootstrap.ImageFamilyOSSKUAzureLinux3), "ImageFamily field must be set to prevent unsupported image family errors")
+	g.Expect(provisionBootstrapper.FIPSMode).To(BeNil(), "FIPSMode should be nil when not specified")
+	g.Expect(provisionBootstrapper.LocalDNSProfile).To(BeNil(), "LocalDNSProfile should be nil when not specified")
 }
 
 func TestAzureLinux3_Name(t *testing.T) {
+	g := NewWithT(t)
 	azureLinux3 := imagefamily.AzureLinux3{}
-	assert.Equal(t, v1beta1.AzureLinuxImageFamily, azureLinux3.Name())
+	g.Expect(azureLinux3.Name()).To(Equal(v1beta1.AzureLinuxImageFamily))
 }

--- a/pkg/providers/imagefamily/azlinux_test.go
+++ b/pkg/providers/imagefamily/azlinux_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/bootstrap"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/customscriptsbootstrap"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/launchtemplate/parameters"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -79,33 +79,36 @@ func TestAzureLinux_CustomScriptsNodeBootstrapping(t *testing.T) {
 		localDNS,
 	)
 
+	g := NewWithT(t)
+
 	// Verify the returned bootstrapper is of the correct type
 	provisionBootstrapper, ok := bootstrapper.(customscriptsbootstrap.ProvisionClientBootstrap)
-	assert.True(t, ok, "Expected customscriptsbootstrap.ProvisionClientBootstrap type")
+	g.Expect(ok).To(BeTrue(), "Expected customscriptsbootstrap.ProvisionClientBootstrap type")
 
 	// Verify all fields are properly set
-	assert.Equal(t, "test-cluster", provisionBootstrapper.ClusterName)
-	assert.Equal(t, kubeletConfig, provisionBootstrapper.KubeletConfig)
-	assert.Equal(t, taints, provisionBootstrapper.Taints)
-	assert.Equal(t, startupTaints, provisionBootstrapper.StartupTaints)
-	assert.Equal(t, labels, provisionBootstrapper.Labels)
-	assert.Equal(t, "/subscriptions/test/resourceGroups/test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", provisionBootstrapper.SubnetID)
-	assert.Equal(t, karpv1.ArchitectureAmd64, provisionBootstrapper.Arch)
-	assert.Equal(t, "test-subscription", provisionBootstrapper.SubscriptionID)
-	assert.Equal(t, "test-rg", provisionBootstrapper.ResourceGroup)
-	assert.Equal(t, "test-cluster-rg", provisionBootstrapper.ClusterResourceGroup)
-	assert.Equal(t, "test-token", provisionBootstrapper.KubeletClientTLSBootstrapToken)
-	assert.Equal(t, "1.31.0", provisionBootstrapper.KubernetesVersion)
-	assert.Equal(t, imageDistro, provisionBootstrapper.ImageDistro)
-	assert.Equal(t, instanceType, provisionBootstrapper.InstanceType)
-	assert.Equal(t, storageProfile, provisionBootstrapper.StorageProfile)
-	assert.Equal(t, nodeBootstrappingClient, provisionBootstrapper.NodeBootstrappingProvider)
-	assert.Equal(t, customscriptsbootstrap.ImageFamilyOSSKUAzureLinux2, provisionBootstrapper.OSSKU, "ImageFamily field must be set to prevent unsupported image family errors")
-	assert.Nil(t, provisionBootstrapper.FIPSMode, "FIPSMode should be nil when not specified")
-	assert.Nil(t, provisionBootstrapper.LocalDNSProfile, "LocalDNSProfile should be nil when not specified")
+	g.Expect(provisionBootstrapper.ClusterName).To(Equal("test-cluster"))
+	g.Expect(provisionBootstrapper.KubeletConfig).To(Equal(kubeletConfig))
+	g.Expect(provisionBootstrapper.Taints).To(Equal(taints))
+	g.Expect(provisionBootstrapper.StartupTaints).To(Equal(startupTaints))
+	g.Expect(provisionBootstrapper.Labels).To(Equal(labels))
+	g.Expect(provisionBootstrapper.SubnetID).To(Equal("/subscriptions/test/resourceGroups/test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"))
+	g.Expect(provisionBootstrapper.Arch).To(Equal(karpv1.ArchitectureAmd64))
+	g.Expect(provisionBootstrapper.SubscriptionID).To(Equal("test-subscription"))
+	g.Expect(provisionBootstrapper.ResourceGroup).To(Equal("test-rg"))
+	g.Expect(provisionBootstrapper.ClusterResourceGroup).To(Equal("test-cluster-rg"))
+	g.Expect(provisionBootstrapper.KubeletClientTLSBootstrapToken).To(Equal("test-token"))
+	g.Expect(provisionBootstrapper.KubernetesVersion).To(Equal("1.31.0"))
+	g.Expect(provisionBootstrapper.ImageDistro).To(Equal(imageDistro))
+	g.Expect(provisionBootstrapper.InstanceType).To(Equal(instanceType))
+	g.Expect(provisionBootstrapper.StorageProfile).To(Equal(storageProfile))
+	g.Expect(provisionBootstrapper.NodeBootstrappingProvider).To(Equal(nodeBootstrappingClient))
+	g.Expect(provisionBootstrapper.OSSKU).To(Equal(customscriptsbootstrap.ImageFamilyOSSKUAzureLinux2), "ImageFamily field must be set to prevent unsupported image family errors")
+	g.Expect(provisionBootstrapper.FIPSMode).To(BeNil(), "FIPSMode should be nil when not specified")
+	g.Expect(provisionBootstrapper.LocalDNSProfile).To(BeNil(), "LocalDNSProfile should be nil when not specified")
 }
 
 func TestAzureLinux_Name(t *testing.T) {
+	g := NewWithT(t)
 	azureLinux := imagefamily.AzureLinux{}
-	assert.Equal(t, v1beta1.AzureLinuxImageFamily, azureLinux.Name())
+	g.Expect(azureLinux.Name()).To(Equal(v1beta1.AzureLinuxImageFamily))
 }

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -186,7 +186,8 @@ func TestKubeletConfigMap(t *testing.T) {
 	}
 	actualKubeletConfig := kubeletConfigToMap(&kubeletConfiguration)
 
+	g := NewWithT(t)
 	for k, v := range expectedKubeletConfigs {
-		assert.Equal(t, v, actualKubeletConfig[k], fmt.Sprintf("parameter mismatch for %s", k))
+		g.Expect(actualKubeletConfig[k]).To(Equal(v), fmt.Sprintf("parameter mismatch for %s", k))
 	}
 }

--- a/pkg/providers/imagefamily/customscriptsbootstrap/utils_test.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/utils_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instancetype"
 	"github.com/Azure/karpenter-provider-azure/pkg/provisionclients/models"
+	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
 
@@ -198,16 +198,17 @@ func TestHydrateBootstrapTokenIfNeeded(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			customData, cse, err := hydrateBootstrapTokenIfNeeded(tt.customDataDehydratable, tt.cseDehydratable, tt.bootstrapToken)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
 
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expectedCustomData, customData)
-			assert.Equal(t, tt.expectedCSE, cse)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(customData).To(Equal(tt.expectedCustomData))
+			g.Expect(cse).To(Equal(tt.expectedCSE))
 		})
 	}
 }
@@ -309,8 +310,9 @@ func TestConvertLocalDNSToModel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			result := convertLocalDNSToModel(tt.localDNS)
-			assert.Equal(t, tt.expected, result)
+			g.Expect(result).To(Equal(tt.expected))
 		})
 	}
 }
@@ -415,8 +417,9 @@ func TestConvertLocalDNSZoneOverrideToModel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			result := convertLocalDNSZoneOverrideToModel(tt.override)
-			assert.Equal(t, tt.expected, result)
+			g.Expect(result).To(Equal(tt.expected))
 		})
 	}
 }

--- a/pkg/providers/imagefamily/ubuntu_2004_test.go
+++ b/pkg/providers/imagefamily/ubuntu_2004_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/bootstrap"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/customscriptsbootstrap"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/launchtemplate/parameters"
+	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -79,33 +79,36 @@ func TestUbuntu2004_CustomScriptsNodeBootstrapping(t *testing.T) {
 		nil, // Ubuntu 20.04 does not support LocalDNS
 	)
 
+	g := NewWithT(t)
+
 	// Verify the returned bootstrapper is of the correct type
 	provisionBootstrapper, ok := bootstrapper.(customscriptsbootstrap.ProvisionClientBootstrap)
-	assert.True(t, ok, "Expected customscriptsbootstrap.ProvisionClientBootstrap type")
+	g.Expect(ok).To(BeTrue(), "Expected customscriptsbootstrap.ProvisionClientBootstrap type")
 
 	// Verify all fields are properly set
-	assert.Equal(t, "test-cluster", provisionBootstrapper.ClusterName)
-	assert.Equal(t, kubeletConfig, provisionBootstrapper.KubeletConfig)
-	assert.Equal(t, taints, provisionBootstrapper.Taints)
-	assert.Equal(t, startupTaints, provisionBootstrapper.StartupTaints)
-	assert.Equal(t, labels, provisionBootstrapper.Labels)
-	assert.Equal(t, "/subscriptions/test/resourceGroups/test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", provisionBootstrapper.SubnetID)
-	assert.Equal(t, karpv1.ArchitectureAmd64, provisionBootstrapper.Arch)
-	assert.Equal(t, "test-subscription", provisionBootstrapper.SubscriptionID)
-	assert.Equal(t, "test-rg", provisionBootstrapper.ResourceGroup)
-	assert.Equal(t, "test-cluster-rg", provisionBootstrapper.ClusterResourceGroup)
-	assert.Equal(t, "test-token", provisionBootstrapper.KubeletClientTLSBootstrapToken)
-	assert.Equal(t, "1.31.0", provisionBootstrapper.KubernetesVersion)
-	assert.Equal(t, imageDistro, provisionBootstrapper.ImageDistro)
-	assert.Equal(t, instanceType, provisionBootstrapper.InstanceType)
-	assert.Equal(t, storageProfile, provisionBootstrapper.StorageProfile)
-	assert.Equal(t, nodeBootstrappingClient, provisionBootstrapper.NodeBootstrappingProvider)
-	assert.Equal(t, customscriptsbootstrap.ImageFamilyOSSKUUbuntu2004, provisionBootstrapper.OSSKU, "ImageFamily field must be set to prevent unsupported image family errors")
-	assert.Equal(t, fipsMode, provisionBootstrapper.FIPSMode, "FIPSMode field must match the input parameter")
-	assert.Nil(t, provisionBootstrapper.LocalDNSProfile, "Ubuntu 20.04 does not support LocalDNS")
+	g.Expect(provisionBootstrapper.ClusterName).To(Equal("test-cluster"))
+	g.Expect(provisionBootstrapper.KubeletConfig).To(Equal(kubeletConfig))
+	g.Expect(provisionBootstrapper.Taints).To(Equal(taints))
+	g.Expect(provisionBootstrapper.StartupTaints).To(Equal(startupTaints))
+	g.Expect(provisionBootstrapper.Labels).To(Equal(labels))
+	g.Expect(provisionBootstrapper.SubnetID).To(Equal("/subscriptions/test/resourceGroups/test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"))
+	g.Expect(provisionBootstrapper.Arch).To(Equal(karpv1.ArchitectureAmd64))
+	g.Expect(provisionBootstrapper.SubscriptionID).To(Equal("test-subscription"))
+	g.Expect(provisionBootstrapper.ResourceGroup).To(Equal("test-rg"))
+	g.Expect(provisionBootstrapper.ClusterResourceGroup).To(Equal("test-cluster-rg"))
+	g.Expect(provisionBootstrapper.KubeletClientTLSBootstrapToken).To(Equal("test-token"))
+	g.Expect(provisionBootstrapper.KubernetesVersion).To(Equal("1.31.0"))
+	g.Expect(provisionBootstrapper.ImageDistro).To(Equal(imageDistro))
+	g.Expect(provisionBootstrapper.InstanceType).To(Equal(instanceType))
+	g.Expect(provisionBootstrapper.StorageProfile).To(Equal(storageProfile))
+	g.Expect(provisionBootstrapper.NodeBootstrappingProvider).To(Equal(nodeBootstrappingClient))
+	g.Expect(provisionBootstrapper.OSSKU).To(Equal(customscriptsbootstrap.ImageFamilyOSSKUUbuntu2004), "ImageFamily field must be set to prevent unsupported image family errors")
+	g.Expect(provisionBootstrapper.FIPSMode).To(Equal(fipsMode), "FIPSMode field must match the input parameter")
+	g.Expect(provisionBootstrapper.LocalDNSProfile).To(BeNil(), "Ubuntu 20.04 does not support LocalDNS")
 }
 
 func TestUbuntu2004_Name(t *testing.T) {
+	g := NewWithT(t)
 	ubuntu := imagefamily.Ubuntu2004{}
-	assert.Equal(t, v1beta1.UbuntuImageFamily, ubuntu.Name())
+	g.Expect(ubuntu.Name()).To(Equal(v1beta1.UbuntuImageFamily))
 }

--- a/pkg/providers/imagefamily/ubuntu_2204_test.go
+++ b/pkg/providers/imagefamily/ubuntu_2204_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/bootstrap"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/customscriptsbootstrap"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/launchtemplate/parameters"
+	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -80,33 +80,36 @@ func TestUbuntu2204_CustomScriptsNodeBootstrapping(t *testing.T) {
 		localDNS,
 	)
 
+	g := NewWithT(t)
+
 	// Verify the returned bootstrapper is of the correct type
 	provisionBootstrapper, ok := bootstrapper.(customscriptsbootstrap.ProvisionClientBootstrap)
-	assert.True(t, ok, "Expected customscriptsbootstrap.ProvisionClientBootstrap type")
+	g.Expect(ok).To(BeTrue(), "Expected customscriptsbootstrap.ProvisionClientBootstrap type")
 
 	// Verify all fields are properly set
-	assert.Equal(t, "test-cluster", provisionBootstrapper.ClusterName)
-	assert.Equal(t, kubeletConfig, provisionBootstrapper.KubeletConfig)
-	assert.Equal(t, taints, provisionBootstrapper.Taints)
-	assert.Equal(t, startupTaints, provisionBootstrapper.StartupTaints)
-	assert.Equal(t, labels, provisionBootstrapper.Labels)
-	assert.Equal(t, "/subscriptions/test/resourceGroups/test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet", provisionBootstrapper.SubnetID)
-	assert.Equal(t, karpv1.ArchitectureAmd64, provisionBootstrapper.Arch)
-	assert.Equal(t, "test-subscription", provisionBootstrapper.SubscriptionID)
-	assert.Equal(t, "test-rg", provisionBootstrapper.ResourceGroup)
-	assert.Equal(t, "test-cluster-rg", provisionBootstrapper.ClusterResourceGroup)
-	assert.Equal(t, "test-token", provisionBootstrapper.KubeletClientTLSBootstrapToken)
-	assert.Equal(t, "1.31.0", provisionBootstrapper.KubernetesVersion)
-	assert.Equal(t, imageDistro, provisionBootstrapper.ImageDistro)
-	assert.Equal(t, instanceType, provisionBootstrapper.InstanceType)
-	assert.Equal(t, storageProfile, provisionBootstrapper.StorageProfile)
-	assert.Equal(t, nodeBootstrappingClient, provisionBootstrapper.NodeBootstrappingProvider)
-	assert.Equal(t, customscriptsbootstrap.ImageFamilyOSSKUUbuntu2204, provisionBootstrapper.OSSKU, "ImageFamily field must be set to prevent unsupported image family errors")
-	assert.Equal(t, fipsMode, provisionBootstrapper.FIPSMode, "FIPSMode field must match the input parameter")
-	assert.Equal(t, localDNS, provisionBootstrapper.LocalDNSProfile, "LocalDNSProfile field must match the input parameter")
+	g.Expect(provisionBootstrapper.ClusterName).To(Equal("test-cluster"))
+	g.Expect(provisionBootstrapper.KubeletConfig).To(Equal(kubeletConfig))
+	g.Expect(provisionBootstrapper.Taints).To(Equal(taints))
+	g.Expect(provisionBootstrapper.StartupTaints).To(Equal(startupTaints))
+	g.Expect(provisionBootstrapper.Labels).To(Equal(labels))
+	g.Expect(provisionBootstrapper.SubnetID).To(Equal("/subscriptions/test/resourceGroups/test/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"))
+	g.Expect(provisionBootstrapper.Arch).To(Equal(karpv1.ArchitectureAmd64))
+	g.Expect(provisionBootstrapper.SubscriptionID).To(Equal("test-subscription"))
+	g.Expect(provisionBootstrapper.ResourceGroup).To(Equal("test-rg"))
+	g.Expect(provisionBootstrapper.ClusterResourceGroup).To(Equal("test-cluster-rg"))
+	g.Expect(provisionBootstrapper.KubeletClientTLSBootstrapToken).To(Equal("test-token"))
+	g.Expect(provisionBootstrapper.KubernetesVersion).To(Equal("1.31.0"))
+	g.Expect(provisionBootstrapper.ImageDistro).To(Equal(imageDistro))
+	g.Expect(provisionBootstrapper.InstanceType).To(Equal(instanceType))
+	g.Expect(provisionBootstrapper.StorageProfile).To(Equal(storageProfile))
+	g.Expect(provisionBootstrapper.NodeBootstrappingProvider).To(Equal(nodeBootstrappingClient))
+	g.Expect(provisionBootstrapper.OSSKU).To(Equal(customscriptsbootstrap.ImageFamilyOSSKUUbuntu2204), "ImageFamily field must be set to prevent unsupported image family errors")
+	g.Expect(provisionBootstrapper.FIPSMode).To(Equal(fipsMode), "FIPSMode field must match the input parameter")
+	g.Expect(provisionBootstrapper.LocalDNSProfile).To(Equal(localDNS), "LocalDNSProfile field must match the input parameter")
 }
 
 func TestUbuntu2204_Name(t *testing.T) {
+	g := NewWithT(t)
 	ubuntu := imagefamily.Ubuntu2204{}
-	assert.Equal(t, v1beta1.Ubuntu2204ImageFamily, ubuntu.Name())
+	g.Expect(ubuntu.Name()).To(Equal(v1beta1.Ubuntu2204ImageFamily))
 }

--- a/pkg/providers/imagefamily/ubuntu_2404_test.go
+++ b/pkg/providers/imagefamily/ubuntu_2404_test.go
@@ -23,14 +23,15 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/customscriptsbootstrap"
 	template "github.com/Azure/karpenter-provider-azure/pkg/providers/launchtemplate/parameters"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/gomega"
 )
 
 func TestUbuntu2404_Name(t *testing.T) {
+	g := NewWithT(t)
 	ubuntu := &imagefamily.Ubuntu2404{
 		Options: &template.StaticParameters{},
 	}
-	assert.Equal(t, v1beta1.Ubuntu2404ImageFamily, ubuntu.Name())
+	g.Expect(ubuntu.Name()).To(Equal(v1beta1.Ubuntu2404ImageFamily))
 }
 
 func TestUbuntu2404_DefaultImages(t *testing.T) {
@@ -39,33 +40,37 @@ func TestUbuntu2404_DefaultImages(t *testing.T) {
 	}
 
 	t.Run("should return correct default images", func(t *testing.T) {
+		g := NewWithT(t)
 		images := ubuntu.DefaultImages(false, nil)
-		assert.Len(t, images, 3)
+		g.Expect(images).To(HaveLen(3))
 
-		assert.Equal(t, imagefamily.Ubuntu2404Gen2ImageDefinition, images[0].ImageDefinition)
-		assert.Equal(t, "aks-ubuntu-containerd-24.04-gen2", images[0].Distro)
+		g.Expect(images[0].ImageDefinition).To(Equal(imagefamily.Ubuntu2404Gen2ImageDefinition))
+		g.Expect(images[0].Distro).To(Equal("aks-ubuntu-containerd-24.04-gen2"))
 
-		assert.Equal(t, imagefamily.Ubuntu2404Gen1ImageDefinition, images[1].ImageDefinition)
-		assert.Equal(t, "aks-ubuntu-containerd-24.04", images[1].Distro)
+		g.Expect(images[1].ImageDefinition).To(Equal(imagefamily.Ubuntu2404Gen1ImageDefinition))
+		g.Expect(images[1].Distro).To(Equal("aks-ubuntu-containerd-24.04"))
 
-		assert.Equal(t, imagefamily.Ubuntu2404Gen2ArmImageDefinition, images[2].ImageDefinition)
-		assert.Equal(t, "aks-ubuntu-arm64-containerd-24.04-gen2", images[2].Distro)
+		g.Expect(images[2].ImageDefinition).To(Equal(imagefamily.Ubuntu2404Gen2ArmImageDefinition))
+		g.Expect(images[2].Distro).To(Equal("aks-ubuntu-arm64-containerd-24.04-gen2"))
 	})
 
 	t.Run("should return empty images for FIPS mode without SIG", func(t *testing.T) {
+		g := NewWithT(t)
 		fipsMode := v1beta1.FIPSModeFIPS
 		images := ubuntu.DefaultImages(false, &fipsMode)
-		assert.Empty(t, images)
+		g.Expect(images).To(BeEmpty())
 	})
 
 	t.Run("should return empty images for FIPS mode with SIG (not yet supported)", func(t *testing.T) {
+		g := NewWithT(t)
 		fipsMode := v1beta1.FIPSModeFIPS
 		images := ubuntu.DefaultImages(true, &fipsMode)
-		assert.Empty(t, images)
+		g.Expect(images).To(BeEmpty())
 	})
 }
 
 func TestUbuntu2404_CustomScriptsNodeBootstrapping(t *testing.T) {
+	g := NewWithT(t)
 	ubuntu := &imagefamily.Ubuntu2404{
 		Options: &template.StaticParameters{
 			ClusterName:                    "test-cluster",
@@ -91,6 +96,6 @@ func TestUbuntu2404_CustomScriptsNodeBootstrapping(t *testing.T) {
 		nil, nil, nil, nil, nil, "test-distro", "Standard_LRS", nil, nil, nil,
 	)
 	provisionBootstrapper, ok := bootstrapper.(customscriptsbootstrap.ProvisionClientBootstrap)
-	assert.True(t, ok, "Expected ProvisionClientBootstrap type")
-	assert.Equal(t, customscriptsbootstrap.ImageFamilyOSSKUUbuntu2404, provisionBootstrapper.OSSKU, "ImageFamily field must be set to prevent unsupported image family errors")
+	g.Expect(ok).To(BeTrue(), "Expected ProvisionClientBootstrap type")
+	g.Expect(provisionBootstrapper.OSSKU).To(Equal(customscriptsbootstrap.ImageFamilyOSSKUUbuntu2404), "ImageFamily field must be set to prevent unsupported image family errors")
 }

--- a/pkg/providers/instance/azure_no_client_test.go
+++ b/pkg/providers/instance/azure_no_client_test.go
@@ -21,55 +21,60 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8"
+	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNoAKSMachinesClient_BeginCreateOrUpdate(t *testing.T) {
+	g := NewWithT(t)
 	ctx := context.Background()
 	client := NewNoAKSMachinesClient()
 
 	_, err := client.BeginCreateOrUpdate(ctx, "test-rg", "test-cluster", "test-pool", "test-machine", armcontainerservice.Machine{}, nil)
 
-	assert.Error(t, err)
-	assert.True(t, IsAKSMachineOrMachinesPoolNotFound(err))
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(IsAKSMachineOrMachinesPoolNotFound(err)).To(BeTrue())
 }
 
 func TestNoAKSMachinesClient_Get(t *testing.T) {
+	g := NewWithT(t)
 	ctx := context.Background()
 	client := NewNoAKSMachinesClient()
 
 	_, err := client.Get(ctx, "test-rg", "test-cluster", "test-pool", "test-machine", nil)
 
-	assert.Error(t, err)
-	assert.True(t, IsAKSMachineOrMachinesPoolNotFound(err))
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(IsAKSMachineOrMachinesPoolNotFound(err)).To(BeTrue())
 }
 
 func TestNoAKSMachinesClient_NewListPager(t *testing.T) {
+	g := NewWithT(t)
 	ctx := context.Background()
 	client := NewNoAKSMachinesClient()
 
 	pager := client.NewListPager("test-rg", "test-cluster", "test-pool", nil)
 
-	assert.NotNil(t, pager)
+	g.Expect(pager).ToNot(BeNil())
 
-	assert.True(t, pager.More())
+	g.Expect(pager.More()).To(BeTrue())
 	_, err := pager.NextPage(ctx)
-	assert.Error(t, err)
-	assert.True(t, IsAKSMachineOrMachinesPoolNotFound(err))
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(IsAKSMachineOrMachinesPoolNotFound(err)).To(BeTrue())
 }
 
 func TestNoAKSAgentPoolsClient_Get(t *testing.T) {
+	g := NewWithT(t)
 	ctx := context.Background()
 	client := NewNoAKSAgentPoolsClient()
 
 	_, err := client.Get(ctx, "test-rg", "test-cluster", "test-pool", nil)
 
-	assert.Error(t, err)
-	assert.True(t, IsAKSMachineOrMachinesPoolNotFound(err))
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(IsAKSMachineOrMachinesPoolNotFound(err)).To(BeTrue())
 }
 
 func TestNoAKSAgentPoolsClient_BeginDeleteMachines(t *testing.T) {
+	g := NewWithT(t)
 	ctx := context.Background()
 	client := NewNoAKSAgentPoolsClient()
 
@@ -79,6 +84,6 @@ func TestNoAKSAgentPoolsClient_BeginDeleteMachines(t *testing.T) {
 		},
 	}, nil)
 
-	assert.Error(t, err)
-	assert.True(t, IsAKSMachineOrMachinesPoolNotFound(err))
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(IsAKSMachineOrMachinesPoolNotFound(err)).To(BeTrue())
 }

--- a/pkg/providers/instance/azureresourcegraphlist_test.go
+++ b/pkg/providers/instance/azureresourcegraphlist_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/gomega"
 )
 
 func TestCreateNICFromQueryResponseData(t *testing.T) {
@@ -69,18 +69,19 @@ func TestCreateNICFromQueryResponseData(t *testing.T) {
 	}
 
 	for _, c := range tc {
+		g := NewWithT(t)
 		nic, err := createNICFromQueryResponseData(c.data)
 		if nic != nil {
 			expected := *c.expectedNIC
 			actual := *nic
-			assert.Equal(t, *expected.ID, *actual.ID, c.testName)
-			assert.Equal(t, *expected.Name, *actual.Name, c.testName)
+			g.Expect(*actual.ID).To(Equal(*expected.ID), c.testName)
+			g.Expect(*actual.Name).To(Equal(*expected.Name), c.testName)
 			for key := range expected.Tags {
-				assert.Equal(t, *(expected.Tags[key]), *(actual.Tags[key]), c.testName)
+				g.Expect(*(actual.Tags[key])).To(Equal(*(expected.Tags[key])), c.testName)
 			}
 		}
 		if err != nil {
-			assert.Equal(t, c.expectedError, err.Error(), c.testName)
+			g.Expect(err.Error()).To(Equal(c.expectedError), c.testName)
 		}
 	}
 }
@@ -137,21 +138,22 @@ func TestCreateVMFromQueryResponseData(t *testing.T) {
 	}
 
 	for _, c := range tc {
+		g := NewWithT(t)
 		vm, err := createVMFromQueryResponseData(c.data)
 		if vm != nil {
 			expected := *c.expectedVM
 			actual := *vm
-			assert.Equal(t, *expected.ID, *actual.ID, c.testName)
-			assert.Equal(t, *expected.Name, *actual.Name, c.testName)
+			g.Expect(*actual.ID).To(Equal(*expected.ID), c.testName)
+			g.Expect(*actual.Name).To(Equal(*expected.Name), c.testName)
 			for key := range expected.Tags {
-				assert.Equal(t, *(expected.Tags[key]), *(actual.Tags[key]), c.testName)
+				g.Expect(*(actual.Tags[key])).To(Equal(*(expected.Tags[key])), c.testName)
 			}
 			for i := range expected.Zones {
-				assert.Equal(t, *(expected.Zones[i]), *(actual.Zones[i]), c.testName)
+				g.Expect(*(actual.Zones[i])).To(Equal(*(expected.Zones[i])), c.testName)
 			}
 		}
 		if err != nil {
-			assert.Equal(t, c.expectedError, err.Error(), c.testName)
+			g.Expect(err.Error()).To(Equal(c.expectedError), c.testName)
 		}
 	}
 }

--- a/pkg/providers/instance/offerings/commonerrorhandlers_test.go
+++ b/pkg/providers/instance/offerings/commonerrorhandlers_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Azure/karpenter-provider-azure/pkg/cache"
 	"github.com/Azure/skewer"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -161,6 +161,7 @@ func createCommonErrorInstanceType(instanceName string, offerings ...offering) *
 }
 
 func TestMarkOfferingsUnavailableForCapacityType(t *testing.T) {
+	g := NewWithT(t)
 	ctx := context.Background()
 	unavailableOfferings := cache.NewUnavailableOfferings()
 	instanceType := createCommonErrorInstanceType(testInstanceName,
@@ -170,15 +171,16 @@ func TestMarkOfferingsUnavailableForCapacityType(t *testing.T) {
 	markOfferingsUnavailableForCapacityType(ctx, unavailableOfferings, instanceType, karpv1.CapacityTypeSpot, SKUNotAvailableReason, SKUNotAvailableSpotTTL)
 
 	// Check that spot offerings are unavailable
-	assert.True(t, unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone1, karpv1.CapacityTypeSpot))
-	assert.True(t, unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone2, karpv1.CapacityTypeSpot))
+	g.Expect(unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone1, karpv1.CapacityTypeSpot)).To(BeTrue())
+	g.Expect(unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone2, karpv1.CapacityTypeSpot)).To(BeTrue())
 
 	// Check that on-demand offerings are still available
-	assert.False(t, unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone1, karpv1.CapacityTypeOnDemand))
-	assert.False(t, unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone2, karpv1.CapacityTypeOnDemand))
+	g.Expect(unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone1, karpv1.CapacityTypeOnDemand)).To(BeFalse())
+	g.Expect(unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone2, karpv1.CapacityTypeOnDemand)).To(BeFalse())
 }
 
 func TestMarkAllZonesUnavailableForBothCapacityTypes(t *testing.T) {
+	g := NewWithT(t)
 	ctx := context.Background()
 	unavailableOfferings := cache.NewUnavailableOfferings()
 	instanceType := createCommonErrorInstanceType(testInstanceName,
@@ -188,10 +190,10 @@ func TestMarkAllZonesUnavailableForBothCapacityTypes(t *testing.T) {
 	markAllZonesUnavailableForBothCapacityTypes(ctx, unavailableOfferings, instanceType, AllocationFailureReason, AllocationFailureTTL)
 
 	// Check that all zones and capacity types are unavailable
-	assert.True(t, unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone1, karpv1.CapacityTypeOnDemand))
-	assert.True(t, unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone1, karpv1.CapacityTypeSpot))
-	assert.True(t, unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone2, karpv1.CapacityTypeOnDemand))
-	assert.True(t, unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone2, karpv1.CapacityTypeSpot))
-	assert.True(t, unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone3, karpv1.CapacityTypeOnDemand))
-	assert.True(t, unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone3, karpv1.CapacityTypeSpot))
+	g.Expect(unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone1, karpv1.CapacityTypeOnDemand)).To(BeTrue())
+	g.Expect(unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone1, karpv1.CapacityTypeSpot)).To(BeTrue())
+	g.Expect(unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone2, karpv1.CapacityTypeOnDemand)).To(BeTrue())
+	g.Expect(unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone2, karpv1.CapacityTypeSpot)).To(BeTrue())
+	g.Expect(unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone3, karpv1.CapacityTypeOnDemand)).To(BeTrue())
+	g.Expect(unavailableOfferings.IsUnavailable(createDefaultCommonErrorTestSKU(), testZone3, karpv1.CapacityTypeSpot)).To(BeTrue())
 }

--- a/pkg/providers/instance/offerings/errordetailhandlers_test.go
+++ b/pkg/providers/instance/offerings/errordetailhandlers_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8"
 	"github.com/Azure/karpenter-provider-azure/pkg/cache"
 	"github.com/Azure/skewer"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/gomega"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
 )
@@ -254,6 +254,7 @@ func TestHandleErrorDetails(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
+			g := NewWithT(t)
 			provider := newTestErrorDetailHandling()
 
 			err := provider.Handle(
@@ -265,7 +266,11 @@ func TestHandleErrorDetails(t *testing.T) {
 				tc.cloudErr,
 			)
 
-			assert.Equal(t, tc.expectedErr, err)
+			if tc.expectedErr == nil {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err).To(Equal(tc.expectedErr))
+			}
 			assertOfferingsState(t, provider.UnavailableOfferings, tc.expectedUnavailableOfferingsInformation, tc.expectedAvailableOfferingsInformation)
 		})
 	}

--- a/pkg/providers/instance/offerings/offerings_test.go
+++ b/pkg/providers/instance/offerings/offerings_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -262,22 +262,23 @@ func TestPickSkuSizePriorityAndZone(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			g := NewWithT(t)
 			instanceType, priority, zone := PickSkuSizePriorityAndZone(context.TODO(), c.nodeClaim, c.instanceTypes)
 
 			if c.expectedInstanceType == "" {
-				assert.Nil(t, instanceType)
+				g.Expect(instanceType).To(BeNil())
 			} else {
-				assert.NotNil(t, instanceType)
-				assert.Equal(t, c.expectedInstanceType, instanceType.Name)
+				g.Expect(instanceType).ToNot(BeNil())
+				g.Expect(instanceType.Name).To(Equal(c.expectedInstanceType))
 			}
 
-			assert.Equal(t, c.expectedPriority, priority)
+			g.Expect(priority).To(Equal(c.expectedPriority))
 
 			if c.name == "Multiple zones - should pick one of the available zones" {
 				// For multiple zones, just verify a zone was selected
-				assert.Contains(t, []string{"westus-1", "westus-2"}, zone)
+				g.Expect([]string{"westus-1", "westus-2"}).To(ContainElement(zone))
 			} else {
-				assert.Equal(t, c.expectedZone, zone)
+				g.Expect(zone).To(Equal(c.expectedZone))
 			}
 		})
 	}
@@ -387,8 +388,9 @@ func TestGetPriorityForInstanceType(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			g := NewWithT(t)
 			priority := getPriorityForInstanceType(c.nodeClaim, c.instanceType)
-			assert.Equal(t, c.expectedPriority, priority)
+			g.Expect(priority).To(Equal(c.expectedPriority))
 		})
 	}
 }
@@ -482,12 +484,13 @@ func TestOrderInstanceTypesByPrice(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ordered := OrderInstanceTypesByPrice(c.instanceTypes, c.requirements)
 			actualOrder := make([]string, len(ordered))
 			for i, it := range ordered {
 				actualOrder[i] = it.Name
 			}
-			assert.Equal(t, c.expectedOrder, actualOrder)
+			g.Expect(actualOrder).To(Equal(c.expectedOrder))
 		})
 	}
 }
@@ -520,8 +523,9 @@ func TestGetOfferingCapacityType(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			g := NewWithT(t)
 			capacityType := getOfferingCapacityType(c.offering)
-			assert.Equal(t, c.expectedCapacity, capacityType)
+			g.Expect(capacityType).To(Equal(c.expectedCapacity))
 		})
 	}
 }
@@ -554,8 +558,9 @@ func TestGetOfferingZone(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			g := NewWithT(t)
 			zone := getOfferingZone(c.offering)
-			assert.Equal(t, c.expectedZone, zone)
+			g.Expect(zone).To(Equal(c.expectedZone))
 		})
 	}
 }
@@ -596,8 +601,9 @@ func TestGetInstanceTypeFromVMSize(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			g := NewWithT(t)
 			result := GetInstanceTypeFromVMSize(c.vmSize, possibleInstanceTypes)
-			assert.Equal(t, c.expectedInstanceType, result)
+			g.Expect(result).To(Equal(c.expectedInstanceType))
 		})
 	}
 }

--- a/pkg/providers/labels/labels_test.go
+++ b/pkg/providers/labels/labels_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/labels"
 	"github.com/awslabs/operatorpkg/status"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -80,8 +80,9 @@ func TestGetAllSingleValuedRequirementLabels(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			g := NewWithT(t)
 			labels := labels.GetAllSingleValuedRequirementLabels(c.requirements)
-			assert.Equal(t, c.expectedLabels, labels)
+			g.Expect(labels).To(Equal(c.expectedLabels))
 		})
 	}
 }
@@ -158,8 +159,9 @@ func TestGetWellKnownSingleValuedRequirementLabels(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			g := NewWithT(t)
 			labels := labels.GetWellKnownSingleValuedRequirementLabels(c.requirements)
-			assert.Equal(t, c.expectedLabels, labels)
+			g.Expect(labels).To(Equal(c.expectedLabels))
 		})
 	}
 }
@@ -234,8 +236,9 @@ func TestIsKubeletLabel(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			g := NewWithT(t)
 			result := labels.IsKubeletLabel(c.label)
-			assert.Equal(t, c.expectedKubelet, result)
+			g.Expect(result).To(Equal(c.expectedKubelet))
 		})
 	}
 }
@@ -313,6 +316,7 @@ func TestLocalDNSLabels(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctx := options.ToContext(context.Background(), &options.Options{
 				NodeResourceGroup:       "test-rg",
 				KubeletIdentityClientID: "test-client-id",
@@ -338,13 +342,14 @@ func TestLocalDNSLabels(t *testing.T) {
 			}
 
 			labelMap, err := labels.Get(ctx, nodeClass)
-			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedLabel, labelMap[labels.AKSLocalDNSStateLabelKey])
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(labelMap[labels.AKSLocalDNSStateLabelKey]).To(Equal(tc.expectedLabel))
 		})
 	}
 }
 
 func TestDoNotSyncTaintsLabel(t *testing.T) {
+	g := NewWithT(t)
 	ctx := options.ToContext(context.Background(), &options.Options{
 		NodeResourceGroup:       "test-rg",
 		KubeletIdentityClientID: "test-client-id",
@@ -367,6 +372,6 @@ func TestDoNotSyncTaintsLabel(t *testing.T) {
 	}
 
 	labelMap, err := labels.Get(ctx, nodeClass)
-	assert.NoError(t, err)
-	assert.Equal(t, "true", labelMap[karpv1.NodeDoNotSyncTaintsLabelKey])
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(labelMap[karpv1.NodeDoNotSyncTaintsLabelKey]).To(Equal("true"))
 }

--- a/pkg/utils/gpu_test.go
+++ b/pkg/utils/gpu_test.go
@@ -19,11 +19,10 @@ package utils
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/gomega"
 )
 
 func TestGetAKSGPUImageSHA(t *testing.T) {
-	assert := assert.New(t)
 	tests := []struct {
 		name          string
 		size          string
@@ -41,14 +40,14 @@ func TestGetAKSGPUImageSHA(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(test.gpuDriverSha, GetAKSGPUImageSHA(test.size), "Failed for size: %s", test.size)
-			assert.Equal(test.gpuDriverType, GetGPUDriverType(test.size), "Failed for size: %s", test.size)
+			g := NewWithT(t)
+			g.Expect(GetAKSGPUImageSHA(test.size)).To(Equal(test.gpuDriverSha), "Failed for size: %s", test.size)
+			g.Expect(GetGPUDriverType(test.size)).To(Equal(test.gpuDriverType), "Failed for size: %s", test.size)
 		})
 	}
 }
 
 func TestGetGPUDriverVersion(t *testing.T) {
-	assert := assert.New(t)
 	tests := []struct {
 		name   string
 		size   string
@@ -64,14 +63,14 @@ func TestGetGPUDriverVersion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
 			result := GetGPUDriverVersion(test.size)
-			assert.Equal(test.output, result, "Failed for size: %s", test.size)
+			g.Expect(result).To(Equal(test.output), "Failed for size: %s", test.size)
 		})
 	}
 }
 
 func TestIsNvidiaEnabledSKU(t *testing.T) {
-	assert := assert.New(t)
 	tests := []struct {
 		name   string
 		input  string
@@ -88,14 +87,14 @@ func TestIsNvidiaEnabledSKU(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
 			result := IsNvidiaEnabledSKU(test.input)
-			assert.Equal(test.output, result, "Failed for input: %s", test.input)
+			g.Expect(result).To(Equal(test.output), "Failed for input: %s", test.input)
 		})
 	}
 }
 
 func TestIsMarinerEnabledGPUSKU(t *testing.T) {
-	assert := assert.New(t)
 	tests := []struct {
 		name   string
 		input  string
@@ -112,8 +111,9 @@ func TestIsMarinerEnabledGPUSKU(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
 			result := IsMarinerEnabledGPUSKU(test.input)
-			assert.Equal(test.output, result, "Failed for input: %s", test.input)
+			g.Expect(result).To(Equal(test.output), "Failed for input: %s", test.input)
 		})
 	}
 }

--- a/pkg/utils/zone_test.go
+++ b/pkg/utils/zone_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/gomega"
 )
 
 func TestMakeAKSLabelZoneFromVM(t *testing.T) {
@@ -74,13 +74,14 @@ func TestMakeAKSLabelZoneFromVM(t *testing.T) {
 	}
 
 	for _, c := range tc {
+		g := NewWithT(t)
 		zone, err := utils.MakeAKSLabelZoneFromVM(c.input)
-		assert.Equal(t, c.expectedZone, zone, c.testName)
+		g.Expect(zone).To(Equal(c.expectedZone), c.testName)
 		if err == nil && c.expectedError != "" {
-			assert.Fail(t, "expected error but got nil", c.testName)
+			g.Expect(err).To(HaveOccurred(), c.testName)
 		}
 		if err != nil {
-			assert.Equal(t, c.expectedError, err.Error(), c.testName)
+			g.Expect(err.Error()).To(Equal(c.expectedError), c.testName)
 		}
 	}
 }


### PR DESCRIPTION
Always thought it was strange that we used 2 assertion packages across our tests. Fixing it.

**How was this change tested?**

* Unit tests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
