### PR TITLE
fix: treat missing kubelet identity label as drift

### DIFF
--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -207,13 +207,16 @@ func (c *CloudProvider) isKubeletIdentityDrifted(ctx context.Context, nodeClaim 
 	}
 
 	kubeletIdentityClientID := node.Labels[v1beta1.AKSLabelKubeletIdentityClientID]
-	// The kubelet identity label is supposed to be set on every node, but prior to
-	// 1.4.0 it was not set by Karpenter. In order to avoid rolling all existing nodes,
-	// we don't count a missing kubelet identity as drift. This situation should resolve itself as
-	// image version and Kubernetes version drift is performed.
-	// TODO: This short-circuit should be removed post 1.4.0 (~2025-07-01)
 	if kubeletIdentityClientID == "" {
-		return "", nil
+		// A missing kubelet identity label means the node was created by a Karpenter version
+		// prior to 1.4.0 (which first started setting this label). Since we are now well past
+		// 1.4.0 (current: 1.7.x), all pre-1.4.0 nodes should have been rotated by now through
+		// image/k8s version drift. A missing label at this point indicates a node that has
+		// somehow survived without rotation and should be drifted to ensure it gets the label.
+		logger.V(1).Info("drift triggered due to missing kubelet identity label on node",
+			"driftType", KubeletIdentityDrift,
+			"expectedKubeletIdentityClientID", opts.KubeletIdentityClientID)
+		return KubeletIdentityDrift, nil
 	}
 
 	if kubeletIdentityClientID != opts.KubeletIdentityClientID {

--- a/pkg/cloudprovider/suite_drift_test.go
+++ b/pkg/cloudprovider/suite_drift_test.go
@@ -260,12 +260,13 @@ var _ = Describe("CloudProvider", func() {
 			})
 
 			Context("Kubelet Client ID", func() {
-				It("should NOT trigger drift if node doesn't have kubelet client ID label", func() {
-					node.Labels[v1beta1.AKSLabelKubeletIdentityClientID] = "" // Not set
+				It("should trigger drift if node doesn't have kubelet client ID label", func() {
+					node.Labels[v1beta1.AKSLabelKubeletIdentityClientID] = "" // Not set — pre-1.4.0 nodes
+					ExpectApplied(ctx, env.Client, node)
 
 					drifted, err := cloudProvider.IsDrifted(ctx, driftNodeClaim)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(drifted).To(BeEmpty())
+					Expect(drifted).To(Equal(KubeletIdentityDrift))
 				})
 
 				It("should trigger drift if node kubelet client ID doesn't match options", func() {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->


**Description**

Removes the transitional short-circuit that silently skipped kubelet identity drift when the label was missing from a node. Missing labels now correctly trigger `KubeletIdentityDrift`, causing the node to be recreated with the proper label.

The short-circuit was added for the v1.4.0 release (which first started setting the `karpenter.azure.com/kubelet-identity-client-id` label). The TODO specified removal after `~2025-07-01`. We are now at v1.7.x — 9 months past the target date. Any node that has survived all drift cycles should be recreated for label consistency.

**How was this change tested?**

* Updated existing unit test expectation
* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note
Missing kubelet identity label on nodes now correctly triggers drift
```