### PR TITLE
feat!: restrict kubernetes.azure.com label namespace except for WellKnownLabels

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
@@ -128,6 +128,16 @@ spec:
                             rule: self != "kubernetes.io/hostname"
                           - message: label domain "karpenter.azure.com" is restricted
                             rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count", "karpenter.azure.com/placement-scope" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                          - message: label domain "kubernetes.azure.com" is restricted
+                            rule: self in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/priority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", ] || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+                          - message: label "agentpool" is restricted
+                            rule: self != 'agentpool'
+                          - message: label "storageprofile" is restricted
+                            rule: self != 'storageprofile'
+                          - message: label "storagetier" is restricted
+                            rule: self != 'storagetier'
+                          - message: label "accelerator" is restricted
+                            rule: self != 'accelerator'
                       minValues:
                         description: |-
                           This field is ALPHA and can be dropped or replaced at any time

--- a/charts/karpenter-crd/templates/karpenter.sh_nodeoverlays.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeoverlays.yaml
@@ -101,6 +101,16 @@ spec:
                             rule: self != "kubernetes.io/hostname"
                           - message: label domain "karpenter.azure.com" is restricted
                             rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count", "karpenter.azure.com/placement-scope" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                          - message: label domain "kubernetes.azure.com" is restricted
+                            rule: self in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/priority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", ] || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+                          - message: label "agentpool" is restricted
+                            rule: self != 'agentpool'
+                          - message: label "storageprofile" is restricted
+                            rule: self != 'storageprofile'
+                          - message: label "storagetier" is restricted
+                            rule: self != 'storagetier'
+                          - message: label "accelerator" is restricted
+                            rule: self != 'accelerator'
                       operator:
                         description: |-
                           Represents a key's relationship to a set of values.

--- a/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -224,6 +224,16 @@ spec:
                               rule: self.all(x, x != "kubernetes.io/hostname")
                             - message: label domain "karpenter.azure.com" is restricted
                               rule: self.all(x, x in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count", "karpenter.azure.com/placement-scope" ] || !x.find("^([^/]+)").endsWith("karpenter.azure.com"))
+                            - message: label domain "kubernetes.azure.com" is restricted
+                              rule: self.all(x, x in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/priority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", ] || !x.find("^([^/]+)").endsWith("kubernetes.azure.com"))
+                            - message: label "agentpool" is restricted
+                              rule: self.all(x, x != 'agentpool')
+                            - message: label "storageprofile" is restricted
+                              rule: self.all(x, x != 'storageprofile')
+                            - message: label "storagetier" is restricted
+                              rule: self.all(x, x != 'storagetier')
+                            - message: label "accelerator" is restricted
+                              rule: self.all(x, x != 'accelerator')
                       type: object
                     spec:
                       description: |-
@@ -293,6 +303,16 @@ spec:
                                     rule: self != "kubernetes.io/hostname"
                                   - message: label domain "karpenter.azure.com" is restricted
                                     rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count", "karpenter.azure.com/placement-scope" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                                  - message: label domain "kubernetes.azure.com" is restricted
+                                    rule: self in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/priority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", ] || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+                                  - message: label "agentpool" is restricted
+                                    rule: self != 'agentpool'
+                                  - message: label "storageprofile" is restricted
+                                    rule: self != 'storageprofile'
+                                  - message: label "storagetier" is restricted
+                                    rule: self != 'storagetier'
+                                  - message: label "accelerator" is restricted
+                                    rule: self != 'accelerator'
                               minValues:
                                 description: |-
                                   This field is ALPHA and can be dropped or replaced at any time

--- a/hack/validation/labels.sh
+++ b/hack/validation/labels.sh
@@ -30,10 +30,80 @@ rule=${rule//\"/\\\"}            # escape double quotes
 rule=${rule//$'\n'/}             # remove newlines
 rule=$(echo "$rule" | tr -s ' ') # remove extra spaces
 
+# kubernetes.azure.com domain restriction
+# We allow well-known labels as well as ebpf-dataplane (required for Cilium)
+aks_rule=$'self.all(x, x in
+    [
+        "kubernetes.azure.com/mode",
+        "kubernetes.azure.com/scalesetpriority",
+        "kubernetes.azure.com/priority",
+        "kubernetes.azure.com/fips_enabled",
+        "kubernetes.azure.com/os-sku",
+        "kubernetes.azure.com/cluster",
+        "kubernetes.azure.com/sku-cpu",
+        "kubernetes.azure.com/sku-memory",
+        "kubernetes.azure.com/ebpf-dataplane",
+    ]
+    || !x.find("^([^/]+)").endsWith("kubernetes.azure.com")
+)
+'
+
+aks_rule=${aks_rule//\"/\\\"}            # escape double quotes
+aks_rule=${aks_rule//$'\n'/}             # remove newlines
+aks_rule=$(echo "$aks_rule" | tr -s ' ') # remove extra spaces
+
+# agentpool restriction
+agentpool_rule=$'self.all(x, x != \x27agentpool\x27)'
+
+agentpool_rule=${agentpool_rule//\"/\\\"}            # escape double quotes
+agentpool_rule=${agentpool_rule//$'\n'/}             # remove newlines
+agentpool_rule=$(echo "$agentpool_rule" | tr -s ' ') # remove extra spaces
+
+# storageprofile restriction
+storageprofile_rule=$'self.all(x, x != \x27storageprofile\x27)'
+
+storageprofile_rule=${storageprofile_rule//\"/\\\"}            # escape double quotes
+storageprofile_rule=${storageprofile_rule//$'\n'/}             # remove newlines
+storageprofile_rule=$(echo "$storageprofile_rule" | tr -s ' ') # remove extra spaces
+
+# storagetier restriction
+storagetier_rule=$'self.all(x, x != \x27storagetier\x27)'
+
+storagetier_rule=${storagetier_rule//\"/\\\"}            # escape double quotes
+storagetier_rule=${storagetier_rule//$'\n'/}             # remove newlines
+storagetier_rule=$(echo "$storagetier_rule" | tr -s ' ') # remove extra spaces
+
+# accelerator restriction
+accelerator_rule=$'self.all(x, x != \x27accelerator\x27)'
+
+accelerator_rule=${accelerator_rule//\"/\\\"}            # escape double quotes
+accelerator_rule=${accelerator_rule//$'\n'/}             # remove newlines
+accelerator_rule=$(echo "$accelerator_rule" | tr -s ' ') # remove extra spaces
+
 # check that .spec.versions has 1 entry
 [[ $(yq e '.spec.versions | length' pkg/apis/crds/karpenter.sh_nodepools.yaml) -eq 1 ]] || { echo "expected one version"; exit 1; }
 
 # nodepool
 printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.metadata.properties.labels.x-kubernetes-validations +=
     [{"message": "label domain \\"karpenter.azure.com\\" is restricted", "rule": "%s"}]' "$rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.metadata.properties.labels.x-kubernetes-validations +=
+    [{"message": "label domain \\"kubernetes.azure.com\\" is restricted", "rule": "%s"}]' "$aks_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.metadata.properties.labels.x-kubernetes-validations +=
+    [{"message": "label \\"agentpool\\" is restricted", "rule": "%s"}]' "$agentpool_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.metadata.properties.labels.x-kubernetes-validations +=
+    [{"message": "label \\"storageprofile\\" is restricted", "rule": "%s"}]' "$storageprofile_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.metadata.properties.labels.x-kubernetes-validations +=
+    [{"message": "label \\"storagetier\\" is restricted", "rule": "%s"}]' "$storagetier_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.metadata.properties.labels.x-kubernetes-validations +=
+    [{"message": "label \\"accelerator\\" is restricted", "rule": "%s"}]' "$accelerator_rule"
 yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml

--- a/hack/validation/requirements.sh
+++ b/hack/validation/requirements.sh
@@ -29,6 +29,55 @@ rule=${rule//\"/\\\"}            # escape double quotes
 rule=${rule//$'\n'/}             # remove newlines
 rule=$(echo "$rule" | tr -s ' ') # remove extra spaces
 
+# kubernetes.azure.com domain restriction
+# We allow well-known labels as well as ebpf-dataplane (required for Cilium)
+aks_rule=$'self in
+    [
+        "kubernetes.azure.com/mode",
+        "kubernetes.azure.com/scalesetpriority",
+        "kubernetes.azure.com/priority",
+        "kubernetes.azure.com/fips_enabled",
+        "kubernetes.azure.com/os-sku",
+        "kubernetes.azure.com/cluster",
+        "kubernetes.azure.com/sku-cpu",
+        "kubernetes.azure.com/sku-memory",
+        "kubernetes.azure.com/ebpf-dataplane",
+    ]
+    || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+'
+
+aks_rule=${aks_rule//\"/\\\"}            # escape double quotes
+aks_rule=${aks_rule//$'\n'/}             # remove newlines
+aks_rule=$(echo "$aks_rule" | tr -s ' ') # remove extra spaces
+
+# agentpool restriction
+agentpool_rule=$'self != \x27agentpool\x27'
+
+agentpool_rule=${agentpool_rule//\"/\\\"}            # escape double quotes
+agentpool_rule=${agentpool_rule//$'\n'/}             # remove newlines
+agentpool_rule=$(echo "$agentpool_rule" | tr -s ' ') # remove extra spaces
+
+# storageprofile restriction
+storageprofile_rule=$'self != \x27storageprofile\x27'
+
+storageprofile_rule=${storageprofile_rule//\"/\\\"}            # escape double quotes
+storageprofile_rule=${storageprofile_rule//$'\n'/}             # remove newlines
+storageprofile_rule=$(echo "$storageprofile_rule" | tr -s ' ') # remove extra spaces
+
+# storagetier restriction
+storagetier_rule=$'self != \x27storagetier\x27'
+
+storagetier_rule=${storagetier_rule//\"/\\\"}            # escape double quotes
+storagetier_rule=${storagetier_rule//$'\n'/}             # remove newlines
+storagetier_rule=$(echo "$storagetier_rule" | tr -s ' ') # remove extra spaces
+
+# accelerator restriction
+accelerator_rule=$'self != \x27accelerator\x27'
+
+accelerator_rule=${accelerator_rule//\"/\\\"}            # escape double quotes
+accelerator_rule=${accelerator_rule//$'\n'/}             # remove newlines
+accelerator_rule=$(echo "$accelerator_rule" | tr -s ' ') # remove extra spaces
+
 # check that .spec.versions has 1 entry
 [[ $(yq e '.spec.versions | length' pkg/apis/crds/karpenter.sh_nodepools.yaml)  -eq 1 ]] || { echo "expected one version"; exit 1; }
 [[ $(yq e '.spec.versions | length' pkg/apis/crds/karpenter.sh_nodeclaims.yaml) -eq 1 ]] || { echo "expected one version"; exit 1; }
@@ -39,12 +88,72 @@ printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.propert
     [{"message": "label domain \\"karpenter.azure.com\\" is restricted", "rule": "%s"}]' "$rule"
 yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
 
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label domain \\"kubernetes.azure.com\\" is restricted", "rule": "%s"}]' "$aks_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"agentpool\\" is restricted", "rule": "%s"}]' "$agentpool_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"storageprofile\\" is restricted", "rule": "%s"}]' "$storageprofile_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"storagetier\\" is restricted", "rule": "%s"}]' "$storagetier_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"accelerator\\" is restricted", "rule": "%s"}]' "$accelerator_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+
 # nodepool
 printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
     [{"message": "label domain \\"karpenter.azure.com\\" is restricted", "rule": "%s"}]' "$rule"
 yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
 
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label domain \\"kubernetes.azure.com\\" is restricted", "rule": "%s"}]' "$aks_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"agentpool\\" is restricted", "rule": "%s"}]' "$agentpool_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"storageprofile\\" is restricted", "rule": "%s"}]' "$storageprofile_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"storagetier\\" is restricted", "rule": "%s"}]' "$storagetier_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"accelerator\\" is restricted", "rule": "%s"}]' "$accelerator_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
 # overlays
 printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
     [{"message": "label domain \\"karpenter.azure.com\\" is restricted", "rule": "%s"}]' "$rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label domain \\"kubernetes.azure.com\\" is restricted", "rule": "%s"}]' "$aks_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"agentpool\\" is restricted", "rule": "%s"}]' "$agentpool_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"storageprofile\\" is restricted", "rule": "%s"}]' "$storageprofile_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"storagetier\\" is restricted", "rule": "%s"}]' "$storagetier_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"accelerator\\" is restricted", "rule": "%s"}]' "$accelerator_rule"
 yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeoverlays.yaml

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -128,6 +128,16 @@ spec:
                             rule: self != "kubernetes.io/hostname"
                           - message: label domain "karpenter.azure.com" is restricted
                             rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count", "karpenter.azure.com/placement-scope" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                          - message: label domain "kubernetes.azure.com" is restricted
+                            rule: self in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/priority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", ] || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+                          - message: label "agentpool" is restricted
+                            rule: self != 'agentpool'
+                          - message: label "storageprofile" is restricted
+                            rule: self != 'storageprofile'
+                          - message: label "storagetier" is restricted
+                            rule: self != 'storagetier'
+                          - message: label "accelerator" is restricted
+                            rule: self != 'accelerator'
                       minValues:
                         description: |-
                           This field is ALPHA and can be dropped or replaced at any time

--- a/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
@@ -101,6 +101,16 @@ spec:
                             rule: self != "kubernetes.io/hostname"
                           - message: label domain "karpenter.azure.com" is restricted
                             rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count", "karpenter.azure.com/placement-scope" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                          - message: label domain "kubernetes.azure.com" is restricted
+                            rule: self in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/priority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", ] || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+                          - message: label "agentpool" is restricted
+                            rule: self != 'agentpool'
+                          - message: label "storageprofile" is restricted
+                            rule: self != 'storageprofile'
+                          - message: label "storagetier" is restricted
+                            rule: self != 'storagetier'
+                          - message: label "accelerator" is restricted
+                            rule: self != 'accelerator'
                       operator:
                         description: |-
                           Represents a key's relationship to a set of values.

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -224,6 +224,16 @@ spec:
                               rule: self.all(x, x != "kubernetes.io/hostname")
                             - message: label domain "karpenter.azure.com" is restricted
                               rule: self.all(x, x in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count", "karpenter.azure.com/placement-scope" ] || !x.find("^([^/]+)").endsWith("karpenter.azure.com"))
+                            - message: label domain "kubernetes.azure.com" is restricted
+                              rule: self.all(x, x in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/priority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", ] || !x.find("^([^/]+)").endsWith("kubernetes.azure.com"))
+                            - message: label "agentpool" is restricted
+                              rule: self.all(x, x != 'agentpool')
+                            - message: label "storageprofile" is restricted
+                              rule: self.all(x, x != 'storageprofile')
+                            - message: label "storagetier" is restricted
+                              rule: self.all(x, x != 'storagetier')
+                            - message: label "accelerator" is restricted
+                              rule: self.all(x, x != 'accelerator')
                       type: object
                     spec:
                       description: |-
@@ -293,6 +303,16 @@ spec:
                                     rule: self != "kubernetes.io/hostname"
                                   - message: label domain "karpenter.azure.com" is restricted
                                     rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count", "karpenter.azure.com/placement-scope" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                                  - message: label domain "kubernetes.azure.com" is restricted
+                                    rule: self in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/priority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", ] || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+                                  - message: label "agentpool" is restricted
+                                    rule: self != 'agentpool'
+                                  - message: label "storageprofile" is restricted
+                                    rule: self != 'storageprofile'
+                                  - message: label "storagetier" is restricted
+                                    rule: self != 'storagetier'
+                                  - message: label "accelerator" is restricted
+                                    rule: self != 'accelerator'
                               minValues:
                                 description: |-
                                   This field is ALPHA and can be dropped or replaced at any time

--- a/pkg/apis/v1alpha2/crd_validation_cel_test.go
+++ b/pkg/apis/v1alpha2/crd_validation_cel_test.go
@@ -903,6 +903,53 @@ var _ = Describe("CEL/Validation", func() {
 			Entry("AKS OS SKU AzureLinux", v1beta1.AKSLabelOSSKU, v1beta1.OSSKUAzureLinux, "AzureLinux3"),
 			Entry("AKS FIPS enabled", v1beta1.AKSLabelFIPSEnabled, "true", "false"),
 		)
+		It("should not allow restricted kubernetes.azure.com requirements", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{"kubernetes.azure.com/some-random-label", "kubernetes.azure.com/agentpool", "kubernetes.azure.com/custom", "kubernetes.azure.com/cluster-health-monitor-checker-synthetic"} {
+				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+					{Key: label, Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
+				}
+				Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should allow special kubernetes.azure.com requirements", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{
+				"kubernetes.azure.com/ebpf-dataplane",
+			} {
+				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+					{Key: label, Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
+				}
+				Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+				Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should not allow agentpool requirement", func() {
+			nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+				{Key: "agentpool", Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should not allow storageprofile requirement", func() {
+			nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+				{Key: "storageprofile", Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should not allow storagetier requirement", func() {
+			nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+				{Key: "storagetier", Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should not allow accelerator requirement", func() {
+			nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+				{Key: "accelerator", Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
 	})
 	Context("Labels", func() {
 		It("should allow well known label exceptions", func() {
@@ -916,6 +963,53 @@ var _ = Describe("CEL/Validation", func() {
 				Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 				nodePool = oldNodePool.DeepCopy()
 			}
+		})
+		It("should not allow restricted kubernetes.azure.com labels", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{"kubernetes.azure.com/some-random-label", "kubernetes.azure.com/agentpool", "kubernetes.azure.com/custom", "kubernetes.azure.com/cluster-health-monitor-checker-synthetic"} {
+				nodePool.Spec.Template.Labels = map[string]string{
+					label: "test",
+				}
+				Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should allow special kubernetes.azure.com labels", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{
+				"kubernetes.azure.com/ebpf-dataplane",
+			} {
+				nodePool.Spec.Template.Labels = map[string]string{
+					label: "test",
+				}
+				Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+				Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should not allow agentpool label", func() {
+			nodePool.Spec.Template.Labels = map[string]string{
+				"agentpool": "test",
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should not allow storageprofile label", func() {
+			nodePool.Spec.Template.Labels = map[string]string{
+				"storageprofile": "test",
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should not allow storagetier label", func() {
+			nodePool.Spec.Template.Labels = map[string]string{
+				"storagetier": "test",
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should not allow accelerator label", func() {
+			nodePool.Spec.Template.Labels = map[string]string{
+				"accelerator": "test",
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
 		})
 	})
 

--- a/pkg/apis/v1beta1/crd_validation_cel_test.go
+++ b/pkg/apis/v1beta1/crd_validation_cel_test.go
@@ -913,6 +913,53 @@ var _ = Describe("CEL/Validation", func() {
 				nodePool = oldNodePool.DeepCopy()
 			}
 		})
+		It("should not allow restricted kubernetes.azure.com requirements", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{"kubernetes.azure.com/some-random-label", "kubernetes.azure.com/agentpool", "kubernetes.azure.com/custom", "kubernetes.azure.com/cluster-health-monitor-checker-synthetic"} {
+				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+					{Key: label, Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
+				}
+				Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should allow special kubernetes.azure.com requirements", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{
+				"kubernetes.azure.com/ebpf-dataplane",
+			} {
+				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+					{Key: label, Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
+				}
+				Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+				Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should not allow agentpool requirement", func() {
+			nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+				{Key: "agentpool", Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should not allow storageprofile requirement", func() {
+			nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+				{Key: "storageprofile", Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should not allow storagetier requirement", func() {
+			nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+				{Key: "storagetier", Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should not allow accelerator requirement", func() {
+			nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+				{Key: "accelerator", Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
 	})
 	Context("Labels", func() {
 		It("should allow well known label exceptions", func() {
@@ -936,6 +983,53 @@ var _ = Describe("CEL/Validation", func() {
 				Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
 				nodePool = oldNodePool.DeepCopy()
 			}
+		})
+		It("should not allow restricted kubernetes.azure.com labels", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{"kubernetes.azure.com/some-random-label", "kubernetes.azure.com/agentpool", "kubernetes.azure.com/custom", "kubernetes.azure.com/cluster-health-monitor-checker-synthetic"} {
+				nodePool.Spec.Template.Labels = map[string]string{
+					label: "test",
+				}
+				Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should allow special kubernetes.azure.com labels", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{
+				"kubernetes.azure.com/ebpf-dataplane",
+			} {
+				nodePool.Spec.Template.Labels = map[string]string{
+					label: "test",
+				}
+				Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+				Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should not allow agentpool label", func() {
+			nodePool.Spec.Template.Labels = map[string]string{
+				"agentpool": "test",
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should not allow storageprofile label", func() {
+			nodePool.Spec.Template.Labels = map[string]string{
+				"storageprofile": "test",
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should not allow storagetier label", func() {
+			nodePool.Spec.Template.Labels = map[string]string{
+				"storagetier": "test",
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should not allow accelerator label", func() {
+			nodePool.Spec.Template.Labels = map[string]string{
+				"accelerator": "test",
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
 		})
 	})
 

--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -28,6 +28,7 @@ import (
 
 func init() {
 	karpv1.RestrictedLabelDomains = karpv1.RestrictedLabelDomains.Insert(RestrictedLabelDomains...)
+	karpv1.RestrictedLabels = karpv1.RestrictedLabels.Union(RestrictedLabels)
 	// Note that adding to WellKnownLabels here requires a corresponding update to
 	// computeRequirements in pkg/providers/instancetype/instancetype.go, because (as far as I can tell)
 	// Karpenter core expects that WellKnownLabels are mapped to requirements.
@@ -52,9 +53,32 @@ var (
 		"x64":   karpv1.ArchitectureAmd64,
 		"Arm64": karpv1.ArchitectureArm64,
 	}
+
+	// We don't include kubernetes.azure.com here because there are labels in that domain that we allow users to set, but which are not
+	// WellKnownLabels (like kubernetes.azure.com/ebpf-dataplane).
 	RestrictedLabelDomains = []string{
 		Group,
 	}
+
+	RestrictedLabels = sets.New(
+		LabelSKUHyperVGeneration,
+
+		// Legacy labels
+		AKSLabelLegacyAgentPool,
+		AKSLabelLegacyStorageProfile,
+		AKSLabelLegacyStorageTier,
+		AKSLabelLegacyAccelerator,
+
+		// Labels we observed were set. Note that we cannot add the whole kubernetes.azure.com domain to RestrictedLabelDomains
+		// see above comment for why
+		"kubernetes.azure.com/accelerator",
+		"kubernetes.azure.com/agentpool",
+		"kubernetes.azure.com/agentpool-family",
+		"kubernetes.azure.com/availability-zone",
+		"kubernetes.azure.com/network-policy",
+		"kubernetes.azure.com/storageprofile",
+		"kubernetes.azure.com/storagetier",
+	)
 
 	AzureWellKnownLabels = sets.New(
 		LabelSKUName,
@@ -83,10 +107,6 @@ var (
 		AKSLabelPriority,
 		AKSLabelOSSKU,
 		AKSLabelFIPSEnabled,
-	)
-
-	RestrictedLabels = sets.New(
-		LabelSKUHyperVGeneration,
 	)
 
 	AllowUndefinedWellKnownAndRestrictedLabels = func(options *scheduling.CompatibilityOptions) {


### PR DESCRIPTION
**Description**

* Restricts kubernetes.azure.com/ label namespace, except for WellKnownLabels (and a few special labels that aren't WellKnown but we allow).
* Also restricts the agentpool label.

**How was this change tested?**

* Unit tests
* End to end test: https://github.com/Azure/karpenter-provider-azure/actions/runs/27564449430

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Restrict kubernetes.azure.com label namespace, except for WellKnownLabels and kubernetes.azure.com/ebpf-dataplane.
```
