### PR TITLE
test: add machine tests

### DIFF
--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -45,6 +45,7 @@ jobs:
           - InPlaceUpdate
           - Integration
           - KubernetesUpgrade
+          - Machine
           - NewSKUs
           - NodeClaim
           - Scheduling

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -45,6 +45,7 @@ on:
           - InPlaceUpdate
           - Integration
           - KubernetesUpgrade
+          - Machine
           - NewSKUs
           - NodeClaim
           - Scheduling
@@ -225,7 +226,7 @@ jobs:
           location: ${{ inputs.location }}
           k8s_version: ${{ inputs.k8s_version }}
           provision_mode: ${{ inputs.provision_mode }}
-          identity_type: ${{ inputs.suite == 'Machines' && 'UserAssigned' || 'SystemAssigned' }}
+          identity_type: ${{ inputs.suite == 'Machine' && 'UserAssigned' || 'SystemAssigned' }}
           azure_vm_size: ${{ inputs.azure_vm_size }}
       - name: install karpenter
         uses: ./.github/actions/e2e/install-karpenter

--- a/pkg/providers/instance/aksmachineinstance.go
+++ b/pkg/providers/instance/aksmachineinstance.go
@@ -404,6 +404,7 @@ func (p *DefaultAKSMachineProvider) deleteMachine(ctx context.Context, aksMachin
 		p.deletingMachinesMu.Unlock()
 	}()
 
+	log.FromContext(ctx).V(1).Info("starting to delete AKS machine", "aksMachineName", aksMachineName)
 	poller, err := p.azClient.AgentPoolsClient().BeginDeleteMachines(ctx, p.clusterResourceGroup, p.clusterName, p.aksMachinesPoolName, aksMachines, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin delete AKS machine %q: %w", aksMachineName, err)

--- a/test/pkg/environment/azure/environment.go
+++ b/test/pkg/environment/azure/environment.go
@@ -166,7 +166,10 @@ func NewEnvironment(t *testing.T) *Environment {
 	azureEnv.KeyVaultClient = lo.Must(armkeyvault.NewVaultsClient(azureEnv.SubscriptionID, cred, byokRetryOptions))
 	azureEnv.DiskEncryptionSetClient = lo.Must(armcompute.NewDiskEncryptionSetsClient(azureEnv.SubscriptionID, cred, byokRetryOptions))
 	azureEnv.RBACManager = lo.Must(NewRBACManager(azureEnv.SubscriptionID, cred))
-	// If ProvisionMode wasn't set, default to scriptless
+	// If ProvisionMode wasn't set, default to scriptless, though note that this is
+	// actually defaulted dynamically based on the value of a toggle in AKS which means
+	// assuming we're always in ProvisionMode Scriptless here is incorrect at times, though OK
+	// for our current usage.
 	if azureEnv.ProvisionMode == "" {
 		azureEnv.ProvisionMode = consts.ProvisionModeAKSScriptless
 	}
@@ -175,11 +178,9 @@ func NewEnvironment(t *testing.T) *Environment {
 	if azureEnv.InClusterController {
 		azureEnv.MachineAgentPoolName = "testmpool"
 	}
-	// Create our BYO testing Machine Pool, if running self-hosted, with machine mode specified
-	// > Note: this only has to occur once per test, since its just a container for the machines
-	// > meaning that there is no risk of the tests modifying the Machine Pool itself.
+	// Confirm we have a machine pool
 	if azureEnv.InClusterController && azureEnv.IsMachineMode() {
-		azureEnv.ExpectRunInClusterControllerWithMachineMode()
+		azureEnv.ExpectMachinesAgentPoolExists()
 	}
 	return azureEnv
 }
@@ -206,8 +207,21 @@ func (env *Environment) ClientOptionsForRBACPropagation() *arm.ClientOptions {
 	}
 }
 
+// IsMachineMode determines if the test is running in machine mode or not.
+// NOTE: This check is imperfect, because we don't currently set the mode (machine or otherwise) when running the tests with
+// an an out-of-cluster controller, because we don't actually know what mode is configured for the out of cluster controller.
 func (env *Environment) IsMachineMode() bool {
 	return env.ProvisionMode == consts.ProvisionModeAKSMachineAPI
+}
+
+func (env *Environment) IsMachineModeOrNPS() bool {
+	// Assumption is if we're not in the cluster, we're in NPS mode. Ideally we would just check this via ProvisionMode, but
+	// we can't do that right now as depending on context we may not set provision mode for the tests
+	return env.ProvisionMode == consts.ProvisionModeAKSMachineAPI || !env.InClusterController
+}
+
+func (env *Environment) UsesSharedImageGallery() bool {
+	return env.IsMachineModeOrNPS()
 }
 
 func (env *Environment) DefaultAKSNodeClass() *v1beta1.AKSNodeClass {

--- a/test/pkg/environment/azure/expectations.go
+++ b/test/pkg/environment/azure/expectations.go
@@ -27,6 +27,7 @@ import (
 	"github.com/samber/lo"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	containerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
@@ -34,15 +35,6 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 )
-
-// ExpectRunInClusterControllerWithMachineMode confirms that the cluster has a Machine AgentPool created for it
-func (env *Environment) ExpectRunInClusterControllerWithMachineMode() *containerservice.AgentPool {
-	GinkgoHelper()
-	Expect(env.InClusterController).To(BeTrue(), "Should only create a byo Machine Pool when running as an InClusterController")
-	By("Setup BYO Machine AgentPool for self-hosted testing")
-	byoMachineAP := env.ExpectMachinesAgentPoolExists()
-	return byoMachineAP
-}
 
 func (env *Environment) EventuallyExpectKarpenterNicsToBeDeleted() {
 	GinkgoHelper()
@@ -85,6 +77,25 @@ func (env *Environment) ExpectCreatedInterface(networkInterface armnetwork.Inter
 	})
 }
 
+func (env *Environment) ExpectGetManagedCluster() *containerservice.ManagedCluster {
+	GinkgoHelper()
+	managedClusterResponse, err := env.managedClusterClient.Get(env.Context, env.ClusterResourceGroup, env.ClusterName, nil)
+	Expect(err).ToNot(HaveOccurred())
+	return &managedClusterResponse.ManagedCluster
+}
+
+// ExpectClusterProvisioningState checks that the cluster's provisioning state matches the expected state,
+// and fails the test if it does not.
+func (env *Environment) ExpectClusterProvisioningState(expectedProvisioningState string) *containerservice.ManagedCluster {
+	GinkgoHelper()
+	managedCluster := env.ExpectGetManagedCluster()
+	Expect(managedCluster.Properties).ToNot(BeNil())
+	Expect(managedCluster.Properties.ProvisioningState).ToNot(BeNil())
+	Expect(*managedCluster.Properties.ProvisioningState).To(Equal(expectedProvisioningState),
+		fmt.Sprintf("expected cluster provisioning state '%s', got '%s'", expectedProvisioningState, *managedCluster.Properties.ProvisioningState))
+	return managedCluster
+}
+
 func (env *Environment) ExpectSuccessfulGetOfAvailableKubernetesVersionUpgradesForManagedCluster() []*containerservice.ManagedClusterPoolUpgradeProfileUpgradesItem {
 	GinkgoHelper()
 	upgradeProfile, err := env.managedClusterClient.GetUpgradeProfile(env.Context, env.ClusterResourceGroup, env.ClusterName, nil)
@@ -92,22 +103,26 @@ func (env *Environment) ExpectSuccessfulGetOfAvailableKubernetesVersionUpgradesF
 	return upgradeProfile.Properties.ControlPlaneProfile.Upgrades
 }
 
-func (env *Environment) ExpectSuccessfulUpgradeOfManagedCluster(kubernetesUpgradeVersion string) containerservice.ManagedCluster {
+func (env *Environment) ExpectSuccessfulUpgradeOfManagedCluster(kubernetesUpgradeVersion string) *containerservice.ManagedCluster {
 	GinkgoHelper()
-	managedClusterResponse, err := env.managedClusterClient.Get(env.Context, env.ClusterResourceGroup, env.ClusterName, nil)
+	poller := env.ExpectUpgradeOfManagedCluster(kubernetesUpgradeVersion)
+	resp, err := poller.PollUntilDone(env.Context, nil)
 	Expect(err).ToNot(HaveOccurred())
-	managedCluster := managedClusterResponse.ManagedCluster
+	return &resp.ManagedCluster
+}
+
+func (env *Environment) ExpectUpgradeOfManagedCluster(kubernetesUpgradeVersion string) *runtime.Poller[containerservice.ManagedClustersClientCreateOrUpdateResponse] {
+	GinkgoHelper()
+	managedCluster := env.ExpectGetManagedCluster()
 
 	// See documentation for KubernetesVersion (client specified) and CurrentKubernetesVersion (version under use):
 	// https://learn.microsoft.com/en-us/rest/api/aks/managed-clusters/get?view=rest-aks-2025-01-01&tabs=HTTP
 	By(fmt.Sprintf("upgrading from kubernetes version %s to kubernetes version %s", *managedCluster.Properties.CurrentKubernetesVersion, kubernetesUpgradeVersion))
 	managedCluster.Properties.KubernetesVersion = &kubernetesUpgradeVersion
 	// Note that this is an update not a create so we don't need to add it to the tracker
-	poller, err := env.managedClusterClient.BeginCreateOrUpdate(env.Context, env.ClusterResourceGroup, env.ClusterName, managedCluster, nil)
+	poller, err := env.managedClusterClient.BeginCreateOrUpdate(env.Context, env.ClusterResourceGroup, env.ClusterName, *managedCluster, nil)
 	Expect(err).ToNot(HaveOccurred())
-	res, err := poller.PollUntilDone(env.Context, nil)
-	Expect(err).ToNot(HaveOccurred())
-	return res.ManagedCluster
+	return poller
 }
 
 func (env *Environment) ExpectParsedProviderID(providerID string) string {

--- a/test/pkg/environment/azure/expectations_machines.go
+++ b/test/pkg/environment/azure/expectations_machines.go
@@ -17,8 +17,11 @@ limitations under the License.
 package azure
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 
 	containerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
 )
@@ -40,4 +43,22 @@ func (env *Environment) ExpectListMachines() []*containerservice.Machine {
 func (env *Environment) ExpectNoMachines() {
 	GinkgoHelper()
 	Expect(len(env.ExpectListMachines())).To(Equal(0))
+}
+
+func (env *Environment) EventuallyExpectCreatedMachineCount(comparator string, count int) []*containerservice.Machine {
+	GinkgoHelper()
+	By(fmt.Sprintf("waiting for created machines to be %s to %d", comparator, count))
+	var createdMachines []*containerservice.Machine
+	Eventually(func(g Gomega) {
+		createdMachines = env.ExpectListMachines()
+		g.Expect(len(createdMachines)).To(BeNumerically(comparator, count),
+			fmt.Sprintf("expected %d created nodes, had %d (%v)", count, len(createdMachines), MachineNames(createdMachines)))
+	}).Should(Succeed())
+	return createdMachines
+}
+
+func MachineNames(machines []*containerservice.Machine) []string {
+	return lo.Map(machines, func(m *containerservice.Machine, index int) string {
+		return *m.Name
+	})
 }

--- a/test/pkg/environment/azure/identity.go
+++ b/test/pkg/environment/azure/identity.go
@@ -18,12 +18,16 @@ package azure
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	containerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/golang-jwt/jwt/v5"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 )
@@ -64,4 +68,99 @@ func (env *Environment) GetCurrentUserPrincipalID(ctx context.Context, cred azco
 	Expect(oid).ToNot(BeEmpty(), "oid claim is empty")
 
 	return oid
+}
+
+// ExpectCreatedManagedIdentity creates a new user-assigned managed identity
+func (env *Environment) ExpectCreatedManagedIdentity(ctx context.Context, identityName string) *armmsi.Identity {
+	GinkgoHelper()
+	msiClient, err := armmsi.NewUserAssignedIdentitiesClient(env.SubscriptionID, env.GetDefaultCredential(), nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	By(fmt.Sprintf("creating managed identity %s in node resource group %s", identityName, env.NodeResourceGroup))
+
+	identity := armmsi.Identity{
+		Location: to.Ptr(env.Region),
+		Tags: map[string]*string{
+			"test": to.Ptr("karpenter-e2e"),
+		},
+	}
+
+	resp, err := msiClient.CreateOrUpdate(ctx, env.NodeResourceGroup, identityName, identity, nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Note: we don't register for cleanup in the env.tracker, in case there are more tests to run. We don't want to break the cluster by deleting the kubelet identity.
+	// It will get deleted when the node resource group is cleaned up.
+	return &resp.Identity
+}
+
+// ExpectUpdatedManagedClusterKubeletIdentityAsync updates the kubelet identity of a managed cluster asynchronously
+func (env *Environment) ExpectUpdatedManagedClusterKubeletIdentityAsync(ctx context.Context, newIdentity *armmsi.Identity) *runtime.Poller[containerservice.ManagedClustersClientCreateOrUpdateResponse] {
+	GinkgoHelper()
+
+	By("getting current managed cluster configuration")
+	mc := env.ExpectGetManagedCluster()
+
+	By("updating kubelet identity")
+
+	// Update the kubelet identity in the identity profile
+	if mc.Properties.IdentityProfile == nil {
+		mc.Properties.IdentityProfile = make(map[string]*containerservice.UserAssignedIdentity)
+	}
+
+	mc.Properties.IdentityProfile["kubeletidentity"] = &containerservice.UserAssignedIdentity{
+		ClientID:   newIdentity.Properties.ClientID,
+		ObjectID:   newIdentity.Properties.PrincipalID,
+		ResourceID: newIdentity.ID,
+	}
+
+	// Update the cluster and wait for the operation to complete
+	poller, err := env.managedClusterClient.BeginCreateOrUpdate(ctx, env.ClusterResourceGroup, env.ClusterName, *mc, nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	return poller
+}
+
+// ExpectGrantedACRAccess grants the specified identity access to pull from the ACR
+func (env *Environment) ExpectGrantedACRAccess(ctx context.Context, identity *armmsi.Identity) {
+	GinkgoHelper()
+
+	By("granting ACR pull access to identity")
+
+	// Get the ACR resource ID
+	acrResourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerRegistry/registries/%s",
+		env.SubscriptionID, env.ClusterResourceGroup, env.ACRName)
+
+	// AcrPull role definition ID: 7f951dda-4ed3-4680-a7ca-43fe172d538d
+	acrPullRoleID := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/7f951dda-4ed3-4680-a7ca-43fe172d538d", env.SubscriptionID)
+
+	identityPrincipalID := lo.FromPtr(identity.Properties.PrincipalID)
+
+	err := env.RBACManager.EnsureRoleWithPrincipalType(ctx, acrResourceID, acrPullRoleID, identityPrincipalID, "ServicePrincipal")
+	Expect(err).ToNot(HaveOccurred())
+}
+
+// CheckClusterIdentityType returns the type of managed identity used by the cluster
+func (env *Environment) CheckClusterIdentityType(ctx context.Context) string {
+	mc := env.ExpectGetManagedCluster()
+	if mc.Identity == nil {
+		return "none"
+	}
+	if mc.Identity.Type == nil {
+		return "unknown"
+	}
+	return string(*mc.Identity.Type)
+}
+
+// IsClusterUserAssignedIdentity checks if the cluster uses user-assigned managed identity
+func (env *Environment) IsClusterUserAssignedIdentity(ctx context.Context) bool {
+	identityType := env.CheckClusterIdentityType(ctx)
+	return identityType == "UserAssigned"
+}
+
+// GetKubeletIdentity returns the current kubelet identity
+func (env *Environment) GetKubeletIdentity(ctx context.Context) *containerservice.UserAssignedIdentity {
+	mc := env.ExpectGetManagedCluster()
+	Expect(mc.Properties.IdentityProfile).ToNot(BeNil())
+	Expect(mc.Properties.IdentityProfile["kubeletidentity"]).ToNot(BeNil())
+	return mc.Properties.IdentityProfile["kubeletidentity"]
 }

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -731,6 +731,18 @@ func (env *Environment) EventuallyExpectRegisteredNodeClaimCount(comparator stri
 	return lo.ToSlicePtr(nodeClaimList.Items)
 }
 
+func (env *Environment) EventuallyExpectRegisteredNodeClaimCountWithSelector(comparator string, count int, selector labels.Selector) []*karpv1.NodeClaim {
+	GinkgoHelper()
+	By(fmt.Sprintf("waiting for node claims with selector %v to be %s to %d", selector, comparator, count))
+	nodeClaimList := &karpv1.NodeClaimList{}
+	Eventually(func(g Gomega) {
+		g.Expect(env.Client.List(env, nodeClaimList, client.HasLabels{test.DiscoveryLabel}, client.MatchingLabelsSelector{Selector: selector})).To(Succeed())
+		g.Expect(lo.CountBy(nodeClaimList.Items, func(nc karpv1.NodeClaim) bool { return nc.StatusConditions().IsTrue(karpv1.ConditionTypeRegistered) })).To(BeNumerically(comparator, count),
+			fmt.Sprintf("expected %d nodeclaims, had %d (%v)", count, len(nodeClaimList.Items), NodeClaimNames(lo.ToSlicePtr(nodeClaimList.Items))))
+	}).Should(Succeed())
+	return lo.ToSlicePtr(nodeClaimList.Items)
+}
+
 func (env *Environment) EventuallyExpectLaunchedNodeClaimCount(comparator string, count int) []*karpv1.NodeClaim {
 	GinkgoHelper()
 	By(fmt.Sprintf("waiting for node claims to be %s to %d", comparator, count))

--- a/test/suites/byok/suite_test.go
+++ b/test/suites/byok/suite_test.go
@@ -68,6 +68,10 @@ var _ = Describe("BYOK", func() {
 	It("should provision a VM with customer-managed key disk encryption", Label("runner"), func(ctx SpecContext) {
 		var diskEncryptionSetID string
 
+		if env.IsMachineMode() {
+			Skip("Machine mode doesn't use the NODE_OSDISK_DISKENCRYPTIONSET_ID env setting, so overriding it below doesn't do anything and the test will fail")
+		}
+
 		By("Phase 1: Setting up DES (Disk Encryption Set)")
 		if env.InClusterController {
 			diskEncryptionSetID = createKeyVaultAndDiskEncryptionSet(ctx, env)
@@ -117,6 +121,10 @@ var _ = Describe("BYOK", func() {
 
 	It("should provision a VM with ephemeral OS disk and customer-managed key disk encryption", Label("runner"), func(ctx SpecContext) {
 		var diskEncryptionSetID string
+
+		if env.IsMachineMode() {
+			Skip("Machine mode doesn't use the NODE_OSDISK_DISKENCRYPTIONSET_ID env setting, so overriding it below doesn't do anything and the test will fail")
+		}
 
 		By("Phase 1: Setting up DES (Disk Encryption Set)")
 		// If not InClusterController, assume the test setup will include the creation of the KV, KV-Key + DES

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -474,8 +474,8 @@ var _ = Describe("Drift", func() {
 
 	Context("FIPS Drift", func() {
 		BeforeEach(func() {
-			if env.InClusterController {
-				Skip("FIPS drift tests require SIG access - skipping in self-hosted mode")
+			if !env.UsesSharedImageGallery() {
+				Skip("FIPS drift tests require SIG access")
 			}
 		})
 

--- a/test/suites/integration/artifactstreaming_test.go
+++ b/test/suites/integration/artifactstreaming_test.go
@@ -43,7 +43,7 @@ const (
 
 var _ = Describe("ArtifactStreaming", func() {
 	BeforeEach(func() {
-		if env.InClusterController {
+		if !env.IsMachineModeOrNPS() {
 			Skip("ArtifactStreaming tests require NPS (Node Provisioning Service) - only supported in NAP/managed Karpenter mode")
 		}
 	})

--- a/test/suites/integration/localdns_test.go
+++ b/test/suites/integration/localdns_test.go
@@ -97,7 +97,7 @@ var (
 
 var _ = Describe("LocalDNS", func() {
 	BeforeEach(func() {
-		if env.InClusterController {
+		if !env.IsMachineModeOrNPS() {
 			Skip("LocalDNS tests require NPS (Node Provisioning Service) - only supported in NAP/managed Karpenter mode")
 		}
 	})

--- a/test/suites/machine/machine_test.go
+++ b/test/suites/machine/machine_test.go
@@ -1,0 +1,351 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	coretest "sigs.k8s.io/karpenter/pkg/test"
+
+	containerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
+	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
+	"github.com/Azure/karpenter-provider-azure/pkg/test"
+	"github.com/blang/semver/v4"
+	"github.com/samber/lo"
+)
+
+var _ = Describe("Machine Tests", func() {
+	var dep *appsv1.Deployment
+	var selector labels.Selector
+	var numPods int32
+	BeforeEach(func() {
+		numPods = 1
+		// Add pods with a do-not-disrupt annotation so that we can check node metadata before we disrupt
+		dep = coretest.Deployment(coretest.DeploymentOptions{
+			Replicas: numPods,
+			PodOptions: coretest.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "my-app",
+					},
+					Annotations: map[string]string{
+						karpv1.DoNotDisruptAnnotationKey: "true",
+					},
+				},
+				// Each node has 8 cpus, so should fit 2 pods.
+				ResourceRequirements: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("3"),
+					},
+				},
+				TerminationGracePeriodSeconds: lo.ToPtr[int64](0),
+			},
+		})
+		selector = labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
+	})
+
+	It("should have networking labels applied by machine api", func() {
+		// Check if networking settings are compatible with this test
+		// NETWORK_PLUGIN_MODE must be overlay, but NETWORK_PLUGIN and NETWORK_DATAPLANE
+		// can be unset (using defaults) or set to expected values (but not set to different values)
+		settings := env.ExpectSettings()
+
+		// Helper function to check if env var is unset or set to expected value
+		checkEnvVar := func(envName, expectedValue string) bool {
+			for _, env := range settings {
+				if env.Name == envName {
+					return env.Value == expectedValue
+				}
+			}
+			return true // Not set is acceptable
+		}
+
+		usingCompatiblePlugin := checkEnvVar("NETWORK_PLUGIN", consts.NetworkPluginAzure)
+		usingExpectedPluginMode := lo.Contains(settings, corev1.EnvVar{Name: "NETWORK_PLUGIN_MODE", Value: consts.NetworkPluginModeOverlay})
+		usingCompatibleDataplane := checkEnvVar("NETWORK_DATAPLANE", consts.NetworkDataplaneCilium)
+
+		if !usingCompatiblePlugin || !usingExpectedPluginMode || !usingCompatibleDataplane {
+			Skip("TODO: generalize test for any networking configuration. Skipping as not in expected config for the test")
+		}
+
+		env.ExpectCreated(nodeClass, nodePool, dep)
+
+		node := env.EventuallyExpectCreatedNodeCount("==", 1)[0]
+		env.EventuallyExpectRegisteredNodeClaimCount("==", 1)
+		env.EventuallyExpectCreatedMachineCount("==", 1)
+		env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+
+		// Check that the node has the expected networking labels
+		Expect(node.Labels).To(HaveKeyWithValue("kubernetes.azure.com/ebpf-dataplane", consts.NetworkDataplaneCilium))
+		Expect(node.Labels).To(HaveKeyWithValue("kubernetes.azure.com/azure-cni-overlay", "true"))
+		Expect(node.Labels).To(HaveKeyWithValue("kubernetes.azure.com/podnetwork-type", consts.NetworkPluginModeOverlay))
+
+		// Note: these labels we only check their keys since the values are dynamic
+		// TODO: improve E2E test to be dynamic, reusing the same provisioning logic we have for labels creation.
+		Expect(lo.Keys(node.Labels)).To(ContainElements([]string{
+			"kubernetes.azure.com/network-subnet",
+			"kubernetes.azure.com/nodenetwork-vnetguid",
+			"kubernetes.azure.com/network-stateless-cni",
+		}))
+	})
+
+	// NOTE: ClusterTests modify the actual cluster itself, which means that performing tests after a cluster test
+	// might not have a clean environment, and might produce unexpected results. Ordering of cluster tests is important.
+	// The cluster modification is safe in CI as each test runs in its own cluster.
+	Context("ClusterTests", func() {
+		BeforeEach(func() {
+			// Add labels to nodepool to ensure pods land on Karpenter nodes
+			nodePool.Spec.Template.Labels = lo.Assign(nodePool.Spec.Template.Labels, map[string]string{
+				"test-name": "karpenter-machine-test",
+			})
+			// Add nodeSelector to deployment to target Karpenter nodes
+			dep.Spec.Template.Spec.NodeSelector = map[string]string{
+				"test-name": "karpenter-machine-test",
+			}
+		})
+
+		It("use the DriftAction to drift nodes that have had their kubeletidentity updated", func() {
+			// Check if cluster supports custom kubelet identity (requires user-assigned managed identity)
+			if !env.IsClusterUserAssignedIdentity(env.Context) {
+				Skip(fmt.Sprintf("Cluster uses %s identity type, but custom kubelet identity requires UserAssigned identity type",
+					env.CheckClusterIdentityType(env.Context)))
+			}
+
+			numPods = 6
+			dep.Spec.Replicas = &numPods
+			nodePool = coretest.ReplaceRequirements(nodePool,
+				karpv1.NodeSelectorRequirementWithMinValues{
+					Key:      v1beta1.LabelSKUCPU,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{"8"},
+				},
+			)
+			env.ExpectCreated(nodeClass, nodePool, dep)
+
+			nodes := env.EventuallyExpectCreatedNodeCount("==", 3)
+			nodeClaims := env.EventuallyExpectRegisteredNodeClaimCount("==", 3)
+			machines := env.EventuallyExpectCreatedMachineCount("==", 3)
+			pods := env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+
+			for _, machine := range machines {
+				if machine.Properties.Status.DriftAction != nil {
+					Expect(*machine.Properties.Status.DriftAction).ToNot(Equal(containerservice.DriftActionRecreate))
+				}
+			}
+
+			By("getting the original kubelet identity")
+			originalKubeletIdentity := env.GetKubeletIdentity(env.Context)
+
+			By("creating a new managed identity for testing")
+			newIdentityName := test.RandomName("karpenter-test-identity")
+			newIdentity := env.ExpectCreatedManagedIdentity(env.Context, newIdentityName)
+
+			By("granting ACR access to the new kubelet identity")
+			env.ExpectGrantedACRAccess(env.Context, newIdentity)
+
+			By("updating the kubelet identity on the managed cluster")
+			poller := env.ExpectUpdatedManagedClusterKubeletIdentityAsync(env.Context, newIdentity)
+
+			By("verifying the kubelet identity was updated")
+			updatedKubeletIdentity := env.GetKubeletIdentity(env.Context)
+			Expect(updatedKubeletIdentity.ResourceID).To(Equal(newIdentity.ID), "Expected updatedKubeletIdentityResourceID to match new kubelet resource id")
+			Expect(updatedKubeletIdentity.ResourceID).ToNot(Equal(originalKubeletIdentity.ResourceID), "Expected updatedKubeletIdentityResourceID to not match old kubelet resource id")
+
+			By("expect machines to have a DriftAction")
+			Eventually(func(g Gomega) {
+				machines := env.EventuallyExpectCreatedMachineCount("==", 3)
+				for _, machine := range machines {
+					g.Expect(machine.Properties.Status.DriftAction).ToNot(BeNil())
+					g.Expect(*machine.Properties.Status.DriftAction).To(Equal(containerservice.DriftActionRecreate))
+				}
+			}).WithTimeout(3 * time.Minute).Should(Succeed())
+
+			By("expecting nodes to drift")
+			env.EventuallyExpectDriftedWithTimeout(5*time.Minute, nodeClaims...)
+
+			By("remove do-not-disrupt annotation and expect pods to be rescheduled on new nodes")
+			for _, pod := range pods {
+				delete(pod.Annotations, karpv1.DoNotDisruptAnnotationKey)
+				env.ExpectUpdated(pod)
+			}
+			env.EventuallyExpectNotFound(lo.Map(pods, func(p *corev1.Pod, _ int) client.Object { return p })...)
+			env.EventuallyExpectNotFound(lo.Map(nodes, func(n *corev1.Node, _ int) client.Object { return n })...)
+			env.EventuallyExpectNotFound(lo.Map(nodeClaims, func(n *karpv1.NodeClaim, _ int) client.Object { return n })...)
+			env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+			env.EventuallyExpectCreatedNodeCount("==", 3)
+			env.EventuallyExpectRegisteredNodeClaimCount("==", 3)
+			env.EventuallyExpectCreatedMachineCount("==", 3)
+
+			// Make sure to wait til cluster is done updating before proceeding to next test
+			_, err := poller.PollUntilDone(env.Context, nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should be able to scale machines during an ongoing managed cluster operation", func() {
+			// Create two NodePools: one for scale-up, one for scale-down
+			scaleUpNodePool := coretest.ReplaceRequirements(env.DefaultNodePool(nodeClass),
+				karpv1.NodeSelectorRequirementWithMinValues{
+					Key:      v1beta1.LabelSKUCPU,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{"8"},
+				},
+			)
+			scaleUpNodePool.Spec.Template.Labels = lo.Assign(scaleUpNodePool.Spec.Template.Labels, map[string]string{
+				"test-role": "scale-up",
+			})
+
+			scaleDownNodePool := coretest.ReplaceRequirements(env.DefaultNodePool(nodeClass),
+				karpv1.NodeSelectorRequirementWithMinValues{
+					Key:      v1beta1.LabelSKUCPU,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{"8"},
+				},
+			)
+			scaleDownNodePool.Spec.Template.Labels = lo.Assign(scaleDownNodePool.Spec.Template.Labels, map[string]string{
+				"test-role": "scale-down",
+			})
+			scaleDownNodePool.Spec.Disruption.ConsolidateAfter = karpv1.MustParseNillableDuration("0s")
+			// Taint scale-down nodes so that only our scale-down pods (which tolerate this taint) can land here.
+			// Without this, cluster workloads like metrics-server can get scheduled on these nodes and
+			// prevent consolidation after the deployment scales to 0.
+			scaleDownNodePool.Spec.Template.Spec.Taints = append(scaleDownNodePool.Spec.Template.Spec.Taints, corev1.Taint{
+				Key:    "test-role",
+				Value:  "scale-down",
+				Effect: corev1.TaintEffectNoSchedule,
+			})
+
+			// Scale-up deployment: starts at 2 pods, will scale to 4
+			var scaleUpPodCount int32 = 2
+			scaleUpDep := coretest.Deployment(coretest.DeploymentOptions{
+				Replicas: scaleUpPodCount,
+				PodOptions: coretest.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "scale-up"},
+						Annotations: map[string]string{
+							karpv1.DoNotDisruptAnnotationKey: "true",
+						},
+					},
+					NodeSelector: map[string]string{"test-role": "scale-up"},
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("3"),
+						},
+					},
+					TerminationGracePeriodSeconds: lo.ToPtr[int64](0),
+				},
+			})
+			scaleUpSelector := labels.SelectorFromSet(scaleUpDep.Spec.Selector.MatchLabels)
+
+			// Scale-down deployment: starts at 2 pods, will scale to 0
+			var scaleDownPodCount int32 = 2
+			scaleDownDep := coretest.Deployment(coretest.DeploymentOptions{
+				Replicas: scaleDownPodCount,
+				PodOptions: coretest.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "scale-down"},
+						Annotations: map[string]string{
+							karpv1.DoNotDisruptAnnotationKey: "true",
+						},
+					},
+					NodeSelector: map[string]string{"test-role": "scale-down"},
+					Tolerations: []corev1.Toleration{{
+						Key:      "test-role",
+						Value:    "scale-down",
+						Operator: corev1.TolerationOpEqual,
+						Effect:   corev1.TaintEffectNoSchedule,
+					}},
+					ResourceRequirements: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("3"),
+						},
+					},
+					TerminationGracePeriodSeconds: lo.ToPtr[int64](0),
+				},
+			})
+			scaleDownSelector := labels.SelectorFromSet(scaleDownDep.Spec.Selector.MatchLabels)
+
+			scaleUpNodeSelector := labels.SelectorFromSet(map[string]string{"test-role": "scale-up"})
+			scaleDownNodeSelector := labels.SelectorFromSet(map[string]string{"test-role": "scale-down"})
+
+			env.ExpectCreated(nodeClass, scaleUpNodePool, scaleDownNodePool, scaleUpDep, scaleDownDep)
+
+			env.EventuallyExpectNodeCountWithSelector("==", 1, scaleUpNodeSelector)
+			env.EventuallyExpectNodeCountWithSelector("==", 1, scaleDownNodeSelector)
+			env.EventuallyExpectRegisteredNodeClaimCountWithSelector("==", 1, scaleUpNodeSelector)
+			env.EventuallyExpectRegisteredNodeClaimCountWithSelector("==", 1, scaleDownNodeSelector)
+			env.EventuallyExpectCreatedMachineCount("==", 2)
+			env.EventuallyExpectHealthyPodCount(scaleUpSelector, int(scaleUpPodCount))
+			env.EventuallyExpectHealthyPodCount(scaleDownSelector, int(scaleDownPodCount))
+
+			By("Performing a K8s upgrade")
+			availableKubernetesUpgrades := env.ExpectSuccessfulGetOfAvailableKubernetesVersionUpgradesForManagedCluster()
+			kubernetesUpgradeVersion := *lo.MaxBy(availableKubernetesUpgrades, func(a, b *containerservice.ManagedClusterPoolUpgradeProfileUpgradesItem) bool {
+				aK8sVersion := lo.Must(semver.Parse(*a.KubernetesVersion))
+				bK8sVersion := lo.Must(semver.Parse(*b.KubernetesVersion))
+				return aK8sVersion.GT(bK8sVersion)
+			}).KubernetesVersion
+
+			poller := env.ExpectUpgradeOfManagedCluster(kubernetesUpgradeVersion)
+
+			By("Scaling up the scale-up deployment to create new nodes")
+			scaleUpPodCount = 4
+			scaleUpDep.Spec.Replicas = &scaleUpPodCount
+			env.ExpectUpdated(scaleUpDep)
+
+			By("Scaling down the scale-down deployment to 0")
+			scaleDownPodCount = 0
+			scaleDownDep.Spec.Replicas = &scaleDownPodCount
+			env.ExpectUpdated(scaleDownDep)
+
+			env.EventuallyExpectNodeCountWithSelector("==", 2, scaleUpNodeSelector)
+			env.EventuallyExpectNodeCountWithSelector("==", 0, scaleDownNodeSelector)
+			env.EventuallyExpectRegisteredNodeClaimCountWithSelector("==", 2, scaleUpNodeSelector)
+			env.EventuallyExpectRegisteredNodeClaimCountWithSelector("==", 0, scaleDownNodeSelector)
+			env.EventuallyExpectCreatedMachineCount("==", 2)
+			env.EventuallyExpectHealthyPodCount(scaleUpSelector, int(scaleUpPodCount))
+			env.EventuallyExpectHealthyPodCount(scaleDownSelector, int(scaleDownPodCount))
+
+			env.ExpectClusterProvisioningState("Upgrading")
+
+			By("Removing do-not-disrupt annotations to allow Karpenter to update the nodes the pods are on")
+			scaleUpPods := env.ExpectPodsMatchingSelector(scaleUpSelector)
+			for _, pod := range scaleUpPods {
+				delete(pod.Annotations, karpv1.DoNotDisruptAnnotationKey)
+				env.ExpectUpdated(pod)
+			}
+
+			By("Waiting for cluster upgrade to complete")
+			upgradeCtx, cancel := context.WithTimeout(env.Context, 30*time.Minute)
+			defer cancel()
+			_, err := poller.PollUntilDone(upgradeCtx, nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/test/suites/machine/suite_test.go
+++ b/test/suites/machine/suite_test.go
@@ -1,0 +1,61 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine_test
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
+	"github.com/Azure/karpenter-provider-azure/test/pkg/environment/azure"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+)
+
+var env *azure.Environment
+var nodeClass *v1beta1.AKSNodeClass
+var nodePool *karpv1.NodePool
+
+func TestMachine(t *testing.T) {
+	// Check provision mode before running the suite to avoid Ginkgo counting skipped specs as failures.
+	// Using t.Skip() instead of Ginkgo's Skip() because in Ginkgo if you skip all tests in the suite it
+	// counts it as a failure
+	provisionMode := os.Getenv("PROVISION_MODE")
+	if provisionMode != consts.ProvisionModeAKSMachineAPI {
+		t.Skipf("Skipping machine suite: provision mode %q is not %s", provisionMode, consts.ProvisionModeAKSMachineAPI)
+	}
+
+	RegisterFailHandler(Fail)
+	BeforeSuite(func() {
+		env = azure.NewEnvironment(t)
+	})
+	AfterSuite(func() {
+		env.Stop()
+	})
+	RunSpecs(t, "Machine")
+}
+
+var _ = BeforeEach(func() {
+	env.BeforeEach()
+	nodeClass = env.DefaultAKSNodeClass()
+	nodePool = env.DefaultNodePool(nodeClass)
+})
+var _ = AfterEach(func() { env.Cleanup() })
+var _ = AfterEach(func() { env.AfterEach() })

--- a/test/suites/scheduling/suite_test.go
+++ b/test/suites/scheduling/suite_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 			v1beta1.LabelSKUGPUName,
 		)
 
-		if env.InClusterController {
+		if env.IsMachineModeOrNPS() {
 			// Can't test FIPS on self-hosted Karpenter
 			selectors.Insert(v1beta1.AKSLabelFIPSEnabled)
 		}
@@ -240,7 +240,7 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 		})
 
 		It("should support FIPS label for instance type selection", func() {
-			if env.InClusterController {
+			if !env.UsesSharedImageGallery() {
 				Skip("FIPS tests require SIG access - skipping in self-hosted mode")
 			}
 

--- a/test/suites/utilization/fips_test.go
+++ b/test/suites/utilization/fips_test.go
@@ -37,7 +37,7 @@ import (
 var _ = Describe("FIPS", Label("runner"), func() {
 	Context("FIPS Validation", func() {
 		It("should reject FIPS without SIG access", func() {
-			if !env.InClusterController {
+			if env.UsesSharedImageGallery() {
 				Skip("Testing FIPS usage cleanly fails without SIG access only makes sense in self-hosted mode - NAP has SIG access")
 			}
 
@@ -63,7 +63,7 @@ var _ = Describe("FIPS", Label("runner"), func() {
 
 	Context("FIPS Provisioning", func() {
 		BeforeEach(func() {
-			if env.InClusterController {
+			if !env.UsesSharedImageGallery() {
 				Skip("FIPS tests require SIG access - skipping in self-hosted mode")
 			}
 		})

--- a/test/suites/utilization/suite_test.go
+++ b/test/suites/utilization/suite_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Utilization", func() {
 	)
 
 	It("should provision one pod per node (AzureLinux, arm64)", func() {
-		if imagefamily.UseAzureLinux3(env.K8sVersion()) && env.InClusterController {
+		if imagefamily.UseAzureLinux3(env.K8sVersion()) && env.UsesSharedImageGallery() {
 			Skip("AzureLinux3 ARM64 VHD is not available in CIG")
 		}
 		nc := env.AZLinuxNodeClass()


### PR DESCRIPTION
**Description**
Add machines tests.

This replaces #1212 

**How was this change tested?**

* E2E:
  * https://github.com/Azure/karpenter-provider-azure/actions/runs/24096871443/job/70336988092 - Consolidation failure due to known flake. Integration failure due to not implemented LocalDNS or ArtifactStreaming (impl coming soon)
  * Machine test with updates (different from above pass): https://github.com/Azure/karpenter-provider-azure/actions/runs/24199496818/job/70638881188

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
