### PR TITLE
 chore: fix issue with ko during build+publish step

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -22,7 +22,8 @@ runs:
         path: |
           /usr/local/kubebuilder/bin
           ~/go/bin
-        key: ${{ runner.os }}-${{ inputs.k8sVersion }}-toolchain-cache-${{ hashFiles('hack/toolchain.sh') }}
+        # Include runner.environment in key because ~/go/bin expands differently on github-hosted vs self-hosted runners
+        key: ${{ runner.os }}-${{ runner.environment }}-${{ inputs.k8sVersion }}-toolchain-cache-${{ hashFiles('hack/toolchain.sh') }}
     - if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
       shell: bash
       env:
@@ -44,3 +45,19 @@ runs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu gcc-x86-64-linux-gnu
         fi
+    # Log environment setup (useful for debugging)
+    - shell: bash
+      run: |
+        echo "=== Environment ==="
+        echo "HOME: $HOME"
+        echo "GOPATH: $(go env GOPATH)"
+        echo "PATH: $PATH"
+        echo ""
+        echo "=== Contents of $HOME/go/bin ==="
+        ls -la "$HOME/go/bin" || echo "$HOME/go/bin does not exist"
+        echo ""
+        echo "=== Contents of \$(go env GOPATH)/bin ==="
+        ls -la "$(go env GOPATH)/bin" || echo "\$(go env GOPATH)/bin does not exist"
+        echo ""
+        echo "=== Go version ==="
+        go version

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -34,25 +34,6 @@ jobs:
 
     - uses: ./.github/actions/install-deps
 
-    - name: Debug toolchain (ko not found issue)
-      run: |
-        echo "=== Environment ==="
-        echo "HOME: $HOME"
-        echo "GOPATH: $(go env GOPATH)"
-        echo "PATH: $PATH"
-        echo ""
-        echo "=== Contents of $HOME/go/bin ==="
-        ls -la "$HOME/go/bin" || echo "$HOME/go/bin does not exist"
-        echo ""
-        echo "=== Contents of \$(go env GOPATH)/bin ==="
-        ls -la "$(go env GOPATH)/bin" || echo "\$(go env GOPATH)/bin does not exist"
-        echo ""
-        echo "=== Which ko ==="
-        which ko || echo "ko not found in PATH"
-        echo ""
-        echo "=== Go version ==="
-        go version
-
     - name: Build and publish image
       env:
         RELEASE_ACR: ${{ secrets.AZURE_REGISTRY }}


### PR DESCRIPTION
Update the build cache to be different for the different runners

The 1ES runner has this env:
=== Environment ===
HOME: /home/cloudtest
GOPATH: /home/cloudtest/go
PATH: /home/cloudtest/go/bin:/opt/hostedtoolcache/go/1.25.7/x64/bin:/snap/bin:/home/cloudtest/.local/bin:/opt/pipx_bin:/home/cloudtest/.cargo/bin:/home/cloudtest/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/cloudtest/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin

The GitHub runner has this env:
=== Environment ===
HOME: /home/runner
GOPATH: /home/runner/go
PATH: /home/runner/go/bin:/opt/hostedtoolcache/go/1.25.7/x64/bin:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin

The different HOME and GOPATH paths means that the cache from one doesn't work on the other.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
