### PR TITLE
refactor: add grouped client interfaces to AZClient

### DIFF
--- a/pkg/providers/azclient/azclient.go
+++ b/pkg/providers/azclient/azclient.go
@@ -84,6 +84,33 @@ type DiskEncryptionSetsAPI interface {
 	Get(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, options *armcompute.DiskEncryptionSetsClientGetOptions) (armcompute.DiskEncryptionSetsClientGetResponse, error)
 }
 
+// VMClients provides Azure clients needed by the VM provisioning path.
+type VMClients interface {
+	VirtualMachinesClient() VirtualMachinesAPI
+	VirtualMachineExtensionsClient() VirtualMachineExtensionsAPI
+	NetworkInterfacesClient() NetworkInterfacesAPI
+	AzureResourceGraphClient() AzureResourceGraphAPI
+}
+
+// MachineClients provides Azure clients needed by the AKS Machine provisioning path.
+type MachineClients interface {
+	AKSMachinesClient() AKSMachinesAPI
+	AgentPoolsClient() AKSAgentPoolsAPI
+}
+
+// NodeClassClients provides Azure clients needed by the AKSNodeClass validation/defaulting controllers.
+type NodeClassClients interface {
+	SubnetsClient() SubnetsAPI
+	DiskEncryptionSetsClient() DiskEncryptionSetsAPI
+}
+
+// Compile-time interface satisfaction checks.
+var (
+	_ VMClients        = (*AZClient)(nil)
+	_ MachineClients   = (*AZClient)(nil)
+	_ NodeClassClients = (*AZClient)(nil)
+)
+
 type AZClient struct {
 	azureResourceGraphClient       AzureResourceGraphAPI
 	virtualMachinesClient          VirtualMachinesAPI

--- a/pkg/providers/instance/aksmachineinstance.go
+++ b/pkg/providers/instance/aksmachineinstance.go
@@ -127,7 +127,7 @@ type AKSMachineProvider interface {
 var _ AKSMachineProvider = (*DefaultAKSMachineProvider)(nil)
 
 type DefaultAKSMachineProvider struct {
-	azClient                *azclient.AZClient
+	azClient                azclient.MachineClients
 	instanceTypeProvider    instancetype.Provider
 	imageResolver           imagefamily.Resolver
 	subscriptionID          string
@@ -141,7 +141,7 @@ type DefaultAKSMachineProvider struct {
 }
 
 func NewAKSMachineProvider(
-	azClient *azclient.AZClient,
+	azClient azclient.MachineClients,
 	instanceTypeProvider instancetype.Provider,
 	imageResolver imagefamily.Resolver,
 	offeringsCache *cache.UnavailableOfferings,

--- a/pkg/providers/instance/vminstance.go
+++ b/pkg/providers/instance/vminstance.go
@@ -158,7 +158,7 @@ var _ VMProvider = (*DefaultVMProvider)(nil)
 
 type DefaultVMProvider struct {
 	location                     string
-	azClient                     *azclient.AZClient
+	azClient                     azclient.VMClients
 	instanceTypeProvider         instancetype.Provider
 	launchTemplateProvider       *launchtemplate.Provider
 	loadBalancerProvider         *loadbalancer.Provider
@@ -176,7 +176,7 @@ type DefaultVMProvider struct {
 }
 
 func NewDefaultVMProvider(
-	azClient *azclient.AZClient,
+	azClient azclient.VMClients,
 	instanceTypeProvider instancetype.Provider,
 	launchTemplateProvider *launchtemplate.Provider,
 	loadBalancerProvider *loadbalancer.Provider,


### PR DESCRIPTION
**Description**

Adds grouped client interfaces to `pkg/providers/azclient/` that make ownership boundaries between VM-path and Machine-path Azure clients explicit.

**Problem:** The `AZClient` struct bundles all Azure SDK clients into a single God-object. Both `DefaultVMProvider` and `DefaultAKSMachineProvider` receive the full `*AZClient` despite using disjoint subsets. This makes it unclear which clients each provider actually depends on.

**Changes:**
- Add `VMClients` interface: groups VirtualMachinesAPI, VirtualMachineExtensionsAPI, NetworkInterfacesAPI, AzureResourceGraphAPI
- Add `MachineClients` interface: groups AKSMachinesAPI, AKSAgentPoolsAPI
- Add `NodeClassClients` interface: groups clients used by NodeClass status controllers (SubnetsAPI, DiskEncryptionSetsAPI)
- Add compile-time assertions
- Narrow provider constructor parameters from `*AZClient` to the specific interface each provider needs

This is a non-breaking, additive change -- AZClient implements all interfaces, so existing code continues to work. The interfaces document the dependency boundaries and enable future testing with narrower mocks.

**How was this change tested?**

Build verification (go build ./...). No behavioral changes -- purely additive interfaces with narrowed parameter types.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened:
- [x] No

**Release Note**

NONE