### PR TITLE
fix: pass CSE_TIMEOUT to CSE provision_start.sh

### DIFF
--- a/pkg/providers/imagefamily/bootstrap/cse_cmd.sh.gtpl
+++ b/pkg/providers/imagefamily/bootstrap/cse_cmd.sh.gtpl
@@ -148,4 +148,5 @@ IS_KATA="{{.IsKata}}"
 MCR_REPOSITORY_BASE="mcr.microsoft.com"
 ENABLE_IMDS_RESTRICTION=false
 INSERT_IMDS_RESTRICTION_RULE_TO_MANGLE_TABLE=false
+CSE_TIMEOUT=15m
 /usr/bin/nohup /bin/bash -c "/bin/bash /opt/azure/containers/provision_start.sh"


### PR DESCRIPTION
**How was this change tested?**

* Unit tests
* E2E
* Manual test

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix issue where nodes would not start/join, due to kubelet not launching in OSS Karpenter.
```
