### PR TITLE
fix: prevent nil dereference in LRO error handling

### DIFF
--- a/pkg/providers/instance/aksmachineinstance.go
+++ b/pkg/providers/instance/aksmachineinstance.go
@@ -500,8 +500,10 @@ func (p *DefaultAKSMachineProvider) beginCreateMachine(
 				// Could be quota error; will be handled with custom logic below
 
 				// Get once after begin create to retrieve error details. This is because if the poller returns error, the sdk doesn't let us look at the real results.
-				failedAKSMachine, _ := p.getMachine(ctx, aksMachineName)
-				if failedAKSMachine.Properties != nil && failedAKSMachine.Properties.Status != nil && failedAKSMachine.Properties.Status.ProvisioningError != nil {
+				failedAKSMachine, getErr := p.getMachine(ctx, aksMachineName)
+				if getErr != nil {
+					log.FromContext(ctx).Error(getErr, "failed to get AKS machine for error details after LRO failure", "aksMachineName", aksMachineName)
+				} else if failedAKSMachine.Properties != nil && failedAKSMachine.Properties.Status != nil && failedAKSMachine.Properties.Status.ProvisioningError != nil {
 					pollingErr = p.handleMachineProvisioningError(ctx, "LRO", aksMachineName, nodeClass, instanceType, zone, capacityType, failedAKSMachine.Properties.Status.ProvisioningError)
 					return
 				}

--- a/pkg/providers/loadbalancer/loadbalancer.go
+++ b/pkg/providers/loadbalancer/loadbalancer.go
@@ -49,7 +49,7 @@ const (
 
 	loadBalancersCacheKey = "LoadBalancers"
 
-	// LoadBalancersCacheTTL configures how freuqently we check for updates to the LBs.
+	// LoadBalancersCacheTTL configures how frequently we check for updates to the LBs.
 	// Currently the choice of this value is entirely "how much work do we want to save cloudprovider".
 	// The faster we do this, the faster we notice the creation of a kubernetes-internal LB and start
 	// including it on new VMs, which saves CloudProvider needing to do that.

--- a/pkg/providers/networksecuritygroup/networksecuritygroup.go
+++ b/pkg/providers/networksecuritygroup/networksecuritygroup.go
@@ -44,7 +44,7 @@ type Provider struct {
 	mu  sync.Mutex
 }
 
-// NewProvider creates a new LoadBalancer provider
+// NewProvider creates a new NetworkSecurityGroup provider
 func NewProvider(nsgAPI API, resourceGroup string) *Provider {
 	return &Provider{
 		nsgAPI:        nsgAPI,


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

In `beginCreateMachine`, when `PollUntilDone` returns an error, the code GETs the machine to retrieve provisioning error details. The GET error was silently discarded (`failedAKSMachine, _ := p.getMachine(...)`) and the returned nil pointer was dereferenced on the next line (`failedAKSMachine.Properties`), causing a **panic** if the GET failed (throttled, network error, or machine already deleted).

Fix: check the GET error first, log it, and only access the response if the GET succeeded.

Also fixes copy-paste comment in NSG provider and typo in LB provider.

**How was this change tested?**

* `go build ./pkg/providers/...` passes
* `go vet ./pkg/providers/instance/...` passes

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note

```
