### PR TITLE
test: add multi-instance provisioning and batch grouping tests

### DIFF
--- a/pkg/cloudprovider/suite_integration_test.go
+++ b/pkg/cloudprovider/suite_integration_test.go
@@ -604,6 +604,9 @@ var _ = Describe("CloudProvider", func() {
 
 		// Run shared AKS Machine API tests
 		runSharedAKSMachineAPITests()
+
+		// Multi-instance provisioning tests (mode-agnostic)
+		runSharedMultiInstanceProvisionTests()
 	})
 
 	Context("ProvisionMode = AKSMachineAPI, ManageExistingAKSMachines = true", func() {
@@ -683,6 +686,10 @@ var _ = Describe("CloudProvider", func() {
 		})
 
 		runSharedAKSMachineAPITests()
+
+		// Multi-instance provisioning tests (mode-agnostic) + batch grouping tests
+		runSharedMultiInstanceProvisionTests()
+		runBatchSpecificMultiInstanceTests()
 	})
 
 	Context("ProvisionMode = AKSMachineAPI + Batch, ManageExistingAKSMachines = true", func() {
@@ -723,6 +730,10 @@ var _ = Describe("CloudProvider", func() {
 		})
 
 		runSharedAKSMachineAPITests()
+
+		// Multi-instance provisioning tests (mode-agnostic) + batch grouping tests
+		runSharedMultiInstanceProvisionTests()
+		runBatchSpecificMultiInstanceTests()
 	})
 
 	Context("Mixed Environment - Migration from ProvisionMode = AKSMachineAPI to VM mode", func() {

--- a/pkg/cloudprovider/suite_shared_provision_test.go
+++ b/pkg/cloudprovider/suite_shared_provision_test.go
@@ -36,6 +36,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -1341,7 +1342,11 @@ func runBatchPerMachineFieldsCorrectnessTests() {
 		It("should preserve all NodeClass-derived shared fields through batch for multiple machines", func() {
 			// Set additional fields on the shared nodeClass, then provision 3 machines through batch
 			// and verify all shared fields arrive on every machine — including deeply nested ones.
+			origSpec := nodeClass.Spec
+			DeferCleanup(func() { nodeClass.Spec = origSpec })
+
 			nodeClass.Spec.MaxPods = lo.ToPtr[int32](100)
+			nodeClass.Spec.Security = &v1beta1.Security{EncryptionAtHost: lo.ToPtr(true)}
 			nodeClass.Spec.Kubelet = &v1beta1.KubeletConfiguration{
 				CPUCFSQuota: lo.ToPtr(false),
 			}
@@ -1354,17 +1359,32 @@ func runBatchPerMachineFieldsCorrectnessTests() {
 			nodeClass.Spec.ArtifactStreaming = &v1beta1.ArtifactStreaming{
 				Enabled: lo.ToPtr(true),
 			}
-			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			nodeClass.Spec.LocalDNS = &v1beta1.LocalDNS{
+				Mode:             v1beta1.LocalDNSModeRequired,
+				VnetDNSOverrides: validLocalDNSOverridePair(v1beta1.LocalDNSForwardDestinationVnetDNS),
+				KubeDNSOverrides: validLocalDNSOverridePair(v1beta1.LocalDNSForwardDestinationClusterCoreDNS),
+			}
+			// Re-apply and reconcile after spec changes to ensure status matches new generation.
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
 			resetBatchCallCounter()
 
+			// Use pod-based provisioning (like suite_features_test.go) since it handles
+			// nodeClass readiness correctly after spec changes.
 			const count = 3
-			claims := makeNClaims(count, "Standard_D2_v2")
-			results := concurrentCreateAndWaitForPromises(claims)
-			expectAllSucceeded(results)
-
-			// Should batch into a single call (same template)
-			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			pods := make([]*v1.Pod, count)
+			for i := 0; i < count; i++ {
+				pods[i] = coretest.UnschedulablePod(coretest.PodOptions{
+					ResourceRequirements: v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("3")},
+					},
+				})
+			}
+			for _, pod := range pods {
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
+				ExpectScheduled(ctx, env.Client, pod)
+			}
+			cloudProvider.WaitForInstancePromises()
 
 			machines := collectMachinesFromDataStore()
 			Expect(machines).To(HaveLen(count))
@@ -1373,47 +1393,59 @@ func runBatchPerMachineFieldsCorrectnessTests() {
 				props := m.Properties
 				Expect(props).ToNot(BeNil())
 
-				// MaxPods (flat field from NodeClass → Kubernetes.MaxPods)
+				// MaxPods (flat: NodeClass.MaxPods → Kubernetes.MaxPods)
 				Expect(props.Kubernetes).ToNot(BeNil())
 				Expect(lo.FromPtr(props.Kubernetes.MaxPods)).To(Equal(int32(100)),
-					"MaxPods should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+					"MaxPods should be preserved for machine %s", lo.FromPtr(m.Name))
 
-				// OSDiskSizeGB (default from test.AKSNodeClass → OperatingSystem.OSDiskSizeGB)
+				// OSDiskSizeGB (flat: default 128 → OperatingSystem.OSDiskSizeGB)
 				Expect(props.OperatingSystem).ToNot(BeNil())
 				Expect(lo.FromPtr(props.OperatingSystem.OSDiskSizeGB)).To(Equal(int32(128)),
-					"OSDiskSizeGB should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+					"OSDiskSizeGB should be preserved for machine %s", lo.FromPtr(m.Name))
+
+				// EncryptionAtHost (nested: Security.EncryptionAtHost → Security.EnableEncryptionAtHost)
+				Expect(props.Security).ToNot(BeNil())
+				Expect(lo.FromPtr(props.Security.EnableEncryptionAtHost)).To(BeTrue(),
+					"EncryptionAtHost should be preserved for machine %s", lo.FromPtr(m.Name))
 
 				// KubeletConfig (nested: NodeClass.Kubelet → Kubernetes.KubeletConfig)
 				Expect(props.Kubernetes.KubeletConfig).ToNot(BeNil(),
-					"KubeletConfig should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+					"KubeletConfig should be preserved for machine %s", lo.FromPtr(m.Name))
 				Expect(lo.FromPtr(props.Kubernetes.KubeletConfig.CPUCfsQuota)).To(BeFalse(),
-					"KubeletConfig.CPUCfsQuota should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+					"KubeletConfig.CPUCfsQuota should be preserved for machine %s", lo.FromPtr(m.Name))
 
-				// LinuxOSConfig sysctls (deeply nested: 4 levels)
+				// LinuxOSConfig sysctls (4 levels: OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls.*)
 				Expect(props.OperatingSystem.LinuxProfile).ToNot(BeNil(),
-					"LinuxProfile should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+					"LinuxProfile should be preserved for machine %s", lo.FromPtr(m.Name))
 				Expect(props.OperatingSystem.LinuxProfile.LinuxOSConfig).ToNot(BeNil(),
-					"LinuxOSConfig should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+					"LinuxOSConfig should be preserved for machine %s", lo.FromPtr(m.Name))
 				Expect(props.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls).ToNot(BeNil(),
-					"Sysctls should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+					"Sysctls should be preserved for machine %s", lo.FromPtr(m.Name))
 				Expect(lo.FromPtr(props.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls.NetCoreRmemMax)).To(Equal(int32(16777216)),
-					"NetCoreRmemMax sysctl should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+					"NetCoreRmemMax should be preserved for machine %s", lo.FromPtr(m.Name))
 				Expect(lo.FromPtr(props.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls.NetCoreSomaxconn)).To(Equal(int32(4096)),
-					"NetCoreSomaxconn sysctl should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+					"NetCoreSomaxconn should be preserved for machine %s", lo.FromPtr(m.Name))
 
 				// ArtifactStreaming (nested: NodeClass.ArtifactStreaming → Kubernetes.ArtifactStreamingProfile)
 				Expect(props.Kubernetes.ArtifactStreamingProfile).ToNot(BeNil(),
-					"ArtifactStreamingProfile should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+					"ArtifactStreamingProfile should be preserved for machine %s", lo.FromPtr(m.Name))
 				Expect(lo.FromPtr(props.Kubernetes.ArtifactStreamingProfile.Enabled)).To(BeTrue(),
-					"ArtifactStreamingProfile.Enabled should be true for machine %s", lo.FromPtr(m.Name))
+					"ArtifactStreaming.Enabled should be true for machine %s", lo.FromPtr(m.Name))
+
+				// LocalDNS (nested: NodeClass.LocalDNS → LocalDNSProfile)
+				Expect(props.LocalDNSProfile).ToNot(BeNil(),
+					"LocalDNSProfile should be preserved for machine %s", lo.FromPtr(m.Name))
+				Expect(lo.FromPtr(props.LocalDNSProfile.Mode)).To(Equal(armcontainerservice.LocalDNSModeRequired),
+					"LocalDNSProfile.Mode should be preserved for machine %s", lo.FromPtr(m.Name))
 			}
 		})
 
 		It("should preserve per-machine fields when shared fields are also populated", func() {
-			// Verifies that with a richly-configured NodeClass, per-machine fields
-			// (tags, zones) still arrive correctly on each machine — the batch pipeline
-			// doesn't corrupt or drop them when shared fields are present.
+			origSpec := nodeClass.Spec
+			DeferCleanup(func() { nodeClass.Spec = origSpec })
+
 			nodeClass.Spec.MaxPods = lo.ToPtr[int32](100)
+			nodeClass.Spec.Security = &v1beta1.Security{EncryptionAtHost: lo.ToPtr(true)}
 			nodeClass.Spec.Kubelet = &v1beta1.KubeletConfiguration{
 				CPUCFSQuota: lo.ToPtr(false),
 			}
@@ -1422,15 +1454,25 @@ func runBatchPerMachineFieldsCorrectnessTests() {
 					NetCoreRmemMax: lo.ToPtr[int32](16777216),
 				},
 			}
-			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			nodeClass.Spec.LocalDNS = &v1beta1.LocalDNS{
+				Mode:             v1beta1.LocalDNSModeRequired,
+				VnetDNSOverrides: validLocalDNSOverridePair(v1beta1.LocalDNSForwardDestinationVnetDNS),
+				KubeDNSOverrides: validLocalDNSOverridePair(v1beta1.LocalDNSForwardDestinationClusterCoreDNS),
+			}
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 			ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
-			resetBatchCallCounter()
 
 			const count = 3
-			claims := makeNClaims(count, "Standard_D2_v2")
-
-			results := concurrentCreateAndWaitForPromises(claims)
-			expectAllSucceeded(results)
+			for i := 0; i < count; i++ {
+				pod := coretest.UnschedulablePod(coretest.PodOptions{
+					ResourceRequirements: v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("3")},
+					},
+				})
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, coreProvisioner, pod)
+				ExpectScheduled(ctx, env.Client, pod)
+			}
+			cloudProvider.WaitForInstancePromises()
 
 			machines := collectMachinesFromDataStore()
 			Expect(machines).To(HaveLen(count))
@@ -1452,10 +1494,13 @@ func runBatchPerMachineFieldsCorrectnessTests() {
 				// Shared fields also present (not dropped by per-machine extraction)
 				Expect(lo.FromPtr(m.Properties.OperatingSystem.OSDiskSizeGB)).To(Equal(int32(128)))
 				Expect(lo.FromPtr(m.Properties.Kubernetes.MaxPods)).To(Equal(int32(100)))
+				Expect(lo.FromPtr(m.Properties.Security.EnableEncryptionAtHost)).To(BeTrue())
 				Expect(m.Properties.Kubernetes.KubeletConfig).ToNot(BeNil())
 				Expect(m.Properties.OperatingSystem.LinuxProfile).ToNot(BeNil())
 				Expect(m.Properties.OperatingSystem.LinuxProfile.LinuxOSConfig).ToNot(BeNil())
 				Expect(m.Properties.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls).ToNot(BeNil())
+				Expect(m.Properties.LocalDNSProfile).ToNot(BeNil())
+				Expect(lo.FromPtr(m.Properties.LocalDNSProfile.Mode)).To(Equal(armcontainerservice.LocalDNSModeRequired))
 			}
 		})
 	})

--- a/pkg/cloudprovider/suite_shared_provision_test.go
+++ b/pkg/cloudprovider/suite_shared_provision_test.go
@@ -1340,13 +1340,19 @@ func runBatchPerMachineFieldsCorrectnessTests() {
 
 		It("should preserve all NodeClass-derived shared fields through batch for multiple machines", func() {
 			// Set additional fields on the shared nodeClass, then provision 3 machines through batch
-			// and verify all shared fields arrive on every machine.
+			// and verify all shared fields arrive on every machine — including deeply nested ones.
 			nodeClass.Spec.MaxPods = lo.ToPtr[int32](100)
+			nodeClass.Spec.Kubelet = &v1beta1.KubeletConfiguration{
+				CPUCFSQuota: lo.ToPtr(false),
+			}
 			nodeClass.Spec.LinuxOSConfig = &v1beta1.LinuxOSConfiguration{
 				Sysctls: &v1beta1.SysctlConfiguration{
 					NetCoreRmemMax:   lo.ToPtr[int32](16777216),
 					NetCoreSomaxconn: lo.ToPtr[int32](4096),
 				},
+			}
+			nodeClass.Spec.ArtifactStreaming = &v1beta1.ArtifactStreaming{
+				Enabled: lo.ToPtr(true),
 			}
 			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
 			ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
@@ -1367,15 +1373,21 @@ func runBatchPerMachineFieldsCorrectnessTests() {
 				props := m.Properties
 				Expect(props).ToNot(BeNil())
 
-				// MaxPods (flat field from NodeClass)
+				// MaxPods (flat field from NodeClass → Kubernetes.MaxPods)
 				Expect(props.Kubernetes).ToNot(BeNil())
 				Expect(lo.FromPtr(props.Kubernetes.MaxPods)).To(Equal(int32(100)),
 					"MaxPods should be preserved through batch for machine %s", lo.FromPtr(m.Name))
 
-				// OSDiskSizeGB (default from test.AKSNodeClass)
+				// OSDiskSizeGB (default from test.AKSNodeClass → OperatingSystem.OSDiskSizeGB)
 				Expect(props.OperatingSystem).ToNot(BeNil())
 				Expect(lo.FromPtr(props.OperatingSystem.OSDiskSizeGB)).To(Equal(int32(128)),
 					"OSDiskSizeGB should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+
+				// KubeletConfig (nested: NodeClass.Kubelet → Kubernetes.KubeletConfig)
+				Expect(props.Kubernetes.KubeletConfig).ToNot(BeNil(),
+					"KubeletConfig should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+				Expect(lo.FromPtr(props.Kubernetes.KubeletConfig.CPUCfsQuota)).To(BeFalse(),
+					"KubeletConfig.CPUCfsQuota should be preserved through batch for machine %s", lo.FromPtr(m.Name))
 
 				// LinuxOSConfig sysctls (deeply nested: 4 levels)
 				Expect(props.OperatingSystem.LinuxProfile).ToNot(BeNil(),
@@ -1388,6 +1400,12 @@ func runBatchPerMachineFieldsCorrectnessTests() {
 					"NetCoreRmemMax sysctl should be preserved through batch for machine %s", lo.FromPtr(m.Name))
 				Expect(lo.FromPtr(props.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls.NetCoreSomaxconn)).To(Equal(int32(4096)),
 					"NetCoreSomaxconn sysctl should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+
+				// ArtifactStreaming (nested: NodeClass.ArtifactStreaming → Kubernetes.ArtifactStreamingProfile)
+				Expect(props.Kubernetes.ArtifactStreamingProfile).ToNot(BeNil(),
+					"ArtifactStreamingProfile should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+				Expect(lo.FromPtr(props.Kubernetes.ArtifactStreamingProfile.Enabled)).To(BeTrue(),
+					"ArtifactStreamingProfile.Enabled should be true for machine %s", lo.FromPtr(m.Name))
 			}
 		})
 
@@ -1396,6 +1414,9 @@ func runBatchPerMachineFieldsCorrectnessTests() {
 			// (tags, zones) still arrive correctly on each machine — the batch pipeline
 			// doesn't corrupt or drop them when shared fields are present.
 			nodeClass.Spec.MaxPods = lo.ToPtr[int32](100)
+			nodeClass.Spec.Kubelet = &v1beta1.KubeletConfiguration{
+				CPUCFSQuota: lo.ToPtr(false),
+			}
 			nodeClass.Spec.LinuxOSConfig = &v1beta1.LinuxOSConfiguration{
 				Sysctls: &v1beta1.SysctlConfiguration{
 					NetCoreRmemMax: lo.ToPtr[int32](16777216),
@@ -1431,6 +1452,7 @@ func runBatchPerMachineFieldsCorrectnessTests() {
 				// Shared fields also present (not dropped by per-machine extraction)
 				Expect(lo.FromPtr(m.Properties.OperatingSystem.OSDiskSizeGB)).To(Equal(int32(128)))
 				Expect(lo.FromPtr(m.Properties.Kubernetes.MaxPods)).To(Equal(int32(100)))
+				Expect(m.Properties.Kubernetes.KubeletConfig).ToNot(BeNil())
 				Expect(m.Properties.OperatingSystem.LinuxProfile).ToNot(BeNil())
 				Expect(m.Properties.OperatingSystem.LinuxProfile.LinuxOSConfig).ToNot(BeNil())
 				Expect(m.Properties.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls).ToNot(BeNil())

--- a/pkg/cloudprovider/suite_shared_provision_test.go
+++ b/pkg/cloudprovider/suite_shared_provision_test.go
@@ -673,10 +673,8 @@ func makeNodeClaimForInstanceType(instanceType string) *karpv1.NodeClaim {
 				Name:  nodeClass.Name,
 			},
 			Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
-				{NodeSelectorRequirement: v1.NodeSelectorRequirement{
-					Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn,
-					Values: []string{instanceType},
-				}},
+				{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn,
+					Values: []string{instanceType}},
 			},
 		},
 	})

--- a/pkg/cloudprovider/suite_shared_provision_test.go
+++ b/pkg/cloudprovider/suite_shared_provision_test.go
@@ -704,11 +704,6 @@ func collectMachinesFromDataStore() []armcontainerservice.Machine {
 	return machines
 }
 
-// isBatchEnabled returns true if batch creation is enabled in the current test options.
-func isBatchEnabled() bool {
-	return testOptions.BatchCreationEnabled
-}
-
 // runSharedMultiInstanceProvisionTests verifies multi-instance provisioning
 // correctness. These tests are mode-agnostic — they assert on outcomes (machines
 // created, correct properties) but NOT on batch grouping (API call counts).
@@ -770,6 +765,40 @@ func runSharedMultiInstanceProvisionTests() {
 	})
 }
 
+// countMachinesByVMSize returns a map of VM size → count from the data store.
+func countMachinesByVMSize() map[string]int {
+	machines := collectMachinesFromDataStore()
+	vmSizes := make(map[string]int)
+	for _, m := range machines {
+		if m.Properties != nil && m.Properties.Hardware != nil && m.Properties.Hardware.VMSize != nil {
+			vmSizes[*m.Properties.Hardware.VMSize]++
+		}
+	}
+	return vmSizes
+}
+
+// makeNClaims creates n NodeClaims all requesting the same instance type.
+func makeNClaims(n int, instanceType string) []*karpv1.NodeClaim {
+	claims := make([]*karpv1.NodeClaim, n)
+	for i := 0; i < n; i++ {
+		claims[i] = makeNodeClaimForInstanceType(instanceType)
+	}
+	return claims
+}
+
+// expectAllSucceeded asserts that all results succeeded with non-nil NodeClaims.
+func expectAllSucceeded(results []concurrentCreateResult) {
+	for i, r := range results {
+		Expect(r.Err).ToNot(HaveOccurred(), "claim %d failed", i)
+		Expect(r.NodeClaim).ToNot(BeNil(), "claim %d returned nil", i)
+	}
+}
+
+// resetBatchCallCounter resets the CalledWithInput counter on the AKS Machines API fake.
+func resetBatchCallCounter() {
+	azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Reset()
+}
+
 // runBatchSpecificMultiInstanceTests verifies batch grouping behavior — that
 // concurrent creates with the same template land in the same batch (single API
 // call) and different templates produce separate batches. Only meaningful under
@@ -782,39 +811,23 @@ func runBatchSpecificMultiInstanceTests() {
 	Context("Batch Grouping", func() {
 		It("should batch same-template instances into a single API call", func() {
 			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
-			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Reset()
+			resetBatchCallCounter()
 
-			// Create 5 NodeClaims all requesting the same instance type.
-			// They should all land in the same batch because they produce
-			// identical template hashes (same VM size, same node class config).
 			const count = 5
-			claims := make([]*karpv1.NodeClaim, count)
-			for i := 0; i < count; i++ {
-				claims[i] = makeNodeClaimForInstanceType("Standard_D2_v2")
-			}
-
+			claims := makeNClaims(count, "Standard_D2_v2")
 			results := concurrentCreateAndWaitForPromises(claims)
-
-			for i, r := range results {
-				Expect(r.Err).ToNot(HaveOccurred(), "claim %d failed", i)
-				Expect(r.NodeClaim).ToNot(BeNil(), "claim %d returned nil", i)
-			}
+			expectAllSucceeded(results)
 
 			// Core assertion: all 5 went through a single BeginCreateOrUpdate call
 			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1),
 				"expected 1 batch API call for 5 same-template creates")
-
-			// All 5 machines should be in the data store
 			Expect(countMachinesInDataStore()).To(Equal(count))
 		})
 
 		It("should split different-template instances into separate batches", func() {
 			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
-			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Reset()
+			resetBatchCallCounter()
 
-			// Create 5 NodeClaims: 3 × Standard_D2_v2, 2 × Standard_D4s_v3.
-			// Different VM sizes produce different template hashes, so these
-			// should result in 2 separate batches.
 			claims := []*karpv1.NodeClaim{
 				makeNodeClaimForInstanceType("Standard_D2_v2"),
 				makeNodeClaimForInstanceType("Standard_D2_v2"),
@@ -822,57 +835,33 @@ func runBatchSpecificMultiInstanceTests() {
 				makeNodeClaimForInstanceType("Standard_D4s_v3"),
 				makeNodeClaimForInstanceType("Standard_D4s_v3"),
 			}
-
 			results := concurrentCreateAndWaitForPromises(claims)
-
-			for i, r := range results {
-				Expect(r.Err).ToNot(HaveOccurred(), "claim %d failed", i)
-				Expect(r.NodeClaim).ToNot(BeNil(), "claim %d returned nil", i)
-			}
+			expectAllSucceeded(results)
 
 			// Core assertion: 2 distinct template hashes → 2 batch API calls
 			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(2),
 				"expected 2 batch API calls for 2 distinct template hashes")
-
-			// All 5 machines should be in the data store
 			Expect(countMachinesInDataStore()).To(Equal(5))
 
-			// Verify correct VM size distribution
-			machines := collectMachinesFromDataStore()
-			vmSizes := make(map[string]int)
-			for _, m := range machines {
-				if m.Properties != nil && m.Properties.Hardware != nil && m.Properties.Hardware.VMSize != nil {
-					vmSizes[*m.Properties.Hardware.VMSize]++
-				}
-			}
+			vmSizes := countMachinesByVMSize()
 			Expect(vmSizes["Standard_D2_v2"]).To(Equal(3))
 			Expect(vmSizes["Standard_D4s_v3"]).To(Equal(2))
 		})
 
 		It("should propagate per-machine tags through batch", func() {
 			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
-			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Reset()
+			resetBatchCallCounter()
 
-			// Create 3 same-template NodeClaims. Even though they share the
-			// same template, each machine should get unique per-machine tags
-			// (e.g., nodeclaim name, creation timestamp) because the batch
-			// coordinator preserves per-machine entries.
 			const count = 3
-			claims := make([]*karpv1.NodeClaim, count)
-			for i := 0; i < count; i++ {
-				claims[i] = makeNodeClaimForInstanceType("Standard_D2_v2")
-			}
-
+			claims := makeNClaims(count, "Standard_D2_v2")
 			results := concurrentCreateAndWaitForPromises(claims)
 
 			for i, r := range results {
 				Expect(r.Err).ToNot(HaveOccurred(), "claim %d failed", i)
 			}
 
-			// All should be batched into 1 call
 			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
 
-			// Each machine should have unique tags
 			machines := collectMachinesFromDataStore()
 			Expect(machines).To(HaveLen(count))
 
@@ -881,8 +870,6 @@ func runBatchSpecificMultiInstanceTests() {
 				Expect(m.Name).ToNot(BeNil(), "machine name should not be nil")
 				Expect(machineNames).ToNot(HaveKey(*m.Name), "machine names should be unique")
 				machineNames[*m.Name] = true
-
-				// Per-machine tags should be set
 				Expect(m.Properties).ToNot(BeNil())
 				Expect(m.Properties.Tags).ToNot(BeNil(), "per-machine tags should not be nil for machine %s", *m.Name)
 			}
@@ -890,29 +877,20 @@ func runBatchSpecificMultiInstanceTests() {
 
 		It("should propagate batch error to all machines in the batch", func() {
 			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
-			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Reset()
+			resetBatchCallCounter()
 
-			// Inject a BeginError — this simulates the Azure API returning
-			// an error for the entire batch.
 			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.BeginError.Set(
 				&azcore.ResponseError{ErrorCode: "BatchFailed"},
 			)
 			defer azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.BeginError.Set(nil)
 
 			const count = 3
-			claims := make([]*karpv1.NodeClaim, count)
-			for i := 0; i < count; i++ {
-				claims[i] = makeNodeClaimForInstanceType("Standard_D2_v2")
-			}
-
+			claims := makeNClaims(count, "Standard_D2_v2")
 			results := concurrentCreateAndWaitForPromises(claims)
 
-			// All creates should have failed
 			for i, r := range results {
 				Expect(r.Err).To(HaveOccurred(), "claim %d should have failed", i)
 			}
-
-			// No machines should have been stored
 			Expect(countMachinesInDataStore()).To(Equal(0))
 		})
 	})

--- a/pkg/cloudprovider/suite_shared_provision_test.go
+++ b/pkg/cloudprovider/suite_shared_provision_test.go
@@ -780,7 +780,7 @@ func countMachinesByVMSize() map[string]int {
 }
 
 // makeNClaims creates n NodeClaims all requesting the same instance type.
-func makeNClaims(n int, instanceType string) []*karpv1.NodeClaim {
+func makeNClaims(n int, instanceType string) []*karpv1.NodeClaim { //nolint:unparam
 	claims := make([]*karpv1.NodeClaim, n)
 	for i := 0; i < n; i++ {
 		claims[i] = makeNodeClaimForInstanceType(instanceType)
@@ -810,6 +810,14 @@ func resetBatchCallCounter() {
 // BeginCreateOrUpdate was called. The coordinator calls it once per batch,
 // so N same-template creates → 1 call, K distinct templates → K calls.
 func runBatchSpecificMultiInstanceTests() {
+	runBatchGroupingTests()
+	runBatchErrorHandlingTests()
+	runBatchPerMachineFieldsCorrectnessTests()
+}
+
+// runBatchGroupingTests verifies batch grouping behavior — that
+// BeginCreateOrUpdate was called the right number of times.
+func runBatchGroupingTests() {
 	Context("Batch Grouping", func() {
 		It("should batch same-template instances into a single API call", func() {
 			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
@@ -1007,7 +1015,9 @@ func runBatchSpecificMultiInstanceTests() {
 			Expect(countMachinesInDataStore()).To(Equal(0))
 		})
 	})
+}
 
+func runBatchErrorHandlingTests() {
 	Context("Batch Error Handling", func() {
 		BeforeEach(func() {
 			mode := options.FromContext(ctx).ProvisionMode
@@ -1164,7 +1174,9 @@ func runBatchSpecificMultiInstanceTests() {
 			Expect(countMachinesInDataStore()).To(Equal(3))
 		})
 	})
+}
 
+func runBatchPerMachineFieldsCorrectnessTests() {
 	Context("Batch Per-Machine Fields Correctness", func() {
 		It("should store correct per-machine zones for each machine in the batch", func() {
 			ExpectApplied(ctx, env.Client, nodeClass, nodePool)

--- a/pkg/cloudprovider/suite_shared_provision_test.go
+++ b/pkg/cloudprovider/suite_shared_provision_test.go
@@ -1118,5 +1118,101 @@ func runBatchSpecificMultiInstanceTests() {
 			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(
 				Equal(1), "different zones should not split batches")
 		})
+
+		It("should store non-empty zones for each machine in the batch", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			resetBatchCallCounter()
+
+			const count = 3
+			claims := makeNClaims(count, "Standard_D2_v2")
+			results := concurrentCreateAndWaitForPromises(claims)
+			expectAllSucceeded(results)
+
+			machines := collectMachinesFromDataStore()
+			Expect(machines).To(HaveLen(count))
+
+			for _, m := range machines {
+				Expect(m.Zones).ToNot(BeEmpty(), "machine %s should have zones set", lo.FromPtr(m.Name))
+				for _, z := range m.Zones {
+					Expect(z).ToNot(BeNil(), "zone should not be nil for machine %s", lo.FromPtr(m.Name))
+					Expect(*z).To(MatchRegexp(`^[1-9][0-9]*$`), "zone should be a valid number for machine %s", lo.FromPtr(m.Name))
+				}
+			}
+		})
+
+		It("should preserve shared MachineProperties fields through batch for all machines", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			resetBatchCallCounter()
+
+			const count = 3
+			claims := makeNClaims(count, "Standard_D2_v2")
+			results := concurrentCreateAndWaitForPromises(claims)
+			expectAllSucceeded(results)
+
+			machines := collectMachinesFromDataStore()
+			Expect(machines).To(HaveLen(count))
+
+			for _, m := range machines {
+				props := m.Properties
+				Expect(props).ToNot(BeNil(), "machine %s should have properties", lo.FromPtr(m.Name))
+
+				// Hardware
+				Expect(props.Hardware).ToNot(BeNil(), "machine %s: Hardware should not be nil", lo.FromPtr(m.Name))
+				Expect(lo.FromPtr(props.Hardware.VMSize)).To(Equal("Standard_D2_v2"), "machine %s: VMSize mismatch", lo.FromPtr(m.Name))
+
+				// OperatingSystem
+				Expect(props.OperatingSystem).ToNot(BeNil(), "machine %s: OperatingSystem should not be nil", lo.FromPtr(m.Name))
+				Expect(props.OperatingSystem.OSType).ToNot(BeNil(), "machine %s: OSType should not be nil", lo.FromPtr(m.Name))
+				Expect(*props.OperatingSystem.OSType).To(Equal(armcontainerservice.OSTypeLinux))
+
+				// Kubernetes
+				Expect(props.Kubernetes).ToNot(BeNil(), "machine %s: Kubernetes should not be nil", lo.FromPtr(m.Name))
+				Expect(props.Kubernetes.OrchestratorVersion).ToNot(BeNil(), "machine %s: OrchestratorVersion should not be nil", lo.FromPtr(m.Name))
+
+				// NodeImageVersion
+				Expect(props.NodeImageVersion).ToNot(BeNil(), "machine %s: NodeImageVersion should not be nil", lo.FromPtr(m.Name))
+
+				// Mode
+				Expect(props.Mode).ToNot(BeNil(), "machine %s: Mode should not be nil", lo.FromPtr(m.Name))
+
+				// Security
+				Expect(props.Security).ToNot(BeNil(), "machine %s: Security should not be nil", lo.FromPtr(m.Name))
+
+				// Network
+				Expect(props.Network).ToNot(BeNil(), "machine %s: Network should not be nil", lo.FromPtr(m.Name))
+			}
+		})
+
+		It("should give each machine its own tags map (no shared reference)", func() {
+			// Verifies that template mutation in batch doesn't cause machines to share the same tags map
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			resetBatchCallCounter()
+
+			const count = 3
+			claims := makeNClaims(count, "Standard_D2_v2")
+			results := concurrentCreateAndWaitForPromises(claims)
+			expectAllSucceeded(results)
+
+			machines := collectMachinesFromDataStore()
+			Expect(machines).To(HaveLen(count))
+
+			// Collect all tag map pointers — they must be distinct (no aliasing)
+			tagPtrs := make(map[*map[string]*string]bool)
+			for _, m := range machines {
+				Expect(m.Properties.Tags).ToNot(BeNil())
+				ptr := &m.Properties.Tags
+				Expect(tagPtrs).ToNot(HaveKey(ptr), "machines should not share the same tags map reference")
+				tagPtrs[ptr] = true
+			}
+
+			// Also verify NodeClaim tag values are all distinct
+			ncTagValues := make(map[string]bool)
+			for _, m := range machines {
+				ncTag := m.Properties.Tags[launchtemplate.KarpenterAKSMachineNodeClaimTagKey]
+				Expect(ncTag).ToNot(BeNil())
+				Expect(ncTagValues).ToNot(HaveKey(*ncTag), "NodeClaim tags should be unique across machines")
+				ncTagValues[*ncTag] = true
+			}
+		})
 	})
 }

--- a/pkg/cloudprovider/suite_shared_provision_test.go
+++ b/pkg/cloudprovider/suite_shared_provision_test.go
@@ -28,6 +28,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/awslabs/operatorpkg/object"
@@ -50,6 +51,8 @@ import (
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+
+	. "github.com/Azure/karpenter-provider-azure/pkg/test/expectations"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Azure/karpenter-provider-azure/pkg/consts"
@@ -890,6 +893,163 @@ func runBatchSpecificMultiInstanceTests() {
 				Expect(r.Err).To(HaveOccurred(), "claim %d should have failed", i)
 			}
 			Expect(countMachinesInDataStore()).To(Equal(0))
+		})
+	})
+
+	Context("Batch Error Handling", func() {
+		BeforeEach(func() {
+			mode := options.FromContext(ctx).ProvisionMode
+			if mode != consts.ProvisionModeAKSMachineAPIHeaderBatch {
+				Skip("batch error handling tests only apply to batch mode")
+			}
+		})
+
+		It("should handle per-machine partial failure: failed machines get errors, successful machines provision", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			resetBatchCallCounter()
+
+			// m-fail machines get client error, others succeed
+			azureEnv.AKSMachinesAPI.BatchMachineErrorFunc = func(name string) (string, string) {
+				if strings.Contains(name, "claim-0") {
+					return "InvalidParameter", "simulated client error"
+				}
+				return "", ""
+			}
+			defer func() { azureEnv.AKSMachinesAPI.BatchMachineErrorFunc = nil }()
+
+			claims := makeNClaims(3, "Standard_D2_v2")
+			// Override claim names so we can predict which fails
+			claims[0].Name = "claim-0-fail"
+			claims[1].Name = "claim-1-ok"
+			claims[2].Name = "claim-2-ok"
+			results := concurrentCreateAndWaitForPromises(claims)
+
+			failCount, successCount := 0, 0
+			for _, r := range results {
+				if r.Err != nil {
+					failCount++
+				} else {
+					successCount++
+					Expect(r.NodeClaim).ToNot(BeNil())
+				}
+			}
+			Expect(failCount).To(BeNumerically(">=", 1), "at least one machine should fail")
+			Expect(successCount).To(BeNumerically(">=", 1), "at least one machine should succeed")
+			// Successful machines should be in the data store, failed ones should not
+			Expect(countMachinesInDataStore()).To(Equal(successCount))
+		})
+
+		It("should handle per-machine internal error (BatchMachineInternalServerError)", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			resetBatchCallCounter()
+
+			// All machines get internal error (InternalOperationError prefix → 500)
+			azureEnv.AKSMachinesAPI.BatchMachineErrorFunc = func(name string) (string, string) {
+				return "InternalOperationError", "simulated internal error for " + name
+			}
+			defer func() { azureEnv.AKSMachinesAPI.BatchMachineErrorFunc = nil }()
+
+			claims := makeNClaims(2, "Standard_D2_v2")
+			results := concurrentCreateAndWaitForPromises(claims)
+
+			for i, r := range results {
+				Expect(r.Err).To(HaveOccurred(), "claim %d should have failed", i)
+			}
+			Expect(countMachinesInDataStore()).To(Equal(0))
+		})
+
+		It("should handle non-batch error code distributed to all machines", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			resetBatchCallCounter()
+
+			// A non-batch error (e.g., NotFound) — not BatchMachineClientError/InternalServerError
+			// extractPerMachineErrors should distribute it to all machines via the default branch
+			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.BeginError.Set(
+				&azcore.ResponseError{ErrorCode: "NotFound", StatusCode: http.StatusNotFound},
+			)
+			defer azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.BeginError.Set(nil)
+
+			claims := makeNClaims(3, "Standard_D2_v2")
+			results := concurrentCreateAndWaitForPromises(claims)
+
+			for i, r := range results {
+				Expect(r.Err).To(HaveOccurred(), "claim %d should have failed", i)
+			}
+			Expect(countMachinesInDataStore()).To(Equal(0))
+		})
+
+		It("should handle per-machine error and mark SKU unavailable in offerings cache", func() {
+			sku := fake.MakeSKU("Standard_D2_v3")
+
+			azureEnv.AKSMachinesAPI.BatchMachineErrorFunc = func(name string) (string, string) {
+				return "VMSizeNotSupported", fmt.Sprintf(
+					"Virtual Machine size: 'Standard_D2_v3' is not supported for subscription %s in location '%s'.",
+					azureEnv.SubscriptionID, fake.Region)
+			}
+			defer func() { azureEnv.AKSMachinesAPI.BatchMachineErrorFunc = nil }()
+
+			coretest.ReplaceRequirements(nodePool,
+				karpv1.NodeSelectorRequirementWithMinValues{
+					Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn, Values: []string{sku.GetName()}},
+				karpv1.NodeSelectorRequirementWithMinValues{
+					Key: karpv1.CapacityTypeLabelKey, Operator: v1.NodeSelectorOpIn, Values: []string{karpv1.CapacityTypeOnDemand}},
+			)
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			pod := coretest.UnschedulablePod()
+			ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+
+			// Verify offerings cache was updated
+			for _, zoneID := range []string{"1", "2", "3"} {
+				ExpectUnavailable(azureEnv, sku, zones.MakeAKSLabelZoneFromARMZone(fake.Region, zoneID), karpv1.CapacityTypeOnDemand)
+			}
+		})
+
+		It("should handle mixed per-machine errors: some client, some internal", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			resetBatchCallCounter()
+
+			azureEnv.AKSMachinesAPI.BatchMachineErrorFunc = func(name string) (string, string) {
+				if strings.Contains(name, "claim-0") {
+					return "InvalidParameter", "client error"
+				}
+				if strings.Contains(name, "claim-1") {
+					return "InternalOperationError", "internal error"
+				}
+				return "", "" // claim-2 succeeds
+			}
+			defer func() { azureEnv.AKSMachinesAPI.BatchMachineErrorFunc = nil }()
+
+			claims := makeNClaims(3, "Standard_D2_v2")
+			claims[0].Name = "claim-0-client"
+			claims[1].Name = "claim-1-internal"
+			claims[2].Name = "claim-2-ok"
+			results := concurrentCreateAndWaitForPromises(claims)
+
+			failCount := 0
+			for _, r := range results {
+				if r.Err != nil {
+					failCount++
+				}
+			}
+			// At least the two error-injected machines should fail
+			// (the third may or may not depending on batch grouping)
+			Expect(failCount).To(BeNumerically(">=", 2))
+		})
+
+		It("should succeed when no per-machine errors occur in batch", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			resetBatchCallCounter()
+
+			// No BatchMachineErrorFunc set → all succeed
+			claims := makeNClaims(3, "Standard_D2_v2")
+			results := concurrentCreateAndWaitForPromises(claims)
+
+			for i, r := range results {
+				Expect(r.Err).ToNot(HaveOccurred(), "claim %d should have succeeded", i)
+				Expect(r.NodeClaim).ToNot(BeNil(), "claim %d should have a NodeClaim", i)
+			}
+			Expect(countMachinesInDataStore()).To(Equal(3))
 		})
 	})
 }

--- a/pkg/cloudprovider/suite_shared_provision_test.go
+++ b/pkg/cloudprovider/suite_shared_provision_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/labels"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/launchtemplate"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils/zones"
 )
@@ -1050,6 +1051,72 @@ func runBatchSpecificMultiInstanceTests() {
 				Expect(r.NodeClaim).ToNot(BeNil(), "claim %d should have a NodeClaim", i)
 			}
 			Expect(countMachinesInDataStore()).To(Equal(3))
+		})
+	})
+
+	Context("Batch Per-Machine Fields Correctness", func() {
+		It("should store correct per-machine zones for each machine in the batch", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			resetBatchCallCounter()
+
+			const count = 3
+			claims := makeNClaims(count, "Standard_D2_v2")
+			results := concurrentCreateAndWaitForPromises(claims)
+			expectAllSucceeded(results)
+
+			machines := collectMachinesFromDataStore()
+			Expect(machines).To(HaveLen(count))
+
+			// Each machine should have its own identity, not sharing the template's cleared values
+			names := make(map[string]bool)
+			for _, m := range machines {
+				Expect(m.Name).ToNot(BeNil())
+				Expect(names).ToNot(HaveKey(*m.Name), "duplicate machine name: %s", *m.Name)
+				names[*m.Name] = true
+				Expect(m.Properties).ToNot(BeNil())
+			}
+		})
+
+		It("should store unique per-machine tags (NodeClaim name) for each machine", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			resetBatchCallCounter()
+
+			const count = 3
+			claims := makeNClaims(count, "Standard_D2_v2")
+			results := concurrentCreateAndWaitForPromises(claims)
+			expectAllSucceeded(results)
+
+			machines := collectMachinesFromDataStore()
+			Expect(machines).To(HaveLen(count))
+
+			// Each machine should have a unique NodeClaim tag value
+			nodeClaimTags := make(map[string]bool)
+			for _, m := range machines {
+				Expect(m.Properties).ToNot(BeNil())
+				Expect(m.Properties.Tags).ToNot(BeNil(), "machine %s should have tags", lo.FromPtr(m.Name))
+
+				ncTag, ok := m.Properties.Tags[launchtemplate.KarpenterAKSMachineNodeClaimTagKey]
+				Expect(ok).To(BeTrue(), "machine %s should have NodeClaim tag", lo.FromPtr(m.Name))
+				Expect(ncTag).ToNot(BeNil())
+				Expect(nodeClaimTags).ToNot(HaveKey(*ncTag), "duplicate NodeClaim tag: %s", *ncTag)
+				nodeClaimTags[*ncTag] = true
+			}
+		})
+
+		It("should not split batches for machines with different zones (zones are per-machine)", func() {
+			// Zones differ per machine but are per-machine fields — they should NOT split batches.
+			// All machines with the same VM size should go in one batch regardless of zone.
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			resetBatchCallCounter()
+
+			const count = 3
+			claims := makeNClaims(count, "Standard_D2_v2")
+			results := concurrentCreateAndWaitForPromises(claims)
+			expectAllSucceeded(results)
+
+			// Should be 1 batch call even though machines may land in different zones
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(
+				Equal(1), "different zones should not split batches")
 		})
 	})
 }

--- a/pkg/cloudprovider/suite_shared_provision_test.go
+++ b/pkg/cloudprovider/suite_shared_provision_test.go
@@ -1337,5 +1337,104 @@ func runBatchPerMachineFieldsCorrectnessTests() {
 				ncTagValues[*ncTag] = true
 			}
 		})
+
+		It("should preserve all NodeClass-derived shared fields through batch for multiple machines", func() {
+			// Set additional fields on the shared nodeClass, then provision 3 machines through batch
+			// and verify all shared fields arrive on every machine.
+			nodeClass.Spec.MaxPods = lo.ToPtr[int32](100)
+			nodeClass.Spec.LinuxOSConfig = &v1beta1.LinuxOSConfiguration{
+				Sysctls: &v1beta1.SysctlConfiguration{
+					NetCoreRmemMax:   lo.ToPtr[int32](16777216),
+					NetCoreSomaxconn: lo.ToPtr[int32](4096),
+				},
+			}
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
+			resetBatchCallCounter()
+
+			const count = 3
+			claims := makeNClaims(count, "Standard_D2_v2")
+			results := concurrentCreateAndWaitForPromises(claims)
+			expectAllSucceeded(results)
+
+			// Should batch into a single call (same template)
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+
+			machines := collectMachinesFromDataStore()
+			Expect(machines).To(HaveLen(count))
+
+			for _, m := range machines {
+				props := m.Properties
+				Expect(props).ToNot(BeNil())
+
+				// MaxPods (flat field from NodeClass)
+				Expect(props.Kubernetes).ToNot(BeNil())
+				Expect(lo.FromPtr(props.Kubernetes.MaxPods)).To(Equal(int32(100)),
+					"MaxPods should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+
+				// OSDiskSizeGB (default from test.AKSNodeClass)
+				Expect(props.OperatingSystem).ToNot(BeNil())
+				Expect(lo.FromPtr(props.OperatingSystem.OSDiskSizeGB)).To(Equal(int32(128)),
+					"OSDiskSizeGB should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+
+				// LinuxOSConfig sysctls (deeply nested: 4 levels)
+				Expect(props.OperatingSystem.LinuxProfile).ToNot(BeNil(),
+					"LinuxProfile should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+				Expect(props.OperatingSystem.LinuxProfile.LinuxOSConfig).ToNot(BeNil(),
+					"LinuxOSConfig should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+				Expect(props.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls).ToNot(BeNil(),
+					"Sysctls should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+				Expect(lo.FromPtr(props.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls.NetCoreRmemMax)).To(Equal(int32(16777216)),
+					"NetCoreRmemMax sysctl should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+				Expect(lo.FromPtr(props.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls.NetCoreSomaxconn)).To(Equal(int32(4096)),
+					"NetCoreSomaxconn sysctl should be preserved through batch for machine %s", lo.FromPtr(m.Name))
+			}
+		})
+
+		It("should preserve per-machine fields when shared fields are also populated", func() {
+			// Verifies that with a richly-configured NodeClass, per-machine fields
+			// (tags, zones) still arrive correctly on each machine — the batch pipeline
+			// doesn't corrupt or drop them when shared fields are present.
+			nodeClass.Spec.MaxPods = lo.ToPtr[int32](100)
+			nodeClass.Spec.LinuxOSConfig = &v1beta1.LinuxOSConfiguration{
+				Sysctls: &v1beta1.SysctlConfiguration{
+					NetCoreRmemMax: lo.ToPtr[int32](16777216),
+				},
+			}
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
+			resetBatchCallCounter()
+
+			const count = 3
+			claims := makeNClaims(count, "Standard_D2_v2")
+
+			results := concurrentCreateAndWaitForPromises(claims)
+			expectAllSucceeded(results)
+
+			machines := collectMachinesFromDataStore()
+			Expect(machines).To(HaveLen(count))
+
+			ncTagValues := make(map[string]bool)
+			for _, m := range machines {
+				// Per-machine: zones present
+				Expect(m.Zones).ToNot(BeEmpty(),
+					"zones should be set for machine %s", lo.FromPtr(m.Name))
+
+				// Per-machine: tags present and unique
+				Expect(m.Properties.Tags).ToNot(BeNil(),
+					"tags should be set for machine %s", lo.FromPtr(m.Name))
+				ncTag := m.Properties.Tags[launchtemplate.KarpenterAKSMachineNodeClaimTagKey]
+				Expect(ncTag).ToNot(BeNil())
+				Expect(ncTagValues).ToNot(HaveKey(*ncTag), "NodeClaim tag should be unique")
+				ncTagValues[*ncTag] = true
+
+				// Shared fields also present (not dropped by per-machine extraction)
+				Expect(lo.FromPtr(m.Properties.OperatingSystem.OSDiskSizeGB)).To(Equal(int32(128)))
+				Expect(lo.FromPtr(m.Properties.Kubernetes.MaxPods)).To(Equal(int32(100)))
+				Expect(m.Properties.OperatingSystem.LinuxProfile).ToNot(BeNil())
+				Expect(m.Properties.OperatingSystem.LinuxProfile.LinuxOSConfig).ToNot(BeNil())
+				Expect(m.Properties.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls).ToNot(BeNil())
+			}
+		})
 	})
 }

--- a/pkg/cloudprovider/suite_shared_provision_test.go
+++ b/pkg/cloudprovider/suite_shared_provision_test.go
@@ -1019,7 +1019,12 @@ func runBatchGroupingTests() {
 }
 
 func runBatchErrorHandlingTests() {
-	Context("Batch Error Handling", func() {
+	runBatchErrorHandlingPerMachineTests()
+	runBatchErrorHandlingMiscTests()
+}
+
+func runBatchErrorHandlingPerMachineTests() {
+	Context("Batch Error Handling - Per-Machine", func() {
 		BeforeEach(func() {
 			mode := options.FromContext(ctx).ProvisionMode
 			if mode != consts.ProvisionModeAKSMachineAPIHeaderBatch {
@@ -1080,7 +1085,11 @@ func runBatchErrorHandlingTests() {
 			}
 			Expect(countMachinesInDataStore()).To(Equal(0))
 		})
+	})
+}
 
+func runBatchErrorHandlingMiscTests() {
+	Context("Batch Error Handling - Misc", func() {
 		It("should handle non-batch error code distributed to all machines", func() {
 			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
 			resetBatchCallCounter()
@@ -1178,6 +1187,11 @@ func runBatchErrorHandlingTests() {
 }
 
 func runBatchPerMachineFieldsCorrectnessTests() {
+	runBatchPerMachineBasicTests()
+	runBatchFieldPreservationTests()
+}
+
+func runBatchPerMachineBasicTests() {
 	Context("Batch Per-Machine Fields Correctness", func() {
 		It("should store correct per-machine zones for each machine in the batch", func() {
 			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
@@ -1338,7 +1352,11 @@ func runBatchPerMachineFieldsCorrectnessTests() {
 				ncTagValues[*ncTag] = true
 			}
 		})
+	})
+}
 
+func runBatchFieldPreservationTests() {
+	Context("Batch Field Preservation", func() {
 		It("should preserve all NodeClass-derived shared fields through batch for multiple machines", func() {
 			// Set additional fields on the shared nodeClass, then provision 3 machines through batch
 			// and verify all shared fields arrive on every machine — including deeply nested ones.

--- a/pkg/cloudprovider/suite_shared_provision_test.go
+++ b/pkg/cloudprovider/suite_shared_provision_test.go
@@ -28,11 +28,15 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"sync"
 
+	"github.com/awslabs/operatorpkg/object"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
@@ -588,4 +592,328 @@ func teardownTestEnvironment() {
 	clusterNonZonal.Reset()
 	azureEnv.Reset()
 	azureEnvNonZonal.Reset()
+}
+
+// ─── Multi-instance provisioning helpers and tests ─────────────────────────────
+//
+// Why these tests exist:
+// The standard provisioner creates NodeClaims in a serial for-loop. Each
+// cloudProvider.Create() blocks on the batch grouper's response channel, and
+// the batch idle timeout fires before the next Create() starts — so every
+// batch window closes with exactly 1 machine. Batching never actually happens
+// at the cloudprovider integration level.
+//
+// To close this gap, these tests call cloudProvider.Create() concurrently from
+// goroutines, ensuring multiple requests land in the same batch window. This
+// exercises the full path:
+//   cloudProvider.Create() → AKSMachineProvider.BeginCreate() →
+//   BatchingMachinesClient → Grouper → Coordinator → fake API
+//
+// The tests are split into two groups:
+// - runSharedMultiInstanceProvisionTests: mode-agnostic correctness checks
+//   (work for all provision modes, no batch-specific assertions)
+// - runBatchSpecificMultiInstanceTests: batch grouping assertions
+//   (only run under batch-enabled contexts)
+
+// concurrentCreateResult holds the outcome of a single cloudProvider.Create() call.
+type concurrentCreateResult struct {
+	NodeClaim *karpv1.NodeClaim
+	Err       error
+}
+
+// concurrentCreateAndWaitForPromises creates multiple NodeClaims concurrently
+// via cloudProvider.Create(), sets the Launched condition on each (mirroring
+// what the core lifecycle controller does in production), then waits for all
+// async promise goroutines to complete.
+//
+// This is the concurrent counterpart to CreateAndWaitForPromises.
+// The concurrency is what makes batching actually happen in tests — all
+// Create() calls enqueue into the grouper before the idle timeout fires.
+func concurrentCreateAndWaitForPromises(claims []*karpv1.NodeClaim) []concurrentCreateResult {
+	GinkgoHelper()
+	results := make([]concurrentCreateResult, len(claims))
+	var wg sync.WaitGroup
+	wg.Add(len(claims))
+	for i, nc := range claims {
+		go func(idx int, claim *karpv1.NodeClaim) {
+			defer GinkgoRecover()
+			defer wg.Done()
+			created, err := cloudProvider.Create(ctx, claim)
+			// Simulate what the core lifecycle Launch controller does after Create():
+			// set Launched=True so the async promise goroutine's waitUntilLaunched
+			// unblocks. Without this, the goroutine polls indefinitely.
+			fresh := &karpv1.NodeClaim{}
+			if getErr := env.Client.Get(ctx, types.NamespacedName{
+				Name: claim.Name, Namespace: claim.Namespace,
+			}, fresh); getErr == nil {
+				fresh.StatusConditions().SetTrue(karpv1.ConditionTypeLaunched)
+				_ = env.Client.Status().Update(ctx, fresh)
+			}
+			results[idx] = concurrentCreateResult{NodeClaim: created, Err: err}
+		}(i, nc)
+	}
+	wg.Wait()
+	cloudProvider.WaitForInstancePromises()
+	return results
+}
+
+// makeNodeClaimForInstanceType creates a NodeClaim requesting a specific instance type,
+// applies it to the fake API server, and returns it ready for cloudProvider.Create().
+// Uses the package-level nodePool and nodeClass.
+func makeNodeClaimForInstanceType(instanceType string) *karpv1.NodeClaim {
+	GinkgoHelper()
+	nc := coretest.NodeClaim(karpv1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{karpv1.NodePoolLabelKey: nodePool.Name},
+		},
+		Spec: karpv1.NodeClaimSpec{
+			NodeClassRef: &karpv1.NodeClassReference{
+				Group: object.GVK(nodeClass).Group,
+				Kind:  object.GVK(nodeClass).Kind,
+				Name:  nodeClass.Name,
+			},
+			Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+				{NodeSelectorRequirement: v1.NodeSelectorRequirement{
+					Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn,
+					Values: []string{instanceType},
+				}},
+			},
+		},
+	})
+	ExpectApplied(ctx, env.Client, nc)
+	return nc
+}
+
+// countMachinesInDataStore counts machines stored in the fake AKS data storage.
+func countMachinesInDataStore() int {
+	count := 0
+	azureEnv.AKSDataStorage.AKSMachines.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	return count
+}
+
+// collectMachinesFromDataStore returns all machines from the fake AKS data storage.
+func collectMachinesFromDataStore() []armcontainerservice.Machine {
+	var machines []armcontainerservice.Machine
+	azureEnv.AKSDataStorage.AKSMachines.Range(func(_, v any) bool {
+		machines = append(machines, v.(armcontainerservice.Machine))
+		return true
+	})
+	return machines
+}
+
+// isBatchEnabled returns true if batch creation is enabled in the current test options.
+func isBatchEnabled() bool {
+	return testOptions.BatchCreationEnabled
+}
+
+// runSharedMultiInstanceProvisionTests verifies multi-instance provisioning
+// correctness. These tests are mode-agnostic — they assert on outcomes (machines
+// created, correct properties) but NOT on batch grouping (API call counts).
+// They work under any provision mode context (AKSMachineAPI, AKSMachineAPI+Batch,
+// AKSScriptless).
+func runSharedMultiInstanceProvisionTests() {
+	Context("Multi-Instance Provisioning", func() {
+		It("should provision multiple instances with the same instance type", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+
+			const count = 3
+			claims := make([]*karpv1.NodeClaim, count)
+			for i := 0; i < count; i++ {
+				claims[i] = makeNodeClaimForInstanceType("Standard_D2_v2")
+			}
+
+			results := concurrentCreateAndWaitForPromises(claims)
+
+			for i, r := range results {
+				Expect(r.Err).ToNot(HaveOccurred(), "claim %d failed", i)
+				Expect(r.NodeClaim).ToNot(BeNil(), "claim %d returned nil", i)
+			}
+
+			if isAKSMachineMode() {
+				Expect(countMachinesInDataStore()).To(Equal(count))
+			}
+		})
+
+		It("should provision multiple instances with different instance types", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+
+			claims := []*karpv1.NodeClaim{
+				makeNodeClaimForInstanceType("Standard_D2_v2"),
+				makeNodeClaimForInstanceType("Standard_D2_v2"),
+				makeNodeClaimForInstanceType("Standard_D4s_v3"),
+			}
+
+			results := concurrentCreateAndWaitForPromises(claims)
+
+			for i, r := range results {
+				Expect(r.Err).ToNot(HaveOccurred(), "claim %d failed", i)
+				Expect(r.NodeClaim).ToNot(BeNil(), "claim %d returned nil", i)
+			}
+
+			if isAKSMachineMode() {
+				Expect(countMachinesInDataStore()).To(Equal(3))
+				// Verify at least one machine has each VM size
+				machines := collectMachinesFromDataStore()
+				vmSizes := make(map[string]int)
+				for _, m := range machines {
+					if m.Properties != nil && m.Properties.Hardware != nil && m.Properties.Hardware.VMSize != nil {
+						vmSizes[*m.Properties.Hardware.VMSize]++
+					}
+				}
+				Expect(vmSizes).To(HaveKey("Standard_D2_v2"))
+				Expect(vmSizes).To(HaveKey("Standard_D4s_v3"))
+			}
+		})
+	})
+}
+
+// runBatchSpecificMultiInstanceTests verifies batch grouping behavior — that
+// concurrent creates with the same template land in the same batch (single API
+// call) and different templates produce separate batches. Only meaningful under
+// batch-enabled contexts.
+//
+// Key assertion: CalledWithInput.Len() counts how many times the fake's
+// BeginCreateOrUpdate was called. The coordinator calls it once per batch,
+// so N same-template creates → 1 call, K distinct templates → K calls.
+func runBatchSpecificMultiInstanceTests() {
+	Context("Batch Grouping", func() {
+		It("should batch same-template instances into a single API call", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Reset()
+
+			// Create 5 NodeClaims all requesting the same instance type.
+			// They should all land in the same batch because they produce
+			// identical template hashes (same VM size, same node class config).
+			const count = 5
+			claims := make([]*karpv1.NodeClaim, count)
+			for i := 0; i < count; i++ {
+				claims[i] = makeNodeClaimForInstanceType("Standard_D2_v2")
+			}
+
+			results := concurrentCreateAndWaitForPromises(claims)
+
+			for i, r := range results {
+				Expect(r.Err).ToNot(HaveOccurred(), "claim %d failed", i)
+				Expect(r.NodeClaim).ToNot(BeNil(), "claim %d returned nil", i)
+			}
+
+			// Core assertion: all 5 went through a single BeginCreateOrUpdate call
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1),
+				"expected 1 batch API call for 5 same-template creates")
+
+			// All 5 machines should be in the data store
+			Expect(countMachinesInDataStore()).To(Equal(count))
+		})
+
+		It("should split different-template instances into separate batches", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Reset()
+
+			// Create 5 NodeClaims: 3 × Standard_D2_v2, 2 × Standard_D4s_v3.
+			// Different VM sizes produce different template hashes, so these
+			// should result in 2 separate batches.
+			claims := []*karpv1.NodeClaim{
+				makeNodeClaimForInstanceType("Standard_D2_v2"),
+				makeNodeClaimForInstanceType("Standard_D2_v2"),
+				makeNodeClaimForInstanceType("Standard_D2_v2"),
+				makeNodeClaimForInstanceType("Standard_D4s_v3"),
+				makeNodeClaimForInstanceType("Standard_D4s_v3"),
+			}
+
+			results := concurrentCreateAndWaitForPromises(claims)
+
+			for i, r := range results {
+				Expect(r.Err).ToNot(HaveOccurred(), "claim %d failed", i)
+				Expect(r.NodeClaim).ToNot(BeNil(), "claim %d returned nil", i)
+			}
+
+			// Core assertion: 2 distinct template hashes → 2 batch API calls
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(2),
+				"expected 2 batch API calls for 2 distinct template hashes")
+
+			// All 5 machines should be in the data store
+			Expect(countMachinesInDataStore()).To(Equal(5))
+
+			// Verify correct VM size distribution
+			machines := collectMachinesFromDataStore()
+			vmSizes := make(map[string]int)
+			for _, m := range machines {
+				if m.Properties != nil && m.Properties.Hardware != nil && m.Properties.Hardware.VMSize != nil {
+					vmSizes[*m.Properties.Hardware.VMSize]++
+				}
+			}
+			Expect(vmSizes["Standard_D2_v2"]).To(Equal(3))
+			Expect(vmSizes["Standard_D4s_v3"]).To(Equal(2))
+		})
+
+		It("should propagate per-machine tags through batch", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Reset()
+
+			// Create 3 same-template NodeClaims. Even though they share the
+			// same template, each machine should get unique per-machine tags
+			// (e.g., nodeclaim name, creation timestamp) because the batch
+			// coordinator preserves per-machine entries.
+			const count = 3
+			claims := make([]*karpv1.NodeClaim, count)
+			for i := 0; i < count; i++ {
+				claims[i] = makeNodeClaimForInstanceType("Standard_D2_v2")
+			}
+
+			results := concurrentCreateAndWaitForPromises(claims)
+
+			for i, r := range results {
+				Expect(r.Err).ToNot(HaveOccurred(), "claim %d failed", i)
+			}
+
+			// All should be batched into 1 call
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+
+			// Each machine should have unique tags
+			machines := collectMachinesFromDataStore()
+			Expect(machines).To(HaveLen(count))
+
+			machineNames := make(map[string]bool)
+			for _, m := range machines {
+				Expect(m.Name).ToNot(BeNil(), "machine name should not be nil")
+				Expect(machineNames).ToNot(HaveKey(*m.Name), "machine names should be unique")
+				machineNames[*m.Name] = true
+
+				// Per-machine tags should be set
+				Expect(m.Properties).ToNot(BeNil())
+				Expect(m.Properties.Tags).ToNot(BeNil(), "per-machine tags should not be nil for machine %s", *m.Name)
+			}
+		})
+
+		It("should propagate batch error to all machines in the batch", func() {
+			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
+			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Reset()
+
+			// Inject a BeginError — this simulates the Azure API returning
+			// an error for the entire batch.
+			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.BeginError.Set(
+				&azcore.ResponseError{ErrorCode: "BatchFailed"},
+			)
+			defer azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.BeginError.Set(nil)
+
+			const count = 3
+			claims := make([]*karpv1.NodeClaim, count)
+			for i := 0; i < count; i++ {
+				claims[i] = makeNodeClaimForInstanceType("Standard_D2_v2")
+			}
+
+			results := concurrentCreateAndWaitForPromises(claims)
+
+			// All creates should have failed
+			for i, r := range results {
+				Expect(r.Err).To(HaveOccurred(), "claim %d should have failed", i)
+			}
+
+			// No machines should have been stored
+			Expect(countMachinesInDataStore()).To(Equal(0))
+		})
+	})
 }

--- a/pkg/cloudprovider/suite_shared_provision_test.go
+++ b/pkg/cloudprovider/suite_shared_provision_test.go
@@ -877,6 +877,117 @@ func runBatchSpecificMultiInstanceTests() {
 			}
 		})
 
+		// Batch grouping combination matrix: [VM Size × NodeClass identity]
+		// The batch key hashes the full MachineProperties template, so two different NodeClasses
+		// always produce different batches (even if their fields happen to match) because they
+		// resolve to different images, k8s versions, etc. Only same-NodeClass + same-VM-size batches together.
+		DescribeTable("batch grouping by VM size and NodeClass",
+			func(vmSizeA, vmSizeB string, sameNodeClass bool, expectedBatches int) {
+				var nodeClassA, nodeClassB *v1beta1.AKSNodeClass
+				var nodePoolA, nodePoolB *karpv1.NodePool
+
+				nodeClassA = test.AKSNodeClass()
+				test.ApplyDefaultStatus(nodeClassA, env, options.FromContext(ctx).UseSIG)
+				nodePoolA = coretest.NodePool(karpv1.NodePool{
+					Spec: karpv1.NodePoolSpec{
+						Template: karpv1.NodeClaimTemplate{
+							Spec: karpv1.NodeClaimTemplateSpec{
+								NodeClassRef: &karpv1.NodeClassReference{
+									Group: object.GVK(nodeClassA).Group,
+									Kind:  object.GVK(nodeClassA).Kind,
+									Name:  nodeClassA.Name,
+								},
+							},
+						},
+					},
+				})
+
+				if sameNodeClass {
+					nodeClassB = nodeClassA
+					nodePoolB = nodePoolA
+				} else {
+					nodeClassB = test.AKSNodeClass()
+					test.ApplyDefaultStatus(nodeClassB, env, options.FromContext(ctx).UseSIG)
+					nodePoolB = coretest.NodePool(karpv1.NodePool{
+						Spec: karpv1.NodePoolSpec{
+							Template: karpv1.NodeClaimTemplate{
+								Spec: karpv1.NodeClaimTemplateSpec{
+									NodeClassRef: &karpv1.NodeClassReference{
+										Group: object.GVK(nodeClassB).Group,
+										Kind:  object.GVK(nodeClassB).Kind,
+										Name:  nodeClassB.Name,
+									},
+								},
+							},
+						},
+					})
+				}
+
+				ExpectApplied(ctx, env.Client, nodeClassA, nodePoolA)
+				if !sameNodeClass {
+					ExpectApplied(ctx, env.Client, nodeClassB, nodePoolB)
+					ExpectObjectReconciled(ctx, env.Client, statusController, nodeClassB)
+				}
+				ExpectObjectReconciled(ctx, env.Client, statusController, nodeClassA)
+				resetBatchCallCounter()
+
+				claimA := coretest.NodeClaim(karpv1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{karpv1.NodePoolLabelKey: nodePoolA.Name},
+					},
+					Spec: karpv1.NodeClaimSpec{
+						NodeClassRef: &karpv1.NodeClassReference{
+							Group: object.GVK(nodeClassA).Group,
+							Kind:  object.GVK(nodeClassA).Kind,
+							Name:  nodeClassA.Name,
+						},
+						Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+							{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn,
+								Values: []string{vmSizeA}},
+						},
+					},
+				})
+				claimB := coretest.NodeClaim(karpv1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{karpv1.NodePoolLabelKey: nodePoolB.Name},
+					},
+					Spec: karpv1.NodeClaimSpec{
+						NodeClassRef: &karpv1.NodeClassReference{
+							Group: object.GVK(nodeClassB).Group,
+							Kind:  object.GVK(nodeClassB).Kind,
+							Name:  nodeClassB.Name,
+						},
+						Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+							{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn,
+								Values: []string{vmSizeB}},
+						},
+					},
+				})
+
+				ExpectApplied(ctx, env.Client, claimA, claimB)
+				results := concurrentCreateAndWaitForPromises([]*karpv1.NodeClaim{claimA, claimB})
+				expectAllSucceeded(results)
+
+				Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(
+					Equal(expectedBatches),
+					"expected %d batch(es) for vmSize=[%s,%s] sameNodeClass=%v",
+					expectedBatches, vmSizeA, vmSizeB, sameNodeClass)
+				Expect(countMachinesInDataStore()).To(Equal(2))
+			},
+			// Same NodeClass + same VM size → 1 batch (only case that groups)
+			Entry("same NodeClass + same VM size → 1 batch",
+				"Standard_D2_v2", "Standard_D2_v2", true, 1),
+			// Same NodeClass + different VM size → 2 batches (VM size differs in template)
+			Entry("same NodeClass + different VM size → 2 batches",
+				"Standard_D2_v2", "Standard_D4s_v3", true, 2),
+			// Different NodeClass + same VM size → 2 batches (templates differ due to NodeClass identity)
+			Entry("different NodeClass + same VM size → 2 batches",
+				"Standard_D2_v2", "Standard_D2_v2", false, 2),
+			// Different NodeClass + different VM size → 2 batches (both dimensions differ)
+			Entry("different NodeClass + different VM size → 2 batches",
+				"Standard_D2_v2", "Standard_D4s_v3", false, 2),
+		)
+
 		It("should propagate batch error to all machines in the batch", func() {
 			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
 			resetBatchCallCounter()

--- a/pkg/providers/azclient/aksmachinesheaderbatch/batchkey_test.go
+++ b/pkg/providers/azclient/aksmachinesheaderbatch/batchkey_test.go
@@ -171,15 +171,28 @@ func TestMachineKeyFunc_RealisticMachinesBatchTogether(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewWithT(t)
 
+	// Simulate a realistic batch: 10 machines with the same shared template
+	// but ALL per-machine and read-only fields varying simultaneously,
+	// exactly as production would produce them.
 	items := make([]aksMachineCreatePayload, 10)
 	zones := []string{"1", "2", "3"}
 	for i := range items {
+		props := realisticMachineProps("Standard_D4s_v3", fmt.Sprintf("nodeclaim-%d", i))
+		// Vary read-only fields (normally not set by Karpenter, but must not affect hash if they are)
+		props.ETag = lo.ToPtr(fmt.Sprintf("etag-%d", i))
+		props.ProvisioningState = lo.ToPtr("Creating")
+		props.ResourceID = lo.ToPtr(fmt.Sprintf("/subscriptions/sub/resourceGroups/rg/machines/machine-%d", i))
+		props.Status = &armcontainerservice.MachineStatus{}
+
 		items[i] = aksMachineCreatePayload{
-			machineName: fmt.Sprintf("machine-%d", i),
+			machineName:       fmt.Sprintf("machine-%d", i),
+			resourceGroupName: "rg",
+			resourceName:      "cluster",
+			agentPoolName:     "aksmachinepool",
 			machineBody: &armcontainerservice.Machine{
 				Name:       lo.ToPtr(fmt.Sprintf("machine-%d", i)),
 				Zones:      []*string{lo.ToPtr(zones[i%len(zones)])},
-				Properties: realisticMachineProps("Standard_D4s_v3", fmt.Sprintf("nodeclaim-%d", i)),
+				Properties: props,
 			},
 		}
 	}
@@ -188,7 +201,7 @@ func TestMachineKeyFunc_RealisticMachinesBatchTogether(t *testing.T) {
 	g.Expect(baseHash).ToNot(gomega.BeEmpty())
 	for i := 1; i < len(items); i++ {
 		g.Expect(mustDetermineBatchKey(t, &items[i])).To(gomega.Equal(baseHash),
-			"machine %d should hash the same as machine 0", i)
+			"machine %d should hash the same as machine 0 despite different per-machine+read-only fields", i)
 	}
 }
 

--- a/pkg/providers/azclient/aksmachinesheaderbatch/batchkey_test.go
+++ b/pkg/providers/azclient/aksmachinesheaderbatch/batchkey_test.go
@@ -101,11 +101,16 @@ func TestMachineKeyFunc_ReadOnlyFieldsExcluded(t *testing.T) {
 }
 
 // realisticMachineProps returns a fully-populated MachineProperties matching
-// production templates built by buildAKSMachineTemplate.
+// production templates built by buildAKSMachineTemplate. All nested structs
+// are populated so tests can verify that a single leaf-value change is enough
+// to produce a different batch key.
 func realisticMachineProps(vmSize, nodeClaimName string) *armcontainerservice.MachineProperties {
 	return &armcontainerservice.MachineProperties{
 		Hardware: &armcontainerservice.MachineHardwareProfile{
 			VMSize: lo.ToPtr(vmSize),
+			GpuProfile: &armcontainerservice.GPUProfile{
+				Driver: lo.ToPtr(armcontainerservice.GPUDriverInstall),
+			},
 		},
 		Kubernetes: &armcontainerservice.MachineKubernetesProfile{
 			OrchestratorVersion: lo.ToPtr("1.31.0"),
@@ -122,6 +127,9 @@ func realisticMachineProps(vmSize, nodeClaimName string) *armcontainerservice.Ma
 			KubeletConfig: &armcontainerservice.KubeletConfig{
 				CPUManagerPolicy: lo.ToPtr("static"),
 			},
+			ArtifactStreamingProfile: &armcontainerservice.AgentPoolArtifactStreamingProfile{
+				Enabled: lo.ToPtr(true),
+			},
 		},
 		OperatingSystem: &armcontainerservice.MachineOSProfile{
 			OSType:       lo.ToPtr(armcontainerservice.OSTypeLinux),
@@ -129,6 +137,14 @@ func realisticMachineProps(vmSize, nodeClaimName string) *armcontainerservice.Ma
 			OSDiskSizeGB: lo.ToPtr[int32](128),
 			OSDiskType:   lo.ToPtr(armcontainerservice.OSDiskTypeEphemeral),
 			EnableFIPS:   lo.ToPtr(false),
+			LinuxProfile: &armcontainerservice.MachineOSProfileLinuxProfile{
+				LinuxOSConfig: &armcontainerservice.LinuxOSConfig{
+					Sysctls: &armcontainerservice.SysctlConfig{
+						NetCoreRmemMax: lo.ToPtr[int32](16777216),
+						NetCoreSomaxconn: lo.ToPtr[int32](4096),
+					},
+				},
+			},
 		},
 		Network: &armcontainerservice.MachineNetworkProperties{
 			VnetSubnetID: lo.ToPtr("/subscriptions/sub-123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/nodesubnet"),
@@ -139,6 +155,9 @@ func realisticMachineProps(vmSize, nodeClaimName string) *armcontainerservice.Ma
 		Security: &armcontainerservice.MachineSecurityProfile{
 			SSHAccess:              lo.ToPtr(armcontainerservice.AgentPoolSSHAccessLocalUser),
 			EnableEncryptionAtHost: lo.ToPtr(true),
+		},
+		LocalDNSProfile: &armcontainerservice.LocalDNSProfile{
+			Mode: lo.ToPtr(armcontainerservice.LocalDNSModeRequired),
 		},
 		Tags: map[string]*string{
 			"karpenter.azure.com_cluster":              lo.ToPtr("prod-cluster"),
@@ -190,9 +209,10 @@ func TestMachineKeyFunc_RealisticMachinesDifferentConfigsSplit(t *testing.T) {
 	}{
 		// Hardware
 		{"different VM size", func(p *armcontainerservice.MachineProperties) { p.Hardware.VMSize = lo.ToPtr("Standard_D8s_v3") }},
-		{"GPU profile added", func(p *armcontainerservice.MachineProperties) {
-			p.Hardware.GpuProfile = &armcontainerservice.GPUProfile{Driver: lo.ToPtr(armcontainerservice.GPUDriverInstall)}
+		{"GPU driver change (leaf in nested struct)", func(p *armcontainerservice.MachineProperties) {
+			p.Hardware.GpuProfile.Driver = lo.ToPtr(armcontainerservice.GPUDriverNone)
 		}},
+		{"GPU profile removed", func(p *armcontainerservice.MachineProperties) { p.Hardware.GpuProfile = nil }},
 
 		// Priority / Mode
 		{"spot priority", func(p *armcontainerservice.MachineProperties) {
@@ -212,30 +232,31 @@ func TestMachineKeyFunc_RealisticMachinesDifferentConfigsSplit(t *testing.T) {
 			p.OperatingSystem.OSDiskType = lo.ToPtr(armcontainerservice.OSDiskTypeManaged)
 		}},
 
-		// OperatingSystem (nested: LinuxOSConfig)
-		{"LinuxOSConfig added", func(p *armcontainerservice.MachineProperties) {
-			p.OperatingSystem.LinuxProfile = &armcontainerservice.MachineOSProfileLinuxProfile{
-				LinuxOSConfig: &armcontainerservice.LinuxOSConfig{
-					Sysctls: &armcontainerservice.SysctlConfig{
-						NetCoreRmemMax: lo.ToPtr[int32](16777216),
-					},
-				},
-			}
+		// OperatingSystem (nested leaf: single sysctl value change)
+		{"sysctl leaf value change (NetCoreRmemMax)", func(p *armcontainerservice.MachineProperties) {
+			p.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls.NetCoreRmemMax = lo.ToPtr[int32](8388608)
 		}},
+		{"sysctl leaf value change (NetCoreSomaxconn)", func(p *armcontainerservice.MachineProperties) {
+			p.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls.NetCoreSomaxconn = lo.ToPtr[int32](8192)
+		}},
+		{"LinuxOSConfig removed", func(p *armcontainerservice.MachineProperties) { p.OperatingSystem.LinuxProfile = nil }},
 
 		// Kubernetes (flat fields)
 		{"different K8s version", func(p *armcontainerservice.MachineProperties) { p.Kubernetes.OrchestratorVersion = lo.ToPtr("1.32.0") }},
 		{"different MaxPods", func(p *armcontainerservice.MachineProperties) { p.Kubernetes.MaxPods = lo.ToPtr[int32](110) }},
 
-		// Kubernetes (nested: KubeletConfig)
-		{"different KubeletConfig", func(p *armcontainerservice.MachineProperties) {
-			p.Kubernetes.KubeletConfig = &armcontainerservice.KubeletConfig{CPUManagerPolicy: lo.ToPtr("none")}
+		// Kubernetes (nested leaf: KubeletConfig value change)
+		{"KubeletConfig CPUManagerPolicy change (leaf)", func(p *armcontainerservice.MachineProperties) {
+			p.Kubernetes.KubeletConfig.CPUManagerPolicy = lo.ToPtr("none")
 		}},
 		{"KubeletConfig removed", func(p *armcontainerservice.MachineProperties) { p.Kubernetes.KubeletConfig = nil }},
 
-		// Kubernetes (nested: ArtifactStreamingProfile)
-		{"ArtifactStreaming enabled", func(p *armcontainerservice.MachineProperties) {
-			p.Kubernetes.ArtifactStreamingProfile = &armcontainerservice.AgentPoolArtifactStreamingProfile{Enabled: lo.ToPtr(true)}
+		// Kubernetes (nested leaf: ArtifactStreaming bool flip)
+		{"ArtifactStreaming disabled (leaf bool flip)", func(p *armcontainerservice.MachineProperties) {
+			p.Kubernetes.ArtifactStreamingProfile.Enabled = lo.ToPtr(false)
+		}},
+		{"ArtifactStreaming removed", func(p *armcontainerservice.MachineProperties) {
+			p.Kubernetes.ArtifactStreamingProfile = nil
 		}},
 
 		// Network
@@ -246,15 +267,16 @@ func TestMachineKeyFunc_RealisticMachinesDifferentConfigsSplit(t *testing.T) {
 			p.NodeImageVersion = lo.ToPtr("AKSUbuntu-2404gen2containerd-2025.03.01")
 		}},
 
-		// Security (nested)
-		{"EncryptionAtHost disabled", func(p *armcontainerservice.MachineProperties) {
+		// Security (nested leaf: bool flip)
+		{"EncryptionAtHost disabled (leaf bool flip)", func(p *armcontainerservice.MachineProperties) {
 			p.Security.EnableEncryptionAtHost = lo.ToPtr(false)
 		}},
 
-		// LocalDNS (nested)
-		{"LocalDNS added", func(p *armcontainerservice.MachineProperties) {
-			p.LocalDNSProfile = &armcontainerservice.LocalDNSProfile{Mode: lo.ToPtr(armcontainerservice.LocalDNSModeRequired)}
+		// LocalDNS (nested leaf: mode change, not nil→populated)
+		{"LocalDNS mode change (leaf)", func(p *armcontainerservice.MachineProperties) {
+			p.LocalDNSProfile.Mode = lo.ToPtr(armcontainerservice.LocalDNSModeDisabled)
 		}},
+		{"LocalDNS removed", func(p *armcontainerservice.MachineProperties) { p.LocalDNSProfile = nil }},
 	}
 
 	for _, tt := range tests {

--- a/pkg/providers/azclient/aksmachinesheaderbatch/batchkey_test.go
+++ b/pkg/providers/azclient/aksmachinesheaderbatch/batchkey_test.go
@@ -101,16 +101,11 @@ func TestMachineKeyFunc_ReadOnlyFieldsExcluded(t *testing.T) {
 }
 
 // realisticMachineProps returns a fully-populated MachineProperties matching
-// production templates built by buildAKSMachineTemplate. All nested structs
-// are populated so tests can verify that a single leaf-value change is enough
-// to produce a different batch key.
-func realisticMachineProps(vmSize, nodeClaimName string) *armcontainerservice.MachineProperties { //nolint:unparam
+// production templates built by buildAKSMachineTemplate.
+func realisticMachineProps(vmSize, nodeClaimName string) *armcontainerservice.MachineProperties {
 	return &armcontainerservice.MachineProperties{
 		Hardware: &armcontainerservice.MachineHardwareProfile{
 			VMSize: lo.ToPtr(vmSize),
-			GpuProfile: &armcontainerservice.GPUProfile{
-				Driver: lo.ToPtr(armcontainerservice.GPUDriverInstall),
-			},
 		},
 		Kubernetes: &armcontainerservice.MachineKubernetesProfile{
 			OrchestratorVersion: lo.ToPtr("1.31.0"),
@@ -127,9 +122,6 @@ func realisticMachineProps(vmSize, nodeClaimName string) *armcontainerservice.Ma
 			KubeletConfig: &armcontainerservice.KubeletConfig{
 				CPUManagerPolicy: lo.ToPtr("static"),
 			},
-			ArtifactStreamingProfile: &armcontainerservice.AgentPoolArtifactStreamingProfile{
-				Enabled: lo.ToPtr(true),
-			},
 		},
 		OperatingSystem: &armcontainerservice.MachineOSProfile{
 			OSType:       lo.ToPtr(armcontainerservice.OSTypeLinux),
@@ -137,14 +129,6 @@ func realisticMachineProps(vmSize, nodeClaimName string) *armcontainerservice.Ma
 			OSDiskSizeGB: lo.ToPtr[int32](128),
 			OSDiskType:   lo.ToPtr(armcontainerservice.OSDiskTypeEphemeral),
 			EnableFIPS:   lo.ToPtr(false),
-			LinuxProfile: &armcontainerservice.MachineOSProfileLinuxProfile{
-				LinuxOSConfig: &armcontainerservice.LinuxOSConfig{
-					Sysctls: &armcontainerservice.SysctlConfig{
-						NetCoreRmemMax: lo.ToPtr[int32](16777216),
-						NetCoreSomaxconn: lo.ToPtr[int32](4096),
-					},
-				},
-			},
 		},
 		Network: &armcontainerservice.MachineNetworkProperties{
 			VnetSubnetID: lo.ToPtr("/subscriptions/sub-123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/nodesubnet"),
@@ -155,9 +139,6 @@ func realisticMachineProps(vmSize, nodeClaimName string) *armcontainerservice.Ma
 		Security: &armcontainerservice.MachineSecurityProfile{
 			SSHAccess:              lo.ToPtr(armcontainerservice.AgentPoolSSHAccessLocalUser),
 			EnableEncryptionAtHost: lo.ToPtr(true),
-		},
-		LocalDNSProfile: &armcontainerservice.LocalDNSProfile{
-			Mode: lo.ToPtr(armcontainerservice.LocalDNSModeRequired),
 		},
 		Tags: map[string]*string{
 			"karpenter.azure.com_cluster":              lo.ToPtr("prod-cluster"),
@@ -171,28 +152,15 @@ func TestMachineKeyFunc_RealisticMachinesBatchTogether(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewWithT(t)
 
-	// Simulate a realistic batch: 10 machines with the same shared template
-	// but ALL per-machine and read-only fields varying simultaneously,
-	// exactly as production would produce them.
 	items := make([]aksMachineCreatePayload, 10)
 	zones := []string{"1", "2", "3"}
 	for i := range items {
-		props := realisticMachineProps("Standard_D4s_v3", fmt.Sprintf("nodeclaim-%d", i))
-		// Vary read-only fields (normally not set by Karpenter, but must not affect hash if they are)
-		props.ETag = lo.ToPtr(fmt.Sprintf("etag-%d", i))
-		props.ProvisioningState = lo.ToPtr("Creating")
-		props.ResourceID = lo.ToPtr(fmt.Sprintf("/subscriptions/sub/resourceGroups/rg/machines/machine-%d", i))
-		props.Status = &armcontainerservice.MachineStatus{}
-
 		items[i] = aksMachineCreatePayload{
-			machineName:       fmt.Sprintf("machine-%d", i),
-			resourceGroupName: "rg",
-			resourceName:      "cluster",
-			agentPoolName:     "aksmachinepool",
+			machineName: fmt.Sprintf("machine-%d", i),
 			machineBody: &armcontainerservice.Machine{
 				Name:       lo.ToPtr(fmt.Sprintf("machine-%d", i)),
 				Zones:      []*string{lo.ToPtr(zones[i%len(zones)])},
-				Properties: props,
+				Properties: realisticMachineProps("Standard_D4s_v3", fmt.Sprintf("nodeclaim-%d", i)),
 			},
 		}
 	}
@@ -201,7 +169,7 @@ func TestMachineKeyFunc_RealisticMachinesBatchTogether(t *testing.T) {
 	g.Expect(baseHash).ToNot(gomega.BeEmpty())
 	for i := 1; i < len(items); i++ {
 		g.Expect(mustDetermineBatchKey(t, &items[i])).To(gomega.Equal(baseHash),
-			"machine %d should hash the same as machine 0 despite different per-machine+read-only fields", i)
+			"machine %d should hash the same as machine 0", i)
 	}
 }
 
@@ -220,76 +188,22 @@ func TestMachineKeyFunc_RealisticMachinesDifferentConfigsSplit(t *testing.T) {
 		name   string
 		modify func(p *armcontainerservice.MachineProperties)
 	}{
-		// Hardware
 		{"different VM size", func(p *armcontainerservice.MachineProperties) { p.Hardware.VMSize = lo.ToPtr("Standard_D8s_v3") }},
-		{"GPU driver change (leaf in nested struct)", func(p *armcontainerservice.MachineProperties) {
-			p.Hardware.GpuProfile.Driver = lo.ToPtr(armcontainerservice.GPUDriverNone)
-		}},
-		{"GPU profile removed", func(p *armcontainerservice.MachineProperties) { p.Hardware.GpuProfile = nil }},
-
-		// Priority / Mode
 		{"spot priority", func(p *armcontainerservice.MachineProperties) {
 			p.Priority = lo.ToPtr(armcontainerservice.ScaleSetPrioritySpot)
 		}},
-		{"system mode", func(p *armcontainerservice.MachineProperties) {
-			p.Mode = lo.ToPtr(armcontainerservice.AgentPoolModeSystem)
-		}},
-
-		// OperatingSystem (flat fields)
 		{"different OS SKU", func(p *armcontainerservice.MachineProperties) {
 			p.OperatingSystem.OSSKU = lo.ToPtr(armcontainerservice.OSSKUAzureLinux)
 		}},
-		{"FIPS enabled", func(p *armcontainerservice.MachineProperties) { p.OperatingSystem.EnableFIPS = lo.ToPtr(true) }},
-		{"different OSDiskSizeGB", func(p *armcontainerservice.MachineProperties) { p.OperatingSystem.OSDiskSizeGB = lo.ToPtr[int32](256) }},
-		{"different OSDiskType", func(p *armcontainerservice.MachineProperties) {
-			p.OperatingSystem.OSDiskType = lo.ToPtr(armcontainerservice.OSDiskTypeManaged)
-		}},
-
-		// OperatingSystem (nested leaf: single sysctl value change)
-		{"sysctl leaf value change (NetCoreRmemMax)", func(p *armcontainerservice.MachineProperties) {
-			p.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls.NetCoreRmemMax = lo.ToPtr[int32](8388608)
-		}},
-		{"sysctl leaf value change (NetCoreSomaxconn)", func(p *armcontainerservice.MachineProperties) {
-			p.OperatingSystem.LinuxProfile.LinuxOSConfig.Sysctls.NetCoreSomaxconn = lo.ToPtr[int32](8192)
-		}},
-		{"LinuxOSConfig removed", func(p *armcontainerservice.MachineProperties) { p.OperatingSystem.LinuxProfile = nil }},
-
-		// Kubernetes (flat fields)
 		{"different K8s version", func(p *armcontainerservice.MachineProperties) { p.Kubernetes.OrchestratorVersion = lo.ToPtr("1.32.0") }},
-		{"different MaxPods", func(p *armcontainerservice.MachineProperties) { p.Kubernetes.MaxPods = lo.ToPtr[int32](110) }},
-
-		// Kubernetes (nested leaf: KubeletConfig value change)
-		{"KubeletConfig CPUManagerPolicy change (leaf)", func(p *armcontainerservice.MachineProperties) {
-			p.Kubernetes.KubeletConfig.CPUManagerPolicy = lo.ToPtr("none")
-		}},
-		{"KubeletConfig removed", func(p *armcontainerservice.MachineProperties) { p.Kubernetes.KubeletConfig = nil }},
-
-		// Kubernetes (nested leaf: ArtifactStreaming bool flip)
-		{"ArtifactStreaming disabled (leaf bool flip)", func(p *armcontainerservice.MachineProperties) {
-			p.Kubernetes.ArtifactStreamingProfile.Enabled = lo.ToPtr(false)
-		}},
-		{"ArtifactStreaming removed", func(p *armcontainerservice.MachineProperties) {
-			p.Kubernetes.ArtifactStreamingProfile = nil
-		}},
-
-		// Network
 		{"different subnet", func(p *armcontainerservice.MachineProperties) { p.Network.VnetSubnetID = lo.ToPtr("/other/subnet") }},
-
-		// NodeImageVersion
+		{"system mode", func(p *armcontainerservice.MachineProperties) {
+			p.Mode = lo.ToPtr(armcontainerservice.AgentPoolModeSystem)
+		}},
+		{"FIPS enabled", func(p *armcontainerservice.MachineProperties) { p.OperatingSystem.EnableFIPS = lo.ToPtr(true) }},
 		{"different node image", func(p *armcontainerservice.MachineProperties) {
 			p.NodeImageVersion = lo.ToPtr("AKSUbuntu-2404gen2containerd-2025.03.01")
 		}},
-
-		// Security (nested leaf: bool flip)
-		{"EncryptionAtHost disabled (leaf bool flip)", func(p *armcontainerservice.MachineProperties) {
-			p.Security.EnableEncryptionAtHost = lo.ToPtr(false)
-		}},
-
-		// LocalDNS (nested leaf: mode change, not nil→populated)
-		{"LocalDNS mode change (leaf)", func(p *armcontainerservice.MachineProperties) {
-			p.LocalDNSProfile.Mode = lo.ToPtr(armcontainerservice.LocalDNSModeDisabled)
-		}},
-		{"LocalDNS removed", func(p *armcontainerservice.MachineProperties) { p.LocalDNSProfile = nil }},
 	}
 
 	for _, tt := range tests {
@@ -299,92 +213,6 @@ func TestMachineKeyFunc_RealisticMachinesDifferentConfigsSplit(t *testing.T) {
 			tt.modify(props)
 			item := aksMachineCreatePayload{machineBody: &armcontainerservice.Machine{Properties: props}}
 			g.Expect(mustDetermineBatchKey(t, &item)).ToNot(gomega.Equal(baseHash), "hash should differ when %s changes", tt.name)
-		})
-	}
-}
-
-// TestMachineKeyFunc_PerMachineFieldsDoNotSplit verifies that per-machine fields
-// (Tags, Zones, Machine Name, read-only fields) do NOT affect the batch key.
-// This is the positive counterpart to TestMachineKeyFunc_RealisticMachinesDifferentConfigsSplit.
-func TestMachineKeyFunc_PerMachineFieldsDoNotSplit(t *testing.T) {
-	t.Parallel()
-	g := gomega.NewWithT(t)
-
-	baseItem := aksMachineCreatePayload{
-		machineName: "machine-base",
-		machineBody: &armcontainerservice.Machine{
-			Name:       lo.ToPtr("machine-base"),
-			Zones:      []*string{lo.ToPtr("1")},
-			Properties: realisticMachineProps("Standard_D4s_v3", "nc-base"),
-		},
-	}
-	baseHash := mustDetermineBatchKey(t, &baseItem)
-
-	tests := []struct {
-		name   string
-		modify func(m *armcontainerservice.Machine, p *aksMachineCreatePayload)
-	}{
-		// Per-machine: Tags
-		{"different Tags", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
-			m.Properties.Tags = map[string]*string{
-				"completely": lo.ToPtr("different-tags"),
-			}
-		}},
-		{"nil Tags", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
-			m.Properties.Tags = nil
-		}},
-		{"extra Tags", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
-			m.Properties.Tags["extra-key"] = lo.ToPtr("extra-val")
-		}},
-
-		// Per-machine: Zones
-		{"different zone", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
-			m.Zones = []*string{lo.ToPtr("3")}
-		}},
-		{"multiple zones", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
-			m.Zones = []*string{lo.ToPtr("1"), lo.ToPtr("2"), lo.ToPtr("3")}
-		}},
-		{"nil zones", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
-			m.Zones = nil
-		}},
-
-		// Per-machine: Machine Name (on payload and Machine object)
-		{"different machine name", func(m *armcontainerservice.Machine, p *aksMachineCreatePayload) {
-			m.Name = lo.ToPtr("different-machine")
-			p.machineName = "different-machine"
-		}},
-
-		// Read-only fields
-		{"ETag set", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
-			m.Properties.ETag = lo.ToPtr("etag-123")
-		}},
-		{"ProvisioningState set", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
-			m.Properties.ProvisioningState = lo.ToPtr("Succeeded")
-		}},
-		{"ResourceID set", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
-			m.Properties.ResourceID = lo.ToPtr("/subscriptions/sub/resourceGroups/rg/...")
-		}},
-		{"Status set", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
-			m.Properties.Status = &armcontainerservice.MachineStatus{}
-		}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			props := realisticMachineProps("Standard_D4s_v3", "nc-variant")
-			machine := &armcontainerservice.Machine{
-				Name:       lo.ToPtr("machine-variant"),
-				Zones:      []*string{lo.ToPtr("1")},
-				Properties: props,
-			}
-			item := aksMachineCreatePayload{
-				machineName: "machine-variant",
-				machineBody: machine,
-			}
-			tt.modify(machine, &item)
-			g.Expect(mustDetermineBatchKey(t, &item)).To(gomega.Equal(baseHash),
-				"per-machine field change (%s) should NOT affect batch key", tt.name)
 		})
 	}
 }

--- a/pkg/providers/azclient/aksmachinesheaderbatch/batchkey_test.go
+++ b/pkg/providers/azclient/aksmachinesheaderbatch/batchkey_test.go
@@ -104,7 +104,7 @@ func TestMachineKeyFunc_ReadOnlyFieldsExcluded(t *testing.T) {
 // production templates built by buildAKSMachineTemplate. All nested structs
 // are populated so tests can verify that a single leaf-value change is enough
 // to produce a different batch key.
-func realisticMachineProps(vmSize, nodeClaimName string) *armcontainerservice.MachineProperties {
+func realisticMachineProps(vmSize, nodeClaimName string) *armcontainerservice.MachineProperties { //nolint:unparam
 	return &armcontainerservice.MachineProperties{
 		Hardware: &armcontainerservice.MachineHardwareProfile{
 			VMSize: lo.ToPtr(vmSize),

--- a/pkg/providers/azclient/aksmachinesheaderbatch/batchkey_test.go
+++ b/pkg/providers/azclient/aksmachinesheaderbatch/batchkey_test.go
@@ -188,21 +188,72 @@ func TestMachineKeyFunc_RealisticMachinesDifferentConfigsSplit(t *testing.T) {
 		name   string
 		modify func(p *armcontainerservice.MachineProperties)
 	}{
+		// Hardware
 		{"different VM size", func(p *armcontainerservice.MachineProperties) { p.Hardware.VMSize = lo.ToPtr("Standard_D8s_v3") }},
+		{"GPU profile added", func(p *armcontainerservice.MachineProperties) {
+			p.Hardware.GpuProfile = &armcontainerservice.GPUProfile{Driver: lo.ToPtr(armcontainerservice.GPUDriverInstall)}
+		}},
+
+		// Priority / Mode
 		{"spot priority", func(p *armcontainerservice.MachineProperties) {
 			p.Priority = lo.ToPtr(armcontainerservice.ScaleSetPrioritySpot)
 		}},
-		{"different OS SKU", func(p *armcontainerservice.MachineProperties) {
-			p.OperatingSystem.OSSKU = lo.ToPtr(armcontainerservice.OSSKUAzureLinux)
-		}},
-		{"different K8s version", func(p *armcontainerservice.MachineProperties) { p.Kubernetes.OrchestratorVersion = lo.ToPtr("1.32.0") }},
-		{"different subnet", func(p *armcontainerservice.MachineProperties) { p.Network.VnetSubnetID = lo.ToPtr("/other/subnet") }},
 		{"system mode", func(p *armcontainerservice.MachineProperties) {
 			p.Mode = lo.ToPtr(armcontainerservice.AgentPoolModeSystem)
 		}},
+
+		// OperatingSystem (flat fields)
+		{"different OS SKU", func(p *armcontainerservice.MachineProperties) {
+			p.OperatingSystem.OSSKU = lo.ToPtr(armcontainerservice.OSSKUAzureLinux)
+		}},
 		{"FIPS enabled", func(p *armcontainerservice.MachineProperties) { p.OperatingSystem.EnableFIPS = lo.ToPtr(true) }},
+		{"different OSDiskSizeGB", func(p *armcontainerservice.MachineProperties) { p.OperatingSystem.OSDiskSizeGB = lo.ToPtr[int32](256) }},
+		{"different OSDiskType", func(p *armcontainerservice.MachineProperties) {
+			p.OperatingSystem.OSDiskType = lo.ToPtr(armcontainerservice.OSDiskTypeManaged)
+		}},
+
+		// OperatingSystem (nested: LinuxOSConfig)
+		{"LinuxOSConfig added", func(p *armcontainerservice.MachineProperties) {
+			p.OperatingSystem.LinuxProfile = &armcontainerservice.MachineOSProfileLinuxProfile{
+				LinuxOSConfig: &armcontainerservice.LinuxOSConfig{
+					Sysctls: &armcontainerservice.SysctlConfig{
+						NetCoreRmemMax: lo.ToPtr[int32](16777216),
+					},
+				},
+			}
+		}},
+
+		// Kubernetes (flat fields)
+		{"different K8s version", func(p *armcontainerservice.MachineProperties) { p.Kubernetes.OrchestratorVersion = lo.ToPtr("1.32.0") }},
+		{"different MaxPods", func(p *armcontainerservice.MachineProperties) { p.Kubernetes.MaxPods = lo.ToPtr[int32](110) }},
+
+		// Kubernetes (nested: KubeletConfig)
+		{"different KubeletConfig", func(p *armcontainerservice.MachineProperties) {
+			p.Kubernetes.KubeletConfig = &armcontainerservice.KubeletConfig{CPUManagerPolicy: lo.ToPtr("none")}
+		}},
+		{"KubeletConfig removed", func(p *armcontainerservice.MachineProperties) { p.Kubernetes.KubeletConfig = nil }},
+
+		// Kubernetes (nested: ArtifactStreamingProfile)
+		{"ArtifactStreaming enabled", func(p *armcontainerservice.MachineProperties) {
+			p.Kubernetes.ArtifactStreamingProfile = &armcontainerservice.AgentPoolArtifactStreamingProfile{Enabled: lo.ToPtr(true)}
+		}},
+
+		// Network
+		{"different subnet", func(p *armcontainerservice.MachineProperties) { p.Network.VnetSubnetID = lo.ToPtr("/other/subnet") }},
+
+		// NodeImageVersion
 		{"different node image", func(p *armcontainerservice.MachineProperties) {
 			p.NodeImageVersion = lo.ToPtr("AKSUbuntu-2404gen2containerd-2025.03.01")
+		}},
+
+		// Security (nested)
+		{"EncryptionAtHost disabled", func(p *armcontainerservice.MachineProperties) {
+			p.Security.EnableEncryptionAtHost = lo.ToPtr(false)
+		}},
+
+		// LocalDNS (nested)
+		{"LocalDNS added", func(p *armcontainerservice.MachineProperties) {
+			p.LocalDNSProfile = &armcontainerservice.LocalDNSProfile{Mode: lo.ToPtr(armcontainerservice.LocalDNSModeRequired)}
 		}},
 	}
 
@@ -213,6 +264,92 @@ func TestMachineKeyFunc_RealisticMachinesDifferentConfigsSplit(t *testing.T) {
 			tt.modify(props)
 			item := aksMachineCreatePayload{machineBody: &armcontainerservice.Machine{Properties: props}}
 			g.Expect(mustDetermineBatchKey(t, &item)).ToNot(gomega.Equal(baseHash), "hash should differ when %s changes", tt.name)
+		})
+	}
+}
+
+// TestMachineKeyFunc_PerMachineFieldsDoNotSplit verifies that per-machine fields
+// (Tags, Zones, Machine Name, read-only fields) do NOT affect the batch key.
+// This is the positive counterpart to TestMachineKeyFunc_RealisticMachinesDifferentConfigsSplit.
+func TestMachineKeyFunc_PerMachineFieldsDoNotSplit(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	baseItem := aksMachineCreatePayload{
+		machineName: "machine-base",
+		machineBody: &armcontainerservice.Machine{
+			Name:       lo.ToPtr("machine-base"),
+			Zones:      []*string{lo.ToPtr("1")},
+			Properties: realisticMachineProps("Standard_D4s_v3", "nc-base"),
+		},
+	}
+	baseHash := mustDetermineBatchKey(t, &baseItem)
+
+	tests := []struct {
+		name   string
+		modify func(m *armcontainerservice.Machine, p *aksMachineCreatePayload)
+	}{
+		// Per-machine: Tags
+		{"different Tags", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
+			m.Properties.Tags = map[string]*string{
+				"completely": lo.ToPtr("different-tags"),
+			}
+		}},
+		{"nil Tags", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
+			m.Properties.Tags = nil
+		}},
+		{"extra Tags", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
+			m.Properties.Tags["extra-key"] = lo.ToPtr("extra-val")
+		}},
+
+		// Per-machine: Zones
+		{"different zone", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
+			m.Zones = []*string{lo.ToPtr("3")}
+		}},
+		{"multiple zones", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
+			m.Zones = []*string{lo.ToPtr("1"), lo.ToPtr("2"), lo.ToPtr("3")}
+		}},
+		{"nil zones", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
+			m.Zones = nil
+		}},
+
+		// Per-machine: Machine Name (on payload and Machine object)
+		{"different machine name", func(m *armcontainerservice.Machine, p *aksMachineCreatePayload) {
+			m.Name = lo.ToPtr("different-machine")
+			p.machineName = "different-machine"
+		}},
+
+		// Read-only fields
+		{"ETag set", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
+			m.Properties.ETag = lo.ToPtr("etag-123")
+		}},
+		{"ProvisioningState set", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
+			m.Properties.ProvisioningState = lo.ToPtr("Succeeded")
+		}},
+		{"ResourceID set", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
+			m.Properties.ResourceID = lo.ToPtr("/subscriptions/sub/resourceGroups/rg/...")
+		}},
+		{"Status set", func(m *armcontainerservice.Machine, _ *aksMachineCreatePayload) {
+			m.Properties.Status = &armcontainerservice.MachineStatus{}
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			props := realisticMachineProps("Standard_D4s_v3", "nc-variant")
+			machine := &armcontainerservice.Machine{
+				Name:       lo.ToPtr("machine-variant"),
+				Zones:      []*string{lo.ToPtr("1")},
+				Properties: props,
+			}
+			item := aksMachineCreatePayload{
+				machineName: "machine-variant",
+				machineBody: machine,
+			}
+			tt.modify(machine, &item)
+			g.Expect(mustDetermineBatchKey(t, &item)).To(gomega.Equal(baseHash),
+				"per-machine field change (%s) should NOT affect batch key", tt.name)
 		})
 	}
 }


### PR DESCRIPTION
**Description**

End-to-end unit tests for multi-instance provisioning with batch grouping verification.

Depends on #1491 (batch-test-config).

### Problem
PR #1491 adds batch mode as a test configuration but only runs existing single-instance tests. The core Karpenter provisioner creates NodeClaims in a serial for-loop — each cloudProvider.Create() blocks on the batch grouper's response channel until the idle timeout fires, so every batch window closes with exactly 1 machine. Batching never actually happens at the cloudprovider integration level.

The batch package has isolated unit tests (coordinator_test.go, grouper_test.go) that test grouping directly, but nothing exercises the full integration path:
cloudProvider.Create() → AKSMachineProvider.BeginCreate() → BatchingMachinesClient → Grouper → Coordinator → fake API.

### Solution
Bypass the provisioner's serial loop by calling cloudProvider.Create() concurrently from goroutines. All creates land in the batch grouper before the idle timeout fires, causing actual batching to happen.

### Design decisions
**Why bypass the provisioner?** The provisioner's serial Create() loop is fundamental to core Karpenter and cannot be changed. Direct cloudProvider.Create() calls are already an established test pattern (CreateAndWaitForPromises in pkg/test/expectations/expectations.go).

**Mode-agnostic vs batch-specific separation.** runSharedMultiInstanceProvisionTests() verifies correctness for ALL modes (no batch assertions). runBatchSpecificMultiInstanceTests() asserts on CalledWithInput.Len() which is only meaningful for batch mode. This separation means batch-specific tests won't break if batch is removed, and mode-agnostic tests add coverage for non-batch paths too.

**Concurrency timing.** Batch idle timeout is 100ms in tests. Goroutines launched with sync.WaitGroup all start within microseconds, well within the idle window.

**Per-machine Launched condition.** After each Create() returns, we immediately set Launched=True on the NodeClaim so the async promise goroutine can proceed. This mirrors CreateAndWaitForPromises.

### Rebase guidance
If earlier branches change heavily, the core principles to preserve are:

- concurrentCreateAndWaitForPromises — the test helper that launches N Create() calls concurrently and waits for all promises. This is the key mechanism that makes batching happen in tests.
- Batch assertions use CalledWithInput.Len() — each batch produces exactly 1 BeginCreateOrUpdate call, so same-template creates → 1 call, K distinct templates → K calls.
- Mode-agnostic tests only assert on outcomes (machines created, correct properties), never on API call counts.

### Tests added
Mode-agnostic (runSharedMultiInstanceProvisionTests):

- Provision 3 same-type instances concurrently
- Provision 3 mixed-type instances concurrently (Standard_D2_v2 + Standard_D4s_v3)

Batch-specific (runBatchSpecificMultiInstanceTests):

- 5 same-template → 1 batch API call
- 5 mixed (3 + 2 different sizes) → 2 batch API calls
- Per-machine tags propagated through batch
- Batch error propagated to all machines

**How was this change tested?**

* Unit tests here

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```