### PR TITLE
fix: suppress machine drift GET during node creation

### DIFF
--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8"
+	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -280,30 +281,35 @@ func (c *CloudProvider) isMachineDrifted(ctx context.Context, nodeClaim *karpv1.
 		return "", fmt.Errorf("AKS machine with name %s not found", aksMachineName)
 	}
 
-	if aksMachine.Properties != nil && aksMachine.Properties.Status != nil && aksMachine.Properties.Status.DriftAction != nil {
-		driftAction := lo.FromPtr(aksMachine.Properties.Status.DriftAction)
-		driftReason := "" // Note: this is not being incorporated yet, and we currently return ClusterConfigDrift for all reasons. // Suggestion: could be extended.
-		if aksMachine.Properties.Status.DriftReason != nil {
-			driftReason = lo.FromPtr(aksMachine.Properties.Status.DriftReason)
-		}
+	return parseDriftAction(logger, aksMachineName, aksMachine)
+}
 
-		switch driftAction {
-		case "":
-			return "", nil
-		case armcontainerservice.DriftActionSynced:
-			return "", nil
-		case armcontainerservice.DriftActionRecreate:
-			return ClusterConfigDrift, nil
-		default:
-			// AKS machine API may add additional drift actions in the future (e.g., restart, reimage). Karpenter (core) need to support them explicitly.
-			// Meanwhile, re-create covers all cases.
-			logger.Error(fmt.Errorf("unknown drift action %s for AKS machine %s", driftAction, aksMachineName), "unknown drift action, considering it as drift",
-				"aksMachineName", aksMachineName,
-				"driftAction", driftAction,
-				"driftReason", driftReason)
-			return ClusterConfigDrift, nil
-		}
+// parseDriftAction interprets the DriftAction/DriftReason from an AKS machine status
+func parseDriftAction(logger logr.Logger, aksMachineName string, aksMachine *armcontainerservice.Machine) (cloudprovider.DriftReason, error) {
+	if aksMachine.Properties == nil || aksMachine.Properties.Status == nil || aksMachine.Properties.Status.DriftAction == nil {
+		return "", nil
 	}
 
-	return "", nil
+	driftAction := lo.FromPtr(aksMachine.Properties.Status.DriftAction)
+	driftReason := "" // Note: this is not being incorporated yet, and we currently return ClusterConfigDrift for all reasons. // Suggestion: could be extended.
+	if aksMachine.Properties.Status.DriftReason != nil {
+		driftReason = lo.FromPtr(aksMachine.Properties.Status.DriftReason)
+	}
+
+	switch driftAction {
+	case "":
+		return "", nil
+	case armcontainerservice.DriftActionSynced:
+		return "", nil
+	case armcontainerservice.DriftActionRecreate:
+		return ClusterConfigDrift, nil
+	default:
+		// AKS machine API may add additional drift actions in the future (e.g., restart, reimage). Karpenter (core) need to support them explicitly.
+		// Meanwhile, re-create covers all cases.
+		logger.Error(fmt.Errorf("unknown drift action %s for AKS machine %s", driftAction, aksMachineName), "unknown drift action, considering it as drift",
+			"aksMachineName", aksMachineName,
+			"driftAction", driftAction,
+			"driftReason", driftReason)
+		return ClusterConfigDrift, nil
+	}
 }

--- a/pkg/cloudprovider/suite_aksmachineapi_drift_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_drift_test.go
@@ -106,7 +106,7 @@ var _ = Describe("CloudProvider", func() {
 				Expect(nodeClaims).To(HaveLen(1))
 
 				nodeClaim = nodeClaims[0]
-				nodeClaim.Status.NodeName = node.Name // Normally core would do this.
+				nodeClaim.Status.NodeName = node.Name                                // Normally core would do this.
 				nodeClaim.StatusConditions().SetTrue(karpv1.ConditionTypeRegistered) // Normally core would do this during node registration.
 				nodeClaim.Spec.NodeClassRef = &karpv1.NodeClassReference{
 					Group: object.GVK(nodeClass).Group,


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->


**Description**

Skips the `isMachineDrifted()` GET Machine API call when the NodeClaim has not yet reached `Registered=True`. Core's drift controller calls `IsDrifted()` once the NodeClaim is "Launched" (PUT accepted), but the machine may still be provisioning. During burst scale-up with batch creation, this generates unnecessary API load and 404 errors.

Follows the same pattern as `getNodeForDrift()` which returns `(nil, nil)` for nodes that haven't joined the cluster yet.

**How was this change tested?**

* New unit test: `should not be drifted if the nodeclass does not exist and NodeClaim is not registered`
* Existing tests pass
* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note

```