### PR TITLE
fix: thread context through VNet GUID lookup

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -298,7 +298,7 @@ func getVnetGUID(ctx context.Context, creds azcore.TokenCredential, cfg *auth.Co
 	if err != nil {
 		return "", err
 	}
-	vnet, err := vnetClient.Get(context.Background(), subnetParts.ResourceGroupName, subnetParts.VNetName, nil)
+	vnet, err := vnetClient.Get(ctx, subnetParts.ResourceGroupName, subnetParts.VNetName, nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

`getVnetGUID()` accepts `ctx context.Context` and uses it for `options.FromContext(ctx)`, but passes `context.Background()` to the actual `vnetClient.Get()` Azure API call. This prevents cancellation propagation during operator shutdown — if the operator context is cancelled, the VNet GET call continues running until it times out or completes.

Fix: use the already-available `ctx` parameter.

**How was this change tested?**

* `go build ./pkg/operator/...` passes

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note

```
