### PR TITLE
fix: handle only AKS node class

### DIFF
--- a/pkg/controllers/nodeclaim/inplaceupdate/controller.go
+++ b/pkg/controllers/nodeclaim/inplaceupdate/controller.go
@@ -252,6 +252,7 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 		For(
 			&karpv1.NodeClaim{},
 			builder.WithPredicates(
+				nodeclaimutils.UsingAKSNodeClassPredicate(),
 				predicate.Or(
 					predicate.GenerationChangedPredicate{}, // Note that this will trigger on pod restart for all Machines.
 				),

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
@@ -32,6 +33,20 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 )
+
+// UsingAKSNodeClassPredicate creates a predicate to filter node claim using AKS node class.
+func UsingAKSNodeClassPredicate() predicate.Funcs {
+	return predicate.NewPredicateFuncs(func(object client.Object) bool {
+		nodeClaim, ok := object.(*karpv1.NodeClaim)
+		if !ok {
+			return false
+		}
+		if nodeClaim.Spec.NodeClassRef == nil {
+			return false
+		}
+		return nodeClaim.Spec.NodeClassRef.Kind == "AKSNodeClass"
+	})
+}
 
 // GetAKSNodeClass resolves the AKSNodeClass from the NodeClaim's NodeClassRef.
 // If the NodeClass for the nodeClaim has DeletionTimestamp set, an error is returned.


### PR DESCRIPTION
**Description**

This pull request added a check to ensure in place update controller only handles AKS node class. This is needed to allow other Karpenter providers / node classes co-exists inside the same cluster. Otherwise, the in place update controller will error out when trying to get a non-exist AKS node class with the name from another node class.

**How was this change tested?**

* Manual test by running along side with another Karpenter provider and node class

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
