### PR TITLE
refactor: extract vminstancenic.go (PR 2/3)

### DIFF
--- a/pkg/providers/instance/vminstance.go
+++ b/pkg/providers/instance/vminstance.go
@@ -29,7 +29,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/samber/lo"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -378,93 +377,9 @@ func (p *DefaultVMProvider) createCSExtension(ctx context.Context, vmName string
 	return nil
 }
 
-func (p *DefaultVMProvider) newNetworkInterfaceForVM(opts *createNICOptions) armnetwork.Interface {
-	var ipv4BackendPools []*armnetwork.BackendAddressPool
-	for _, poolID := range opts.BackendPools.IPv4PoolIDs {
-		ipv4BackendPools = append(ipv4BackendPools, &armnetwork.BackendAddressPool{
-			ID: &poolID,
-		})
-	}
-
-	skuAcceleratedNetworkingRequirements := scheduling.NewRequirements(
-		scheduling.NewRequirement(v1beta1.LabelSKUAcceleratedNetworking, v1.NodeSelectorOpIn, "true"))
-
-	enableAcceleratedNetworking := false
-	if err := opts.InstanceType.Requirements.Compatible(skuAcceleratedNetworkingRequirements); err == nil {
-		enableAcceleratedNetworking = true
-	}
-
-	var nsgRef *armnetwork.SecurityGroup
-	if opts.NetworkSecurityGroupID != "" {
-		nsgRef = &armnetwork.SecurityGroup{
-			ID: &opts.NetworkSecurityGroupID,
-		}
-	}
-
-	nic := armnetwork.Interface{
-		Location: lo.ToPtr(p.location),
-		Properties: &armnetwork.InterfacePropertiesFormat{
-			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
-				{
-					Name: &opts.NICName,
-					Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
-						Primary:                   lo.ToPtr(true),
-						PrivateIPAllocationMethod: lo.ToPtr(armnetwork.IPAllocationMethodDynamic),
-
-						LoadBalancerBackendAddressPools: ipv4BackendPools,
-					},
-				},
-			},
-			NetworkSecurityGroup:        nsgRef,
-			EnableAcceleratedNetworking: lo.ToPtr(enableAcceleratedNetworking),
-			EnableIPForwarding:          lo.ToPtr(false),
-		},
-	}
-	if opts.NetworkPlugin == consts.NetworkPluginAzure && opts.NetworkPluginMode != consts.NetworkPluginModeOverlay {
-		// AzureCNI without overlay requires secondary IPs, for pods. (These IPs are not included in backend address pools.)
-		// NOTE: Unlike AKS RP, this logic does not reduce secondary IP count by the number of expected hostNetwork pods, favoring simplicity instead
-		for i := 1; i < int(opts.MaxPods); i++ {
-			nic.Properties.IPConfigurations = append(
-				nic.Properties.IPConfigurations,
-				&armnetwork.InterfaceIPConfiguration{
-					Name: lo.ToPtr(fmt.Sprintf("ipconfig%d", i)),
-					Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
-						Primary:                   lo.ToPtr(false),
-						PrivateIPAllocationMethod: lo.ToPtr(armnetwork.IPAllocationMethodDynamic),
-					},
-				},
-			)
-		}
-	}
-	return nic
-}
-
 // E.g., aks-default-2jf98
 func GenerateResourceName(nodeClaimName string) string {
 	return fmt.Sprintf("aks-%s", nodeClaimName)
-}
-
-type createNICOptions struct {
-	NICName                string
-	BackendPools           *loadbalancer.BackendAddressPools
-	InstanceType           *corecloudprovider.InstanceType
-	LaunchTemplate         *launchtemplate.Template
-	NetworkPlugin          string
-	NetworkPluginMode      string
-	MaxPods                int32
-	NetworkSecurityGroupID string
-}
-
-func (p *DefaultVMProvider) createNetworkInterface(ctx context.Context, opts *createNICOptions) (string, error) {
-	nic := p.newNetworkInterfaceForVM(opts)
-	p.applyTemplateToNic(&nic, opts.LaunchTemplate)
-	log.FromContext(ctx).V(1).Info("creating network interface", "nicName", opts.NICName)
-	res, err := createNic(ctx, p.azClient.NetworkInterfacesClient(), p.resourceGroup, opts.NICName, nic)
-	if err != nil {
-		return "", err
-	}
-	log.FromContext(ctx).V(1).Info("successfully created network interface", "nicName", opts.NICName, "nicID", *res.ID)
-	return *res.ID, nil
 }
 
 // createVMOptions contains all the parameters needed to create a VM
@@ -692,43 +607,8 @@ func (p *DefaultVMProvider) beginLaunchInstance(
 	// resourceName for the NIC, VM, and Disk
 	resourceName := GenerateResourceName(nodeClaim.Name)
 
-	backendPools, err := p.loadBalancerProvider.LoadBalancerBackendPools(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting backend pools: %w", err)
-	}
-	networkPlugin := options.FromContext(ctx).NetworkPlugin
-	networkPluginMode := options.FromContext(ctx).NetworkPluginMode
-
-	isAKSManagedVNET, err := utils.IsAKSManagedVNET(options.FromContext(ctx).NodeResourceGroup, launchTemplate.SubnetID)
-	if err != nil {
-		return nil, fmt.Errorf("checking if vnet is managed: %w", err)
-	}
-	var nsgID string
-	if !isAKSManagedVNET {
-		nsg, err := p.networkSecurityGroupProvider.ManagedNetworkSecurityGroup(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("getting managed network security group: %w", err)
-		}
-		nsgID = lo.FromPtr(nsg.ID)
-	}
-
-	// TODO: Not returning after launching this LRO because
-	// TODO: doing so would bypass the capacity and other errors that are currently handled by
-	// TODO: core pkg/controllers/nodeclaim/lifecycle/controller.go - in particular, there are metrics/events
-	// TODO: emitted in capacity failure cases that we probably want.
-	nicReference, err := p.createNetworkInterface(
-		ctx,
-		&createNICOptions{
-			NICName:                resourceName,
-			NetworkPlugin:          networkPlugin,
-			NetworkPluginMode:      networkPluginMode,
-			MaxPods:                utils.GetMaxPods(nodeClass, networkPlugin, networkPluginMode),
-			LaunchTemplate:         launchTemplate,
-			BackendPools:           backendPools,
-			InstanceType:           instanceType,
-			NetworkSecurityGroupID: nsgID,
-		},
-	)
+	// Create NIC
+	nicReference, err := p.buildAndCreateNIC(ctx, resourceName, instanceType, nodeClass, launchTemplate)
 	if err != nil {
 		return nil, err
 	}
@@ -827,14 +707,6 @@ func (p *DefaultVMProvider) beginLaunchInstance(
 		},
 		VM: result.VM,
 	}, nil
-}
-
-func (p *DefaultVMProvider) applyTemplateToNic(nic *armnetwork.Interface, template *launchtemplate.Template) {
-	// set tags
-	nic.Tags = template.Tags
-	for _, ipConfig := range nic.Properties.IPConfigurations {
-		ipConfig.Properties.Subnet = &armnetwork.Subnet{ID: &template.SubnetID}
-	}
 }
 
 func (p *DefaultVMProvider) getLaunchTemplate(

--- a/pkg/providers/instance/vminstancenic.go
+++ b/pkg/providers/instance/vminstancenic.go
@@ -1,0 +1,178 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/launchtemplate"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
+	"github.com/Azure/karpenter-provider-azure/pkg/utils"
+)
+
+type createNICOptions struct {
+	NICName                string
+	BackendPools           *loadbalancer.BackendAddressPools
+	InstanceType           *corecloudprovider.InstanceType
+	LaunchTemplate         *launchtemplate.Template
+	NetworkPlugin          string
+	NetworkPluginMode      string
+	MaxPods                int32
+	NetworkSecurityGroupID string
+}
+
+func (p *DefaultVMProvider) newNetworkInterfaceForVM(opts *createNICOptions) armnetwork.Interface {
+	var ipv4BackendPools []*armnetwork.BackendAddressPool
+	for _, poolID := range opts.BackendPools.IPv4PoolIDs {
+		ipv4BackendPools = append(ipv4BackendPools, &armnetwork.BackendAddressPool{
+			ID: &poolID,
+		})
+	}
+
+	skuAcceleratedNetworkingRequirements := scheduling.NewRequirements(
+		scheduling.NewRequirement(v1beta1.LabelSKUAcceleratedNetworking, v1.NodeSelectorOpIn, "true"))
+
+	enableAcceleratedNetworking := false
+	if err := opts.InstanceType.Requirements.Compatible(skuAcceleratedNetworkingRequirements); err == nil {
+		enableAcceleratedNetworking = true
+	}
+
+	var nsgRef *armnetwork.SecurityGroup
+	if opts.NetworkSecurityGroupID != "" {
+		nsgRef = &armnetwork.SecurityGroup{
+			ID: &opts.NetworkSecurityGroupID,
+		}
+	}
+
+	nic := armnetwork.Interface{
+		Location: lo.ToPtr(p.location),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+				{
+					Name: &opts.NICName,
+					Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+						Primary:                   lo.ToPtr(true),
+						PrivateIPAllocationMethod: lo.ToPtr(armnetwork.IPAllocationMethodDynamic),
+
+						LoadBalancerBackendAddressPools: ipv4BackendPools,
+					},
+				},
+			},
+			NetworkSecurityGroup:        nsgRef,
+			EnableAcceleratedNetworking: lo.ToPtr(enableAcceleratedNetworking),
+			EnableIPForwarding:          lo.ToPtr(false),
+		},
+	}
+	if opts.NetworkPlugin == consts.NetworkPluginAzure && opts.NetworkPluginMode != consts.NetworkPluginModeOverlay {
+		// AzureCNI without overlay requires secondary IPs, for pods. (These IPs are not included in backend address pools.)
+		// NOTE: Unlike AKS RP, this logic does not reduce secondary IP count by the number of expected hostNetwork pods, favoring simplicity instead
+		for i := 1; i < int(opts.MaxPods); i++ {
+			nic.Properties.IPConfigurations = append(
+				nic.Properties.IPConfigurations,
+				&armnetwork.InterfaceIPConfiguration{
+					Name: lo.ToPtr(fmt.Sprintf("ipconfig%d", i)),
+					Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+						Primary:                   lo.ToPtr(false),
+						PrivateIPAllocationMethod: lo.ToPtr(armnetwork.IPAllocationMethodDynamic),
+					},
+				},
+			)
+		}
+	}
+	return nic
+}
+
+func (p *DefaultVMProvider) applyTemplateToNic(nic *armnetwork.Interface, template *launchtemplate.Template) {
+	// set tags
+	nic.Tags = template.Tags
+	for _, ipConfig := range nic.Properties.IPConfigurations {
+		ipConfig.Properties.Subnet = &armnetwork.Subnet{ID: &template.SubnetID}
+	}
+}
+
+func (p *DefaultVMProvider) createNetworkInterface(ctx context.Context, opts *createNICOptions) (string, error) {
+	nic := p.newNetworkInterfaceForVM(opts)
+	p.applyTemplateToNic(&nic, opts.LaunchTemplate)
+	log.FromContext(ctx).V(1).Info("creating network interface", "nicName", opts.NICName)
+	res, err := createNic(ctx, p.azClient.NetworkInterfacesClient(), p.resourceGroup, opts.NICName, nic)
+	if err != nil {
+		return "", err
+	}
+	log.FromContext(ctx).V(1).Info("successfully created network interface", "nicName", opts.NICName, "nicID", *res.ID)
+	return *res.ID, nil
+}
+
+// buildAndCreateNIC consolidates NIC creation: fetches backend pools, resolves NSG if needed, builds and creates the NIC.
+func (p *DefaultVMProvider) buildAndCreateNIC(
+	ctx context.Context,
+	resourceName string,
+	instanceType *corecloudprovider.InstanceType,
+	nodeClass *v1beta1.AKSNodeClass,
+	launchTemplate *launchtemplate.Template,
+) (string, error) {
+	backendPools, err := p.loadBalancerProvider.LoadBalancerBackendPools(ctx)
+	if err != nil {
+		return "", fmt.Errorf("getting backend pools: %w", err)
+	}
+
+	nodeResourceGroup := options.FromContext(ctx).NodeResourceGroup
+	networkPlugin := options.FromContext(ctx).NetworkPlugin
+	networkPluginMode := options.FromContext(ctx).NetworkPluginMode
+
+	isAKSManagedVNET, err := utils.IsAKSManagedVNET(nodeResourceGroup, launchTemplate.SubnetID)
+	if err != nil {
+		return "", fmt.Errorf("checking if vnet is managed: %w", err)
+	}
+	var nsgID string
+	if !isAKSManagedVNET {
+		nsg, err := p.networkSecurityGroupProvider.ManagedNetworkSecurityGroup(ctx)
+		if err != nil {
+			return "", fmt.Errorf("getting managed network security group: %w", err)
+		}
+		nsgID = lo.FromPtr(nsg.ID)
+	}
+
+	nicReference, err := p.createNetworkInterface(
+		ctx,
+		&createNICOptions{
+			NICName:                resourceName,
+			NetworkPlugin:          networkPlugin,
+			NetworkPluginMode:      networkPluginMode,
+			MaxPods:                utils.GetMaxPods(nodeClass, networkPlugin, networkPluginMode),
+			LaunchTemplate:         launchTemplate,
+			BackendPools:           backendPools,
+			InstanceType:           instanceType,
+			NetworkSecurityGroupID: nsgID,
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return nicReference, nil
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Extract NIC construction functions from `vminstance.go` into `vminstancenic.go`: `createNICOptions`, `newNetworkInterfaceForVM`, `applyTemplateToNic`, `createNetworkInterface`.

Add `buildAndCreateNIC` orchestrator that consolidates backend pool fetching, NSG resolution, and NIC creation (previously scattered inline in `beginLaunchInstance`). Simplify `beginLaunchInstance` by replacing inline NIC logic with single `buildAndCreateNIC` call.

Part 2 of 3 in the VM path refactoring series. Stacked on PR 1 (#1484).

**How was this change tested?**

* `go build ./...` passes
* `go test ./pkg/providers/instance/...` passes
* `go test ./pkg/cloudprovider/...` passes

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note

```
