### PR TITLE
fix: remove hard timeout from WaitForCRDs and retry transient errors

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -307,8 +307,16 @@ func getVnetGUID(ctx context.Context, creds azcore.TokenCredential, cfg *auth.Co
 	return *vnet.Properties.ResourceGUID, nil
 }
 
-// WaitForCRDs waits for the required CRDs to be available with a timeout
-func WaitForCRDs(ctx context.Context, timeout time.Duration, config *rest.Config, log logr.Logger) error {
+// WaitForCRDs waits for the required CRDs to be available.
+// The timeout parameter is accepted for backward compatibility but is no longer used.
+// Instead, the function waits indefinitely, relying on kubelet liveness probes to restart
+// the pod if CRDs truly never appear. In CCP deployments, CRD installation via the overlay
+// Flux HelmController can take minutes to tens of minutes depending on infrastructure load.
+// A hard timeout here causes crash-loop overhead that makes the situation worse: the
+// DynamicRESTMapper's cache is lost on each restart, and CrashLoopBackOff exponential
+// backoff delays the next attempt. Waiting indefinitely allows the pod to succeed as soon
+// as CRDs arrive, without wasting time on restarts.
+func WaitForCRDs(ctx context.Context, _ time.Duration, config *rest.Config, log logr.Logger) error {
 	requiredGVKs := getRequiredGVKs()
 	client, err := rest.HTTPClientFor(config)
 	if err != nil {
@@ -319,9 +327,7 @@ func WaitForCRDs(ctx context.Context, timeout time.Duration, config *rest.Config
 		return fmt.Errorf("creating dynamic rest mapper, %w", err)
 	}
 
-	log.Info("waiting for required CRDs to be available", "gvks", requiredGVKs, "timeout", timeout)
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	log.Info("waiting for required CRDs to be available", "gvks", requiredGVKs)
 
 	for _, gvk := range requiredGVKs {
 		err := wait.PollUntilContextCancel(ctx, 10*time.Second, true, func(ctx context.Context) (bool, error) {
@@ -330,15 +336,17 @@ func WaitForCRDs(ctx context.Context, timeout time.Duration, config *rest.Config
 					log.V(1).Info("waiting for CRD to be available", "gvk", gvk)
 					return false, nil
 				}
-				return false, err
+				// Transient errors (network, 503, etc.) should also be retried rather than
+				// treated as fatal. The DynamicRESTMapper wraps discovery failures as
+				// ErrResourceDiscoveryFailed which is not a NoMatchError, but these are
+				// typically transient and will resolve once the API server is reachable.
+				log.V(1).Info("transient error checking CRD, will retry", "gvk", gvk, "error", err)
+				return false, nil
 			}
 			log.V(1).Info("CRD is available", "gvk", gvk)
 			return true, nil
 		})
 		if err != nil {
-			if ctx.Err() == context.DeadlineExceeded {
-				return fmt.Errorf("timed out waiting for CRD %s to be available", gvk)
-			}
 			return fmt.Errorf("failed to wait for CRD %s: %w", gvk, err)
 		}
 	}


### PR DESCRIPTION
## Summary
- Remove the hard 2-minute timeout from `WaitForCRDs` — wait indefinitely instead
- Treat transient discovery errors (network, 503, `ErrResourceDiscoveryFailed`) as retryable instead of fatal

## Problem

Data from E2E `KarpenterEvents` (Kusto analysis on ~25,000 CCP namespaces across 7+ days) shows that the CRD wait success rate dropped significantly when NodeOverlay was added to the CRD check list:

| Version | CRD Count | Overall Success Rate |
|---------|-----------|---------------------|
| v1.7.0 (3 CRDs) | NodePool, NodeClaim, AKSNodeClass | **93.7%** (9910/10580) |
| v1.7.2 (4 CRDs) | + NodeOverlay | **66.3%** (9929/14974) |

On good infrastructure days both achieve ~90-96%. On bad days, v1.7.0 stays at 92%+ while v1.7.2 drops to 16-36%.

Two mechanisms cause the failures:

1. **Hard timeout**: The 2-minute timeout causes unnecessary crash-loops. The `DynamicRESTMapper` cache is lost on each restart, and `CrashLoopBackOff` exponential backoff delays subsequent attempts. CRD installation can take 5-20+ minutes in loaded E2E environments.

2. **Transient errors treated as fatal**: The `DynamicRESTMapper` wraps discovery failures (network errors, 503s) as `ErrResourceDiscoveryFailed`, which is not a `meta.NoMatchError`. The old code treated these as fatal (`return false, err`), crashing the pod immediately instead of retrying.

## Fix

1. **Remove the timeout**: Wait indefinitely. Kubelet liveness probes handle truly stuck pods. The pod stays in "waiting for CRDs" state without crashing, succeeding as soon as CRDs arrive.

2. **Retry transient errors**: Log them and retry on the next 10-second poll instead of crashing.

## Context

The NodeOverlay CRD check was added in `be398caf` (PR #1448) as a hotfix for Sev 2 IcM-21000000914813. **It must remain in the CRD check list** — without it, the pod can start before the CRD is installed, causing a race condition where the NodeOverlay controller never reconciles and provisioning breaks silently. This PR keeps all CRDs in the check list while making the check resilient to slow installation.

## Testing

- `go build ./cmd/controller/` and `go build -tags ccp ./cmd/controller/` — both pass
- `go test ./pkg/operator/...` — passes
