### PR TITLE
Remove stale kubelet identity empty-label drift short-circuit

### DIFF
--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -207,15 +207,6 @@ func (c *CloudProvider) isKubeletIdentityDrifted(ctx context.Context, nodeClaim 
 	}
 
 	kubeletIdentityClientID := node.Labels[v1beta1.AKSLabelKubeletIdentityClientID]
-	// The kubelet identity label is supposed to be set on every node, but prior to
-	// 1.4.0 it was not set by Karpenter. In order to avoid rolling all existing nodes,
-	// we don't count a missing kubelet identity as drift. This situation should resolve itself as
-	// image version and Kubernetes version drift is performed.
-	// TODO: This short-circuit should be removed post 1.4.0 (~2025-07-01)
-	if kubeletIdentityClientID == "" {
-		return "", nil
-	}
-
 	if kubeletIdentityClientID != opts.KubeletIdentityClientID {
 		logger.V(1).Info("drift triggered due to expected and actual kubelet identity client id mismatch",
 			"driftType", KubeletIdentityDrift,

--- a/pkg/cloudprovider/suite_drift_test.go
+++ b/pkg/cloudprovider/suite_drift_test.go
@@ -260,12 +260,13 @@ var _ = Describe("CloudProvider", func() {
 			})
 
 			Context("Kubelet Client ID", func() {
-				It("should NOT trigger drift if node doesn't have kubelet client ID label", func() {
+				It("should trigger drift if node doesn't have kubelet client ID label", func() {
 					node.Labels[v1beta1.AKSLabelKubeletIdentityClientID] = "" // Not set
+					ExpectApplied(ctx, env.Client, node)
 
 					drifted, err := cloudProvider.IsDrifted(ctx, driftNodeClaim)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(drifted).To(BeEmpty())
+					Expect(drifted).To(Equal(KubeletIdentityDrift))
 				})
 
 				It("should trigger drift if node kubelet client ID doesn't match options", func() {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Removes the backward compatibility short-circuit that skipped drift detection for nodes with an empty kubelet identity client ID label. This was scheduled for removal post-1.4.0 (~2025-07-01); we are now at v1.7.2 (March 2026). All pre-1.4.0 nodes would have been cycled through K8s version and image drift by now.

Also fixes a latent test bug where the "empty label" test was not applying the node change to the API server, so it was asserting "matching labels don't drift" instead of "empty label doesn't drift". The updated test properly applies the node to the API server and verifies that an empty label triggers `KubeletIdentityDrift`.

**How was this change tested?**

* Updated test to properly apply node to API server and verify empty label triggers `KubeletIdentityDrift`
* All 37 drift tests pass

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note

```
