### PR TITLE
chore: extract MaxConcurrentReconciles into shared constant

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -40,4 +40,11 @@ const (
 	ProvisionModeAKSScriptless       = "aksscriptless"
 	ProvisionModeBootstrappingClient = "bootstrappingclient"
 	ProvisionModeAKSMachineAPI       = "aksmachineapi"
+
+	// MaxConcurrentReconciles is the default concurrency limit for Azure-specific reconcilers.
+	// Set to 10 to allow moderate parallelism for handling multiple AKSNodeClass/NodeClaim objects
+	// without overwhelming the API server or Azure API rate limits. This matches the commonly used
+	// controller-runtime default for reconcilers with external I/O dependencies.
+	// Discussion: https://github.com/Azure/karpenter-provider-azure/pull/729#discussion_r2006629809
+	MaxConcurrentReconciles = 10
 )

--- a/pkg/controllers/nodeclaim/inplaceupdate/controller.go
+++ b/pkg/controllers/nodeclaim/inplaceupdate/controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 	nodeclaimutils "github.com/Azure/karpenter-provider-azure/pkg/utils/nodeclaim"
@@ -262,10 +263,8 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 		// TODO: similar to https://github.com/kubernetes-sigs/karpenter/blob/main/pkg/controllers/nodeclaim/disruption/controller.go#L214C3-L217C5
 		// TODO: if/when we need to monitor provisioner changes and flow updates on the NodePool down to the underlying VMs.
 		WithOptions(controller.Options{
-			RateLimiter: reasonable.RateLimiter(),
-			// TODO: Document why this magic number used. If we want to consistently use it accoss reconcilers, refactor to a reused const.
-			// Comments thread discussing this: https://github.com/Azure/karpenter-provider-azure/pull/729#discussion_r2006629809
-			MaxConcurrentReconciles: 10,
+			RateLimiter:             reasonable.RateLimiter(),
+			MaxConcurrentReconciles: consts.MaxConcurrentReconciles,
 		}).
 		Complete(reconcile.AsReconciler(m.GetClient(), c))
 }

--- a/pkg/controllers/nodeclass/hash/controller.go
+++ b/pkg/controllers/nodeclass/hash/controller.go
@@ -33,6 +33,7 @@ import (
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 )
 
 type Controller struct {
@@ -74,10 +75,8 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 		Named("nodeclass.hash").
 		For(&v1beta1.AKSNodeClass{}).
 		WithOptions(controller.Options{
-			RateLimiter: reasonable.RateLimiter(),
-			// TODO: Document why this magic number used. If we want to consistently use it accoss reconcilers, refactor to a reused const.
-			// Comments thread discussing this: https://github.com/Azure/karpenter-provider-azure/pull/729#discussion_r2006629809
-			MaxConcurrentReconciles: 10,
+			RateLimiter:             reasonable.RateLimiter(),
+			MaxConcurrentReconciles: consts.MaxConcurrentReconciles,
 		}).
 		Complete(reconcile.AsReconciler(m.GetClient(), c))
 }

--- a/pkg/controllers/nodeclass/status/controller.go
+++ b/pkg/controllers/nodeclass/status/controller.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/kubernetesversion"
@@ -119,10 +120,8 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 		Named("nodeclass.status").
 		For(&v1beta1.AKSNodeClass{}).
 		WithOptions(controller.Options{
-			RateLimiter: reasonable.RateLimiter(),
-			// TODO: Document why this magic number used. If we want to consistently use it accoss reconcilers, refactor to a reused const.
-			// Comments thread discussing this: https://github.com/Azure/karpenter-provider-azure/pull/729#discussion_r2006629809
-			MaxConcurrentReconciles: 10,
+			RateLimiter:             reasonable.RateLimiter(),
+			MaxConcurrentReconciles: consts.MaxConcurrentReconciles,
 		}).
 		Complete(reconcile.AsReconciler(m.GetClient(), c))
 }

--- a/pkg/controllers/nodeclass/status/images.go
+++ b/pkg/controllers/nodeclass/status/images.go
@@ -36,6 +36,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
@@ -83,10 +84,8 @@ func (r *NodeImageReconciler) Register(_ context.Context, m manager.Manager) err
 		Named(nodeImageReconcilerName).
 		For(&v1beta1.AKSNodeClass{}).
 		WithOptions(controller.Options{
-			RateLimiter: reasonable.RateLimiter(),
-			// TODO: Document why this magic number used. If we want to consistently use it accoss reconcilers, refactor to a reused const.
-			// Comments thread discussing this: https://github.com/Azure/karpenter-provider-azure/pull/729#discussion_r2006629809
-			MaxConcurrentReconciles: 10,
+			RateLimiter:             reasonable.RateLimiter(),
+			MaxConcurrentReconciles: consts.MaxConcurrentReconciles,
 		}).
 		Complete(reconcile.AsReconciler(m.GetClient(), r))
 }

--- a/pkg/controllers/nodeclass/status/kubernetesversion.go
+++ b/pkg/controllers/nodeclass/status/kubernetesversion.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	azurecache "github.com/Azure/karpenter-provider-azure/pkg/cache"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/kubernetesversion"
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -58,10 +59,8 @@ func (r *KubernetesVersionReconciler) Register(_ context.Context, m manager.Mana
 		Named(kubernetesVersionReconcilerName).
 		For(&v1beta1.AKSNodeClass{}).
 		WithOptions(controller.Options{
-			RateLimiter: reasonable.RateLimiter(),
-			// TODO: Document why this magic number used. If we want to consistently use it accoss reconcilers, refactor to a reused const.
-			// Comments thread discussing this: https://github.com/Azure/karpenter-provider-azure/pull/729#discussion_r2006629809
-			MaxConcurrentReconciles: 10,
+			RateLimiter:             reasonable.RateLimiter(),
+			MaxConcurrentReconciles: consts.MaxConcurrentReconciles,
 		}).
 		Complete(reconcile.AsReconciler(m.GetClient(), r))
 }

--- a/pkg/controllers/nodeclass/termination/controller.go
+++ b/pkg/controllers/nodeclass/termination/controller.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
@@ -118,10 +119,8 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 			}),
 		).
 		WithOptions(controller.Options{
-			RateLimiter: reasonable.RateLimiter(),
-			// TODO: Document why this magic number used. If we want to consistently use it accoss reconcilers, refactor to a reused const.
-			// Comments thread discussing this: https://github.com/Azure/karpenter-provider-azure/pull/729#discussion_r2006629809
-			MaxConcurrentReconciles: 10,
+			RateLimiter:             reasonable.RateLimiter(),
+			MaxConcurrentReconciles: consts.MaxConcurrentReconciles,
 		}).
 		Complete(reconcile.AsReconciler(m.GetClient(), c))
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->


**Description**

Extracts the magic number `10` for `MaxConcurrentReconciles` into `consts.MaxConcurrentReconciles` with documentation. Replaces 6 identical TODO blocks across controller files. No behavioral change — same value, now documented and shared.

Resolves the TODO: "Document why this magic number used. If we want to consistently use it across reconcilers, refactor to a reused const."

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note
NONE
```