### PR TITLE
feat: writing compute.aks.billing tag

### DIFF
--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -536,6 +536,7 @@ var _ = Describe("VMInstanceProvider", func() {
 		Expect(err).To(BeNil())
 		tags := vm.Tags
 		Expect(lo.FromPtr(tags[launchtemplate.NodePoolTagKey])).To(Equal(nodePool.Name))
+		Expect(lo.FromPtr(tags[launchtemplate.BillingTagKey])).To(Equal("linux"))
 		Expect(lo.PickBy(tags, func(key string, value *string) bool {
 			return strings.Contains(key, "/") // ARM tags can't contain '/'
 		})).To(HaveLen(0))
@@ -545,6 +546,7 @@ var _ = Describe("VMInstanceProvider", func() {
 		Expect(nic).ToNot(BeNil())
 		nicTags := nic.Tags
 		Expect(lo.FromPtr(nicTags[launchtemplate.NodePoolTagKey])).To(Equal(nodePool.Name))
+		Expect(lo.FromPtr(nicTags[launchtemplate.BillingTagKey])).To(Equal("linux"))
 		Expect(lo.PickBy(nicTags, func(key string, value *string) bool {
 			return strings.Contains(key, "/") // ARM tags can't contain '/'
 		})).To(HaveLen(0))
@@ -554,6 +556,7 @@ var _ = Describe("VMInstanceProvider", func() {
 		nodeClass.Spec.Tags = map[string]string{
 			"karpenter.azure.com/cluster": "my-override-cluster",
 			"karpenter.sh/nodepool":       "my-override-nodepool",
+			"compute.aks.billing":         "my-override-billing",
 		}
 		ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 
@@ -568,6 +571,7 @@ var _ = Describe("VMInstanceProvider", func() {
 		tags := vm.Tags
 		Expect(lo.FromPtr(tags[launchtemplate.NodePoolTagKey])).To(Equal(nodePool.Name))
 		Expect(lo.FromPtr(tags[launchtemplate.KarpenterManagedTagKey])).To(Equal(testOptions.ClusterName))
+		Expect(lo.FromPtr(tags[launchtemplate.BillingTagKey])).To(Equal("linux"))
 
 		Expect(azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
 		nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop().Interface
@@ -575,6 +579,7 @@ var _ = Describe("VMInstanceProvider", func() {
 		nicTags := nic.Tags
 		Expect(lo.FromPtr(nicTags[launchtemplate.NodePoolTagKey])).To(Equal(nodePool.Name))
 		Expect(lo.FromPtr(nicTags[launchtemplate.KarpenterManagedTagKey])).To(Equal(testOptions.ClusterName))
+		Expect(lo.FromPtr(nicTags[launchtemplate.BillingTagKey])).To(Equal("linux"))
 	})
 
 	It("should list nic from karpenter provisioning request", func() {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -590,6 +590,7 @@ var _ = Describe("InstanceType Provider", func() {
 				Expect(vm.Tags).To(Equal(map[string]*string{
 					"karpenter.azure.com_test-tag": lo.ToPtr("test-value"),
 					"karpenter.azure.com_cluster":  lo.ToPtr("test-cluster"),
+					"compute.aks.billing":          lo.ToPtr("linux"),
 					"karpenter.sh_nodepool":        lo.ToPtr(nodePool.Name),
 				}))
 
@@ -598,6 +599,7 @@ var _ = Describe("InstanceType Provider", func() {
 				Expect(nic.Interface.Tags).To(Equal(map[string]*string{
 					"karpenter.azure.com_test-tag": lo.ToPtr("test-value"),
 					"karpenter.azure.com_cluster":  lo.ToPtr("test-cluster"),
+					"compute.aks.billing":          lo.ToPtr("linux"),
 					"karpenter.sh_nodepool":        lo.ToPtr(nodePool.Name),
 				}))
 			})

--- a/pkg/providers/launchtemplate/tags.go
+++ b/pkg/providers/launchtemplate/tags.go
@@ -29,6 +29,8 @@ import (
 const (
 	KarpenterManagedTagKey             = "karpenter.azure.com_cluster"
 	KarpenterAKSMachineNodeClaimTagKey = "karpenter.azure.com_aksmachine_nodeclaim"
+	BillingTagKey                      = "compute.aks.billing"
+	BillingTagValueLinux               = "linux"
 )
 
 var (
@@ -44,6 +46,7 @@ func Tags(
 ) map[string]*string {
 	defaultTags := map[string]string{
 		KarpenterManagedTagKey: options.ClusterName,
+		BillingTagKey:          BillingTagValueLinux,
 	}
 	// Note: Be careful depending on nodeClaim.Labels here, as we assign some additional labels during the creation
 	// of the static parameters for the launch template. Those labels haven't actually been applied to the nodeClaim yet,


### PR DESCRIPTION
* Add inplace update consideration of default tags (which was missed before). NOTE: This will trigger a PATCH of all existing VMs tags when it rolls out.
* Adds new compute.aks.billing tag to default tags.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add new compute.aks.billing tag to all provisioned VMs and other resources (NICs, etc)
```
