### PR TITLE
fix: handle silenced errors in deep copy and instance type cache key

### DIFF
--- a/pkg/controllers/nodeclaim/inplaceupdate/controller.go
+++ b/pkg/controllers/nodeclaim/inplaceupdate/controller.go
@@ -215,9 +215,12 @@ func (c *Controller) applyAKSMachinePatch(
 	aksMachine *armcontainerservice.Machine,
 ) error {
 	// Create a deep copy of the original for diff comparison
-	originalBytes, _ := json.Marshal(aksMachine)
+	originalBytes, err := json.Marshal(aksMachine)
+	if err != nil {
+		return fmt.Errorf("failed to marshal AKS machine for deep copy: %w", err)
+	}
 	var originalAKSMachine armcontainerservice.Machine
-	err := json.Unmarshal(originalBytes, &originalAKSMachine)
+	err = json.Unmarshal(originalBytes, &originalAKSMachine)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal original AKS machine for comparison: %w", err)
 	}

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -118,7 +118,10 @@ func (p *DefaultProvider) List(
 	}
 
 	// Compute fully initialized instance types hash key
-	kcHash, _ := hashstructure.Hash(kc, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+	kcHash, kcHashErr := hashstructure.Hash(kc, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+	if kcHashErr != nil {
+		log.FromContext(ctx).Error(kcHashErr, "failed to hash kubelet configuration, skipping instance type cache")
+	}
 	key := fmt.Sprintf("%d-%d-%016x-%s-%d-%d-%t-%t",
 		p.instanceTypesSeqNum,
 		p.unavailableOfferings.SeqNum,
@@ -129,10 +132,12 @@ func (p *DefaultProvider) List(
 		nodeClass.GetEncryptionAtHost(),
 		nodeClass.IsLocalDNSEnabled(),
 	)
-	if item, ok := p.instanceTypesCache.Get(key); ok {
-		// Ensure what's returned from this function is a shallow-copy of the slice (not a deep-copy of the data itself)
-		// so that modifications to the ordering of the data don't affect the original
-		return append([]*cloudprovider.InstanceType{}, item.([]*cloudprovider.InstanceType)...), nil
+	if kcHashErr == nil {
+		if item, ok := p.instanceTypesCache.Get(key); ok {
+			// Ensure what's returned from this function is a shallow-copy of the slice (not a deep-copy of the data itself)
+			// so that modifications to the ordering of the data don't affect the original
+			return append([]*cloudprovider.InstanceType{}, item.([]*cloudprovider.InstanceType)...), nil
+		}
 	}
 
 	// Get Viable offerings
@@ -172,7 +177,9 @@ func (p *DefaultProvider) List(
 		result = append(result, instanceType)
 	}
 
-	p.instanceTypesCache.SetDefault(key, result)
+	if kcHashErr == nil {
+		p.instanceTypesCache.SetDefault(key, result)
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
## Summary
- **In-place update controller**: `json.Marshal` error was silenced during deep copy of AKS Machine object for diff comparison. If marshal failed, nil bytes would flow into `json.Unmarshal`, producing a confusing downstream error instead of a clear root cause.
- **Instance type provider**: `hashstructure.Hash` error was silenced when computing the cache key for fully-initialized instance types. If hashing failed, `kcHash` would be 0, causing cache key collisions across different kubelet configs — potentially returning incorrect cached instance types for a NodeClass. Now the cache is skipped entirely when hashing fails, trading performance for correctness.

## Test plan
- [x] `go test ./pkg/controllers/nodeclaim/inplaceupdate/...` passes
- [x] `go test ./pkg/providers/instancetype/...` passes
- [x] `go build ./...` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)