### PR TITLE
fix: handle empty times in maintenance window

### DIFF
--- a/pkg/controllers/nodeclass/status/images.go
+++ b/pkg/controllers/nodeclass/status/images.go
@@ -224,6 +224,13 @@ func (r *NodeImageReconciler) isMaintenanceWindowOpen(ctx context.Context) (bool
 
 	nextNodeOSMWStartStr, okStart := mwConfigMap.Data[fmt.Sprintf(configMapStartTimeFormat, nodeOSMaintenanceWindowChannel)]
 	nextNodeOSMWEndStr, okEnd := mwConfigMap.Data[fmt.Sprintf(configMapEndTimeFormat, nodeOSMaintenanceWindowChannel)]
+	// Treat empty string values as missing, since the ConfigMap may have keys present with empty values
+	if nextNodeOSMWStartStr == "" {
+		okStart = false
+	}
+	if nextNodeOSMWEndStr == "" {
+		okEnd = false
+	}
 	if !okStart && !okEnd {
 		// No maintenance window defined for aksManagedNodeOSUpgradeSchedule, so its up to us when to preform maintenance
 		return true, nil

--- a/pkg/controllers/nodeclass/status/images_test.go
+++ b/pkg/controllers/nodeclass/status/images_test.go
@@ -124,6 +124,19 @@ func getEmptyMWConfigMap() *corev1.ConfigMap {
 	}
 }
 
+// getEmptyValuesMWConfigMap returns a ConfigMap with all maintenance window keys present
+// but with empty string values, which may be observed under some circumstances
+func getEmptyValuesMWConfigMap() *corev1.ConfigMap {
+	configMap := getEmptyMWConfigMap()
+	configMap.Data["aksManagedAutoUpgradeSchedule-start"] = ""
+	configMap.Data["aksManagedAutoUpgradeSchedule-end"] = ""
+	configMap.Data["aksManagedNodeOSUpgradeSchedule-start"] = ""
+	configMap.Data["aksManagedNodeOSUpgradeSchedule-end"] = ""
+	configMap.Data["default-start"] = ""
+	configMap.Data["default-end"] = ""
+	return configMap
+}
+
 var _ = Describe("NodeClass NodeImage Status Controller", func() {
 	var nodeClass *v1beta1.AKSNodeClass
 
@@ -233,6 +246,15 @@ var _ = Describe("NodeClass NodeImage Status Controller", func() {
 
 			It("Should update NodeImages when ConfigMap is empty (maintenance window undefined)", func() {
 				ExpectApplied(ctx, env.Client, getEmptyMWConfigMap())
+
+				_, err := imageReconciler.Reconcile(ctx, nodeClass)
+				Expect(err).ToNot(HaveOccurred())
+
+				ExpectReadyWithCIGImages(nodeClass, newCIGImageVersion)
+			})
+
+			It("Should update NodeImages when ConfigMap has keys with empty string values (fail open)", func() {
+				ExpectApplied(ctx, env.Client, getEmptyValuesMWConfigMap())
 
 				_, err := imageReconciler.Reconcile(ctx, nodeClass)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->


**Description**

Treat empty string values for times in Maintenance Window as missing, since the ConfigMap may have keys present with empty values. 

Without this, if empty values are present, AKSNodeClass reconciliation returns would fail persistently, breaking provisioning.

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Empty values for times in maintenance window no longer break provisioning
```
