### PR TITLE
fix: improve error message for cases where we cannot read the subnet

### DIFF
--- a/pkg/controllers/nodeclass/status/subnet.go
+++ b/pkg/controllers/nodeclass/status/subnet.go
@@ -44,9 +44,9 @@ func NewSubnetReconciler(subnetClient instance.SubnetsAPI) *SubnetReconciler {
 }
 
 const (
-	SubnetUnreadyReasonNotFound = "SubnetNotFound"
-
-	SubnetUnreadyReasonIDInvalid = "SubnetIDInvalid"
+	SubnetUnreadyReasonNotFound     = "SubnetNotFound"
+	SubnetUnreadyReasonIDInvalid    = "SubnetIDInvalid"
+	SubnetUnreadyReasonUnknownError = "SubnetUnknownError"
 )
 
 const (
@@ -122,6 +122,11 @@ func (r *SubnetReconciler) validateVNETSubnetID(ctx context.Context, nodeClass *
 			)
 			return reconcile.Result{RequeueAfter: time.Minute}, err
 		}
+		nodeClass.StatusConditions().SetFalse(
+			v1beta1.ConditionTypeSubnetsReady,
+			SubnetUnreadyReasonUnknownError,
+			fmt.Sprintf("unknown error getting subnet: %s", err.Error()),
+		)
 		logger.Error(err, "getting subnet failed during reconciliation with unknown error", "error", err.Error())
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
This should make it easier for users to self-diagnose issues with subnet access especially.

**How was this change tested?**

* Unit tests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Improve error message in NodeClass condition when Karpenter is unable to read the subnet for some reason
```
