### PR TITLE
fix: close HTTP response body and thread context in pricing API

### DIFF
--- a/pkg/providers/pricing/client/pricingapi.go
+++ b/pkg/providers/pricing/client/pricingapi.go
@@ -46,7 +46,7 @@ func New(cloud cloud.Configuration) PricingAPI {
 	return &pricingAPI{cloud: cloud}
 }
 
-func (papi *pricingAPI) GetProductsPricePages(_ context.Context, filters []*Filter, pageHandler func(output *ProductsPricePage)) error {
+func (papi *pricingAPI) GetProductsPricePages(ctx context.Context, filters []*Filter, pageHandler func(output *ProductsPricePage)) error {
 	nextURL := pricingURL
 
 	if !auth.IsPublic(papi.cloud) {
@@ -66,16 +66,22 @@ func (papi *pricingAPI) GetProductsPricePages(_ context.Context, filters []*Filt
 	}
 
 	for nextURL != "" {
-		res, err := http.Get(nextURL)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
+		if err != nil {
+			return fmt.Errorf("creating pricing request: %w", err)
+		}
+		res, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return err
 		}
 
 		if res.StatusCode != 200 {
+			res.Body.Close()
 			return fmt.Errorf("got a non-200 status code: %d", res.StatusCode)
 		}
 
 		resBody, err := io.ReadAll(res.Body)
+		res.Body.Close()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

The pricing API pagination loop never closed `res.Body`, leaking an HTTP connection per page on every 12-hour pricing update cycle. `http.Get` was used instead of `http.NewRequestWithContext`, so the context parameter was silently ignored (`_ context.Context`), preventing cancellation during operator shutdown.

Fix: use `http.NewRequestWithContext` to propagate context, and explicitly close `res.Body` after reading on every path (including non-200 status).

**How was this change tested?**

* `go test ./pkg/providers/pricing/...` passes
* `go vet ./pkg/providers/pricing/...` passes

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note

```
