### PR TITLE
fix: correct misleading error wrapping in VM creation error handler

### DIFF
--- a/pkg/providers/instance/vminstance.go
+++ b/pkg/providers/instance/vminstance.go
@@ -811,7 +811,9 @@ func (p *DefaultVMProvider) beginLaunchInstance(
 	if err != nil {
 		sku, skuErr := p.instanceTypeProvider.Get(ctx, nodeClass, instanceType.Name)
 		if skuErr != nil {
-			return nil, fmt.Errorf("failed to get instance type %q: %w", instanceType.Name, err)
+			// Can't look up the SKU to do proper error handling (e.g., marking offerings unavailable),
+			// so return the original VM creation error with context about the SKU lookup failure.
+			return nil, fmt.Errorf("VM creation failed and unable to look up instance type %q for error handling (skuErr: %v): %w", instanceType.Name, skuErr, err)
 		}
 		handledError := p.errorHandling.Handle(ctx, sku, instanceType, zone, capacityType, err)
 		if handledError != nil {
@@ -855,7 +857,9 @@ func (p *DefaultVMProvider) beginLaunchInstance(
 
 				sku, skuErr := p.instanceTypeProvider.Get(ctx, nodeClass, instanceType.Name)
 				if skuErr != nil {
-					return fmt.Errorf("failed to get instance type %q: %w", instanceType.Name, err)
+					// Can't look up the SKU to do proper error handling (e.g., marking offerings unavailable),
+					// so return the original VM creation error with context about the SKU lookup failure.
+					return fmt.Errorf("VM creation failed and unable to look up instance type %q for error handling (skuErr: %v): %w", instanceType.Name, skuErr, err)
 				}
 				handledError := p.errorHandling.Handle(ctx, sku, instanceType, zone, capacityType, err)
 				if handledError != nil {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

When VM creation fails and the subsequent SKU lookup (for error handling like caching insufficient capacity) also fails, the error message said "failed to get instance type" but wrapped the original VM creation error (`err`) instead of the SKU lookup error (`skuErr`). This produced misleading logs like: `failed to get instance type "Standard_D2_v2": OperationNotAllowed: ...` where the inner error was about VM creation, not about the SKU lookup.

Fixed both the sync path and async path to include both errors with accurate context: `VM creation failed and unable to look up instance type "Standard_D2_v2" for error handling (skuErr: ...): <original VM creation error>`

**How was this change tested?**

* `go test ./pkg/providers/instance/...` passes
* `go build ./...` compiles clean

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note

```
