### PR TITLE
fix: remove --pod-infra-container-image kubelet flag for K8s >= 1.35

### DIFF
--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -329,6 +329,9 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 	if minorVersion >= 34 {
 		delete(kubeletFlagsBase, "--cloud-config") // removed in 1.34
 	}
+	if minorVersion >= 35 {
+		delete(kubeletFlagsBase, "--pod-infra-container-image") // removed in 1.35 (https://github.com/kubernetes/kubernetes/pull/133779)
+	}
 
 	credentialProviderURL := CredentialProviderURL(a.KubernetesVersion, a.Arch)
 	if credentialProviderURL != "" { // use OOT credential provider


### PR DESCRIPTION
Fixes #1516

**Description**

The `--pod-infra-container-image` kubelet flag was removed in Kubernetes 1.35 ([kubernetes/kubernetes#133779](https://github.com/kubernetes/kubernetes/pull/133779)). Nodes provisioned with this flag on 1.35+ fail kubelet startup:

```
failed to parse kubelet flag: unknown flag: --pod-infra-container-image
```

This removes the flag from the base kubelet flags for K8s minor version >= 35, following the same pattern used for `--cloud-config` (>= 1.34) and `--keep-terminated-pod-volumes` (< 1.31).

**How was this change tested?**

* Existing bootstrap unit tests pass
* Follows established pattern for version-gated kubelet flag removal

**Does this change impact docs?**
- [x] No

**Release Note**

```release-note
Fixed Karpenter-provisioned nodes failing to register on Kubernetes 1.35 due to the removed `--pod-infra-container-image` kubelet flag.
```