### PR TITLE
chore: make actions parameters use _ for separator uniformly

### DIFF
--- a/.github/actions/e2e/cleanup/action.yaml
+++ b/.github/actions/e2e/cleanup/action.yaml
@@ -1,13 +1,13 @@
 name: Cleanup
 description: 'Runs all the cleanup tasks to cleanup resources deployed during E2E'
 inputs:
-  client-id:
+  client_id:
     description: "Client ID"
     required: true
-  tenant-id:
+  tenant_id:
     description: "Tenant ID"
     required: true
-  subscription-id:
+  subscription_id:
     description: "Subscription ID"
     required: true
   # region:
@@ -34,13 +34,13 @@ runs:
     - name: az login
       uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
       with:
-        client-id: ${{ inputs.client-id }}
-        tenant-id: ${{ inputs.tenant-id }}
-        subscription-id: ${{ inputs.subscription-id }}
+        client-id: ${{ inputs.client_id }}
+        tenant-id: ${{ inputs.tenant_id }}
+        subscription-id: ${{ inputs.subscription_id }}
     - name: az set sub
       shell: bash
       env:
-        SUBSCRIPTION_ID: ${{ inputs.subscription-id }}
+        SUBSCRIPTION_ID: ${{ inputs.subscription_id }}
       run: az account set --subscription "$SUBSCRIPTION_ID"
     - name: delete cluster
       shell: bash

--- a/.github/actions/e2e/create-acr/action.yaml
+++ b/.github/actions/e2e/create-acr/action.yaml
@@ -1,13 +1,13 @@
 name: CreateACR
 description: 'Creates ACR'
 inputs:
-  client-id:
+  client_id:
     description: "Client ID"
     required: true
-  tenant-id:
+  tenant_id:
     description: "Tenant ID"
     required: true
-  subscription-id:
+  subscription_id:
     description: "Subscription ID"
     required: true
   resource_group:
@@ -31,13 +31,13 @@ runs:
   - name: az login
     uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
     with:
-      client-id: ${{ inputs.client-id }}
-      tenant-id: ${{ inputs.tenant-id }}
-      subscription-id: ${{ inputs.subscription-id }}
+      client-id: ${{ inputs.client_id }}
+      tenant-id: ${{ inputs.tenant_id }}
+      subscription-id: ${{ inputs.subscription_id }}
   - name: az set sub
     shell: bash
     env:
-      SUBSCRIPTION_ID: ${{ inputs.subscription-id }}
+      SUBSCRIPTION_ID: ${{ inputs.subscription_id }}
     run: az account set --subscription "$SUBSCRIPTION_ID"
   - name: create ACR
     shell: bash

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -4,13 +4,13 @@ inputs:
   k8s_version:
     description: "Version of Kubernetes to use for the launched cluster (e.g., 1.30). If empty, uses AKS default."
     required: false
-  client-id:
+  client_id:
     description: "ID of the client to create the cluster with"
     required: true
-  tenant-id:
+  tenant_id:
     description: "ID of the tenant to create the cluster in"
     required: true
-  subscription-id:
+  subscription_id:
     description: "ID of the subscription to create the cluster in"
     required: true
   resource_group:
@@ -37,13 +37,13 @@ runs:
     - name: az login
       uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
       with:
-        client-id: ${{ inputs.client-id }}
-        tenant-id: ${{ inputs.tenant-id }}
-        subscription-id: ${{ inputs.subscription-id }}
+        client-id: ${{ inputs.client_id }}
+        tenant-id: ${{ inputs.tenant_id }}
+        subscription-id: ${{ inputs.subscription_id }}
     - name: az set sub
       shell: bash
       env:
-        SUBSCRIPTION_ID: ${{ inputs.subscription-id }}
+        SUBSCRIPTION_ID: ${{ inputs.subscription_id }}
       run: az account set --subscription "$SUBSCRIPTION_ID"
     - name: create workload msi
       shell: bash
@@ -64,9 +64,9 @@ runs:
     - name: az login 2
       uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
       with:
-        client-id: ${{ inputs.client-id }}
-        tenant-id: ${{ inputs.tenant-id }}
-        subscription-id: ${{ inputs.subscription-id }}
+        client-id: ${{ inputs.client_id }}
+        tenant-id: ${{ inputs.tenant_id }}
+        subscription-id: ${{ inputs.subscription_id }}
     - name: create federated cred
       shell: bash
       env:

--- a/.github/actions/e2e/dump-logs/action.yaml
+++ b/.github/actions/e2e/dump-logs/action.yaml
@@ -1,13 +1,13 @@
 name: DumpLogs
 description: 'Dump logs and debug information from the cluster after a test run'
 inputs:
-  client-id:
+  client_id:
     description: "Client ID"
     required: true
-  tenant-id:
+  tenant_id:
     description: "Tenant ID"
     required: true
-  subscription-id:
+  subscription_id:
     description: "Subscription ID"
     required: true
   resource_group:
@@ -28,9 +28,9 @@ runs:
   - name: az login
     uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
     with:
-      client-id: ${{ inputs.client-id }}
-      tenant-id: ${{ inputs.tenant-id }}
-      subscription-id: ${{ inputs.subscription-id }}
+      client-id: ${{ inputs.client_id }}
+      tenant-id: ${{ inputs.tenant_id }}
+      subscription-id: ${{ inputs.subscription_id }}
   - name: update cluster context
     shell: bash
     env:

--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -1,13 +1,13 @@
 name: InstallKarpenter
 description: 'Installs Karpenter on the aks cluster'
 inputs:
-  client-id:
+  client_id:
     description: "ID of the client to install Karpenter with"
     required: true
-  tenant-id:
+  tenant_id:
     description: "ID of the tenant containing the cluster to install Karpenter into"
     required: true
-  subscription-id:
+  subscription_id:
     description: "ID of the subscription containing the cluster to install Karpenter into"
     required: true
   # region:
@@ -40,13 +40,13 @@ runs:
   - name: az login
     uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
     with:
-      client-id: ${{ inputs.client-id }}
-      tenant-id: ${{ inputs.tenant-id }}
-      subscription-id: ${{ inputs.subscription-id }}
+      client-id: ${{ inputs.client_id }}
+      tenant-id: ${{ inputs.tenant_id }}
+      subscription-id: ${{ inputs.subscription_id }}
   - name: az set sub
     shell: bash
     env:
-      SUBSCRIPTION_ID: ${{ inputs.subscription-id }}
+      SUBSCRIPTION_ID: ${{ inputs.subscription_id }}
     run: az account set --subscription "$SUBSCRIPTION_ID"
   - name: configure Helm chart values
     shell: bash

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -176,9 +176,9 @@ jobs:
       - name: create acr '${{ env.ACR_NAME }}'
         uses: ./.github/actions/e2e/create-acr
         with:
-          client-id: ${{ secrets.E2E_CLIENT_ID }}
-          tenant-id: ${{ secrets.E2E_TENANT_ID }}
-          subscription-id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
+          client_id: ${{ secrets.E2E_CLIENT_ID }}
+          tenant_id: ${{ secrets.E2E_TENANT_ID }}
+          subscription_id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
           resource_group: ${{ env.RG_NAME }}
           acr_name: ${{ env.ACR_NAME }}
           git_ref: ${{ inputs.git_ref }}
@@ -195,9 +195,9 @@ jobs:
       - name: create aks cluster '${{ env.CLUSTER_NAME }}'
         uses: ./.github/actions/e2e/create-cluster
         with:
-          client-id: ${{ secrets.E2E_CLIENT_ID }}
-          tenant-id: ${{ secrets.E2E_TENANT_ID }}
-          subscription-id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
+          client_id: ${{ secrets.E2E_CLIENT_ID }}
+          tenant_id: ${{ secrets.E2E_TENANT_ID }}
+          subscription_id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
           resource_group: ${{ env.RG_NAME }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           acr_name: ${{ env.ACR_NAME }}
@@ -212,9 +212,9 @@ jobs:
       - name: install karpenter
         uses: ./.github/actions/e2e/install-karpenter
         with:
-          client-id: ${{ secrets.E2E_CLIENT_ID }}
-          tenant-id: ${{ secrets.E2E_TENANT_ID }}
-          subscription-id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
+          client_id: ${{ secrets.E2E_CLIENT_ID }}
+          tenant_id: ${{ secrets.E2E_TENANT_ID }}
+          subscription_id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
           resource_group: ${{ env.RG_NAME }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           acr_name: ${{ env.ACR_NAME }}
@@ -238,9 +238,9 @@ jobs:
         uses: ./.github/actions/e2e/dump-logs
         if: failure() || cancelled()
         with:
-          client-id: ${{ secrets.E2E_CLIENT_ID }}
-          tenant-id: ${{ secrets.E2E_TENANT_ID }}
-          subscription-id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
+          client_id: ${{ secrets.E2E_CLIENT_ID }}
+          tenant_id: ${{ secrets.E2E_TENANT_ID }}
+          subscription_id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
           resource_group: ${{ env.RG_NAME }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           git_ref: ${{ inputs.git_ref }}
@@ -248,9 +248,9 @@ jobs:
         uses: ./.github/actions/e2e/cleanup
         if: always()
         with:
-          client-id: ${{ secrets.E2E_CLIENT_ID }}
-          tenant-id: ${{ secrets.E2E_TENANT_ID }}
-          subscription-id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
+          client_id: ${{ secrets.E2E_CLIENT_ID }}
+          tenant_id: ${{ secrets.E2E_TENANT_ID }}
+          subscription_id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
           resource_group: ${{ env.RG_NAME }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           acr_name: ${{ env.ACR_NAME }}


### PR DESCRIPTION
**How was this change tested?**

* E2E: https://github.com/Azure/karpenter-provider-azure/actions/runs/22115020482/job/63920784425

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
