### PR TITLE
Remove commented-out dead code from Create path

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -141,17 +141,6 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 		return nil, cloudprovider.NewInsufficientCapacityError(fmt.Errorf("resolving node class, %w", err))
 	}
 
-	/*
-		// TODO: Remove this after v1
-		nodePool, err := utils.ResolveNodePoolFromNodeClaim(ctx, c.kubeClient, nodeClaim)
-		if err != nil {
-			return nil, err
-		}
-		kubeletHash, err := utils.GetHashKubelet(nodePool, nodeClass)
-		if err != nil {
-			return nil, err
-		}
-	*/
 	if err = c.validateNodeClass(nodeClass); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Removes a commented-out block in `cloudprovider.go` that was marked `TODO: Remove this after v1`. We are now at v1.7.2; this dead code referencing `ResolveNodePoolFromNodeClaim` and `GetHashKubelet` (neither of which exist in the codebase) has been sitting here since pre-v1.

Pure cleanup, no behavioral change.

**How was this change tested?**

* All 45 create-related tests pass
* Build succeeds

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note

```
