### PR TITLE
Add kuberentes.azure.com/NodeHealthy repair policy condition

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -545,7 +545,7 @@ func (c *CloudProvider) RepairPolicies() []cloudprovider.RepairPolicy {
 			TolerationDuration: 10 * time.Minute,
 		},
 		{
-			ConditionType:      "kuberentes.azure.com/NodeHealthy",
+			ConditionType:      "kubernetes.azure.com/NodeHealthy",
 			ConditionStatus:    corev1.ConditionFalse,
 			TolerationDuration: 0,
 		},

--- a/test/suites/integration/repair_policy_test.go
+++ b/test/suites/integration/repair_policy_test.go
@@ -90,6 +90,11 @@ var _ = Describe("Repair Policy", func() {
 			Status:             corev1.ConditionUnknown,
 			LastTransitionTime: metav1.Time{Time: time.Now().Add(-11 * time.Minute)},
 		}),
+		Entry("Node Healthy False", corev1.NodeCondition{
+			Type:               corev1.NodeConditionType("kubernetes.azure.com/NodeHealthy"),
+			Status:             corev1.ConditionFalse,
+			LastTransitionTime: metav1.Time{Time: time.Now()},
+		}),
 	)
 	It("should ignore disruption budgets", func() {
 		nodePool.Spec.Disruption.Budgets = []karpenterv1.Budget{


### PR DESCRIPTION
**Description**
This add a new condition in the RepairPolicies to integrate with [Azure's Cluster Health Monitor.](https://github.com/Azure/cluster-health-monitor/blob/5172303fe1c06b46a81dca2c33060c7174539c5c/pkg/controller/checknodehealth/controller.go#L65) 

**How was this change tested?**

* No test for this. E2E will be done in Cluster Health Monitor when it integrate with Karpenter.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**


```release-note

```
