### PR TITLE
Thread context through CIG image listing

### DIFF
--- a/pkg/providers/imagefamily/nodeimage.go
+++ b/pkg/providers/imagefamily/nodeimage.go
@@ -150,10 +150,10 @@ func (p *provider) listSIG(ctx context.Context, supportedImages []types.DefaultI
 	return nodeImages, nil
 }
 
-func (p *provider) listCIG(_ context.Context, supportedImages []types.DefaultImageOutput) ([]NodeImage, error) {
+func (p *provider) listCIG(ctx context.Context, supportedImages []types.DefaultImageOutput) ([]NodeImage, error) {
 	nodeImages := []NodeImage{}
 	for _, supportedImage := range supportedImages {
-		cigImageID, err := p.getCIGImageID(supportedImage.PublicGalleryURL, supportedImage.ImageDefinition)
+		cigImageID, err := p.getCIGImageID(ctx, supportedImage.PublicGalleryURL, supportedImage.ImageDefinition)
 		if err != nil {
 			return nil, err
 		}
@@ -179,19 +179,19 @@ func (p *provider) cacheKey(supportedImages []types.DefaultImageOutput, k8sVersi
 	return fmt.Sprintf("%016x", hash), nil
 }
 
-func (p *provider) getCIGImageID(publicGalleryURL, communityImageName string) (string, error) {
-	imageVersion, err := p.latestNodeImageVersionCommunity(publicGalleryURL, communityImageName)
+func (p *provider) getCIGImageID(ctx context.Context, publicGalleryURL, communityImageName string) (string, error) {
+	imageVersion, err := p.latestNodeImageVersionCommunity(ctx, publicGalleryURL, communityImageName)
 	if err != nil {
 		return "", err
 	}
 	return BuildImageIDCIG(publicGalleryURL, communityImageName, imageVersion), nil
 }
 
-func (p *provider) latestNodeImageVersionCommunity(publicGalleryURL, communityImageName string) (string, error) {
+func (p *provider) latestNodeImageVersionCommunity(ctx context.Context, publicGalleryURL, communityImageName string) (string, error) {
 	pager := p.imageVersionsClient.NewListPager(p.location, publicGalleryURL, communityImageName, nil)
 	topImageVersionCandidate := armcompute.CommunityGalleryImageVersion{}
 	for pager.More() {
-		page, err := pager.NextPage(context.Background())
+		page, err := pager.NextPage(ctx)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

`latestNodeImageVersionCommunity()` was using `context.Background()` for Azure pager calls instead of the caller's context. This prevented cancellation propagation during Karpenter shutdown — in-flight API calls would continue indefinitely.

Threads ctx through the call chain: `listCIG` → `getCIGImageID` → `latestNodeImageVersionCommunity` → `NextPage(ctx)`.

**How was this change tested?**

* All imagefamily tests pass
* All 10 image drift tests pass

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note

```
