### PR TITLE
IGNORE THIS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ verify: tidy download ## Verify code. Includes dependencies, linting, formatting
 	cp $(KARPENTER_CORE_DIR)/pkg/apis/crds/* pkg/apis/crds
 	hack/validation/kubelet.sh
 	hack/validation/labels.sh
+	hack/validation/taints.sh
 	hack/validation/requirements.sh
 	hack/mutation/kubectl_get_ux.sh
 	cp pkg/apis/crds/* charts/karpenter-crd/templates

--- a/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
@@ -132,6 +132,10 @@ spec:
                             rule: self != "kubernetes.io/hostname"
                           - message: label domain "karpenter.azure.com" is restricted
                             rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                          - message: label domain "kubernetes.azure.com" is restricted
+                            rule: self in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", "kubernetes.azure.com/cluster-health-monitor-checker-synthetic", ] || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+                          - message: label "agentpool" is restricted
+                            rule: self != 'agentpool'
                       minValues:
                         description: |-
                           This field is ALPHA and can be dropped or replaced at any time

--- a/charts/karpenter-crd/templates/karpenter.sh_nodeoverlays.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeoverlays.yaml
@@ -105,6 +105,10 @@ spec:
                             rule: self != "kubernetes.io/hostname"
                           - message: label domain "karpenter.azure.com" is restricted
                             rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                          - message: label domain "kubernetes.azure.com" is restricted
+                            rule: self in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", "kubernetes.azure.com/cluster-health-monitor-checker-synthetic", ] || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+                          - message: label "agentpool" is restricted
+                            rule: self != 'agentpool'
                       operator:
                         description: |-
                           Represents a key's relationship to a set of values.

--- a/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -209,6 +209,10 @@ spec:
                               rule: self.all(x, x != "kubernetes.io/hostname")
                             - message: label domain "karpenter.azure.com" is restricted
                               rule: self.all(x, x in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !x.find("^([^/]+)").endsWith("karpenter.azure.com"))
+                            - message: label domain "kubernetes.azure.com" is restricted
+                              rule: self.all(x, x in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", "kubernetes.azure.com/cluster-health-monitor-checker-synthetic", ] || !x.find("^([^/]+)").endsWith("kubernetes.azure.com"))
+                            - message: label "agentpool" is restricted
+                              rule: self.all(x, x != 'agentpool')
                       type: object
                     spec:
                       description: |-
@@ -282,6 +286,10 @@ spec:
                                     rule: self != "kubernetes.io/hostname"
                                   - message: label domain "karpenter.azure.com" is restricted
                                     rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                                  - message: label domain "kubernetes.azure.com" is restricted
+                                    rule: self in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", "kubernetes.azure.com/cluster-health-monitor-checker-synthetic", ] || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+                                  - message: label "agentpool" is restricted
+                                    rule: self != 'agentpool'
                               minValues:
                                 description: |-
                                   This field is ALPHA and can be dropped or replaced at any time
@@ -353,6 +361,7 @@ spec:
                                 type: string
                                 minLength: 1
                                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                maxLength: 253
                               timeAdded:
                                 description: TimeAdded represents the time at which the taint was added.
                                 format: date-time
@@ -366,6 +375,12 @@ spec:
                               - key
                             type: object
                           type: array
+                          x-kubernetes-validations:
+                            - message: taint domain "kubernetes.azure.com" is restricted
+                              rule: self.all(x, x.key in ["egressgateway.kubernetes.azure.com/cni-not-ready"] || !x.key.split("/")[0].endsWith("kubernetes.azure.com"))
+                            - message: taint "egressgateway.kubernetes.azure.com/cni-not-ready" must have value "true" and effect "NoSchedule"
+                              rule: self.all(x, !(x.key == "egressgateway.kubernetes.azure.com/cni-not-ready" && !(x.value == "true" && x.effect == "NoSchedule")))
+                          maxItems: 100
                         taints:
                           description: Taints will be applied to the NodeClaim's node.
                           items:
@@ -388,6 +403,7 @@ spec:
                                 type: string
                                 minLength: 1
                                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                maxLength: 253
                               timeAdded:
                                 description: TimeAdded represents the time at which the taint was added.
                                 format: date-time
@@ -401,6 +417,14 @@ spec:
                               - key
                             type: object
                           type: array
+                          x-kubernetes-validations:
+                            - message: taint domain "kubernetes.azure.com" is restricted
+                              rule: self.all(x, x.key in ["kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/mode"] || !x.key.split("/")[0].endsWith("kubernetes.azure.com"))
+                            - message: taint "kubernetes.azure.com/scalesetpriority" must have value "spot" and effect "NoSchedule"
+                              rule: self.all(x, !(x.key == "kubernetes.azure.com/scalesetpriority" && !(x.value == "spot" && x.effect == "NoSchedule")))
+                            - message: taint "kubernetes.azure.com/mode" must have value "gateway" and effect "NoSchedule"
+                              rule: self.all(x, !(x.key == "kubernetes.azure.com/mode" && !(x.value == "gateway" && x.effect == "NoSchedule")))
+                          maxItems: 100
                         terminationGracePeriod:
                           description: |-
                             TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.

--- a/hack/validation/labels.sh
+++ b/hack/validation/labels.sh
@@ -29,10 +29,55 @@ rule=${rule//\"/\\\"}            # escape double quotes
 rule=${rule//$'\n'/}             # remove newlines
 rule=$(echo "$rule" | tr -s ' ') # remove extra spaces
 
+# kubernetes.azure.com domain restriction
+# Synced with AKS RP label validation (utils_agentpool.go).
+# Machine API reuses the same AgentPool label validation pipeline.
+#
+# We allow well-known labels that Karpenter uses for scheduling or that users
+# legitimately need to set, plus special labels:
+#   - ebpf-dataplane: required for Cilium networking
+#   - cluster-health-monitor-checker-synthetic: written by Automatic clusters
+aks_rule=$'self.all(x, x in
+    [
+        "kubernetes.azure.com/mode",
+        "kubernetes.azure.com/scalesetpriority",
+        "kubernetes.azure.com/fips_enabled",
+        "kubernetes.azure.com/os-sku",
+        "kubernetes.azure.com/cluster",
+        "kubernetes.azure.com/sku-cpu",
+        "kubernetes.azure.com/sku-memory",
+        "kubernetes.azure.com/ebpf-dataplane",
+        "kubernetes.azure.com/cluster-health-monitor-checker-synthetic",
+    ]
+    || !x.find("^([^/]+)").endsWith("kubernetes.azure.com")
+)
+'
+
+aks_rule=${aks_rule//\"/\\\"}            # escape double quotes
+aks_rule=${aks_rule//$'\n'/}             # remove newlines
+aks_rule=$(echo "$aks_rule" | tr -s ' ') # remove extra spaces
+
+# agentpool label restriction
+# AKS RP blocks users from setting agentpool, storageprofile, storagetier, and accelerator labels.
+# These are AgentBaker-generated labels that Karpenter/RP assigns automatically.
+agentpool_rule=$'self.all(x, x != \x27agentpool\x27)'
+
+agentpool_rule=${agentpool_rule//\"/\\\"}            # escape double quotes
+agentpool_rule=${agentpool_rule//$'\n'/}             # remove newlines
+agentpool_rule=$(echo "$agentpool_rule" | tr -s ' ') # remove extra spaces
+
 # check that .spec.versions has 1 entry
 [[ $(yq e '.spec.versions | length' pkg/apis/crds/karpenter.sh_nodepools.yaml) -eq 1 ]] || { echo "expected one version"; exit 1; }
 
-# nodepool
+# nodepool labels
 printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.metadata.properties.labels.x-kubernetes-validations +=
     [{"message": "label domain \\"karpenter.azure.com\\" is restricted", "rule": "%s"}]' "$rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.metadata.properties.labels.x-kubernetes-validations +=
+    [{"message": "label domain \\"kubernetes.azure.com\\" is restricted", "rule": "%s"}]' "$aks_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.metadata.properties.labels.x-kubernetes-validations +=
+    [{"message": "label \\"agentpool\\" is restricted", "rule": "%s"}]' "$agentpool_rule"
 yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml

--- a/hack/validation/requirements.sh
+++ b/hack/validation/requirements.sh
@@ -28,6 +28,33 @@ rule=${rule//\"/\\\"}            # escape double quotes
 rule=${rule//$'\n'/}             # remove newlines
 rule=$(echo "$rule" | tr -s ' ') # remove extra spaces
 
+# kubernetes.azure.com domain restriction (same allowlist as labels.sh)
+aks_rule=$'self in
+    [
+        "kubernetes.azure.com/mode",
+        "kubernetes.azure.com/scalesetpriority",
+        "kubernetes.azure.com/fips_enabled",
+        "kubernetes.azure.com/os-sku",
+        "kubernetes.azure.com/cluster",
+        "kubernetes.azure.com/sku-cpu",
+        "kubernetes.azure.com/sku-memory",
+        "kubernetes.azure.com/ebpf-dataplane",
+        "kubernetes.azure.com/cluster-health-monitor-checker-synthetic",
+    ]
+    || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+'
+
+aks_rule=${aks_rule//\"/\\\"}            # escape double quotes
+aks_rule=${aks_rule//$'\n'/}             # remove newlines
+aks_rule=$(echo "$aks_rule" | tr -s ' ') # remove extra spaces
+
+# agentpool requirement restriction
+agentpool_rule=$'self != \x27agentpool\x27'
+
+agentpool_rule=${agentpool_rule//\"/\\\"}            # escape double quotes
+agentpool_rule=${agentpool_rule//$'\n'/}             # remove newlines
+agentpool_rule=$(echo "$agentpool_rule" | tr -s ' ') # remove extra spaces
+
 # check that .spec.versions has 1 entry
 [[ $(yq e '.spec.versions | length' pkg/apis/crds/karpenter.sh_nodepools.yaml)  -eq 1 ]] || { echo "expected one version"; exit 1; }
 [[ $(yq e '.spec.versions | length' pkg/apis/crds/karpenter.sh_nodeclaims.yaml) -eq 1 ]] || { echo "expected one version"; exit 1; }
@@ -38,12 +65,36 @@ printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.propert
     [{"message": "label domain \\"karpenter.azure.com\\" is restricted", "rule": "%s"}]' "$rule"
 yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
 
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label domain \\"kubernetes.azure.com\\" is restricted", "rule": "%s"}]' "$aks_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"agentpool\\" is restricted", "rule": "%s"}]' "$agentpool_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+
 # nodepool
 printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
     [{"message": "label domain \\"karpenter.azure.com\\" is restricted", "rule": "%s"}]' "$rule"
 yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
 
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label domain \\"kubernetes.azure.com\\" is restricted", "rule": "%s"}]' "$aks_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"agentpool\\" is restricted", "rule": "%s"}]' "$agentpool_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
 # overlays
 printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
     [{"message": "label domain \\"karpenter.azure.com\\" is restricted", "rule": "%s"}]' "$rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label domain \\"kubernetes.azure.com\\" is restricted", "rule": "%s"}]' "$aks_rule"
+yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+
+printf -v expr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.requirements.items.properties.key.x-kubernetes-validations +=
+    [{"message": "label \\"agentpool\\" is restricted", "rule": "%s"}]' "$agentpool_rule"
 yq eval "${expr}" -i pkg/apis/crds/karpenter.sh_nodeoverlays.yaml

--- a/hack/validation/taints.sh
+++ b/hack/validation/taints.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -euo pipefail
+
+# taints validation for nodepool
+# checking for restricted taints in kubernetes.azure.com domain
+#
+# Synced with AKS RP taint validation (nodetaintsvalidator.go).
+# Machine API reuses the same AgentPool taint validation pipeline.
+#
+# For startupTaints: block all kubernetes.azure.com domain taints except
+# egressgateway.kubernetes.azure.com/cni-not-ready (used by egress gateway feature).
+#
+# For taints: allow only the known system taints with exact key/value/effect:
+#   - kubernetes.azure.com/scalesetpriority=spot:NoSchedule (spot pools)
+#   - kubernetes.azure.com/mode=gateway:NoSchedule (gateway pools)
+
+# Rule for startupTaints: allow only egressgateway.kubernetes.azure.com/cni-not-ready, block all other kubernetes.azure.com domain taints
+startupTaintsDomainRule='self.all(x, x.key in ["egressgateway.kubernetes.azure.com/cni-not-ready"] || !x.key.split("/")[0].endsWith("kubernetes.azure.com"))'
+startupTaintsValueRule='self.all(x, !(x.key == "egressgateway.kubernetes.azure.com/cni-not-ready" && !(x.value == "true" && x.effect == "NoSchedule")))'
+
+# Rules for taints: allow only specific kubernetes.azure.com taints with exact values/effects
+taintsDomainRule='self.all(x, x.key in ["kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/mode"] || !x.key.split("/")[0].endsWith("kubernetes.azure.com"))'
+scalesetpriorityRule='self.all(x, !(x.key == "kubernetes.azure.com/scalesetpriority" && !(x.value == "spot" && x.effect == "NoSchedule")))'
+modeRule='self.all(x, !(x.key == "kubernetes.azure.com/mode" && !(x.value == "gateway" && x.effect == "NoSchedule")))'
+
+# Escape quotes and clean up the rules
+startupTaintsDomainRule=${startupTaintsDomainRule//\"/\\\"}
+startupTaintsDomainRule=${startupTaintsDomainRule//$'\n'/}
+startupTaintsDomainRule=$(echo "$startupTaintsDomainRule" | tr -s ' ')
+
+startupTaintsValueRule=${startupTaintsValueRule//\"/\\\"}
+startupTaintsValueRule=${startupTaintsValueRule//$'\n'/}
+startupTaintsValueRule=$(echo "$startupTaintsValueRule" | tr -s ' ')
+
+taintsDomainRule=${taintsDomainRule//\"/\\\"}
+taintsDomainRule=${taintsDomainRule//$'\n'/}
+taintsDomainRule=$(echo "$taintsDomainRule" | tr -s ' ')
+
+scalesetpriorityRule=${scalesetpriorityRule//\"/\\\"}
+scalesetpriorityRule=${scalesetpriorityRule//$'\n'/}
+scalesetpriorityRule=$(echo "$scalesetpriorityRule" | tr -s ' ')
+
+modeRule=${modeRule//\"/\\\"}
+modeRule=${modeRule//$'\n'/}
+modeRule=$(echo "$modeRule" | tr -s ' ')
+
+# check that .spec.versions has 1 entry
+[[ $(yq e '.spec.versions | length' pkg/apis/crds/karpenter.sh_nodepools.yaml) -eq 1 ]] || { echo "expected one version"; exit 1; }
+
+# Add validation for startupTaints at array level
+printf -v startupTaintsDomainExpr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.startupTaints.x-kubernetes-validations +=
+    [{"message": "taint domain \\"kubernetes.azure.com\\" is restricted", "rule": "%s"}]' "$startupTaintsDomainRule"
+yq eval "${startupTaintsDomainExpr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v startupTaintsValueExpr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.startupTaints.x-kubernetes-validations +=
+    [{"message": "taint \\"egressgateway.kubernetes.azure.com/cni-not-ready\\" must have value \\"true\\" and effect \\"NoSchedule\\"", "rule": "%s"}]' "$startupTaintsValueRule"
+yq eval "${startupTaintsValueExpr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+# Add validation for taints at array level
+printf -v taintsDomainExpr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.taints.x-kubernetes-validations +=
+    [{"message": "taint domain \\"kubernetes.azure.com\\" is restricted", "rule": "%s"}]' "$taintsDomainRule"
+yq eval "${taintsDomainExpr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v scalesetpriorityExpr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.taints.x-kubernetes-validations +=
+    [{"message": "taint \\"kubernetes.azure.com/scalesetpriority\\" must have value \\"spot\\" and effect \\"NoSchedule\\"", "rule": "%s"}]' "$scalesetpriorityRule"
+yq eval "${scalesetpriorityExpr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+printf -v modeExpr '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.taints.x-kubernetes-validations +=
+    [{"message": "taint \\"kubernetes.azure.com/mode\\" must have value \\"gateway\\" and effect \\"NoSchedule\\"", "rule": "%s"}]' "$modeRule"
+yq eval "${modeExpr}" -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+# Set maxItems limit for both arrays (required for CEL validation cost budget)
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.startupTaints.maxItems = 100' -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.taints.maxItems = 100' -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+
+# Set maxLength limit for taint keys (required for CEL cost estimation with split/endsWith)
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.startupTaints.items.properties.key.maxLength = 253' -i pkg/apis/crds/karpenter.sh_nodepools.yaml
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.taints.items.properties.key.maxLength = 253' -i pkg/apis/crds/karpenter.sh_nodepools.yaml

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -132,6 +132,10 @@ spec:
                             rule: self != "kubernetes.io/hostname"
                           - message: label domain "karpenter.azure.com" is restricted
                             rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                          - message: label domain "kubernetes.azure.com" is restricted
+                            rule: self in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", "kubernetes.azure.com/cluster-health-monitor-checker-synthetic", ] || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+                          - message: label "agentpool" is restricted
+                            rule: self != 'agentpool'
                       minValues:
                         description: |-
                           This field is ALPHA and can be dropped or replaced at any time

--- a/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeoverlays.yaml
@@ -105,6 +105,10 @@ spec:
                             rule: self != "kubernetes.io/hostname"
                           - message: label domain "karpenter.azure.com" is restricted
                             rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                          - message: label domain "kubernetes.azure.com" is restricted
+                            rule: self in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", "kubernetes.azure.com/cluster-health-monitor-checker-synthetic", ] || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+                          - message: label "agentpool" is restricted
+                            rule: self != 'agentpool'
                       operator:
                         description: |-
                           Represents a key's relationship to a set of values.

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -209,6 +209,10 @@ spec:
                               rule: self.all(x, x != "kubernetes.io/hostname")
                             - message: label domain "karpenter.azure.com" is restricted
                               rule: self.all(x, x in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !x.find("^([^/]+)").endsWith("karpenter.azure.com"))
+                            - message: label domain "kubernetes.azure.com" is restricted
+                              rule: self.all(x, x in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", "kubernetes.azure.com/cluster-health-monitor-checker-synthetic", ] || !x.find("^([^/]+)").endsWith("kubernetes.azure.com"))
+                            - message: label "agentpool" is restricted
+                              rule: self.all(x, x != 'agentpool')
                       type: object
                     spec:
                       description: |-
@@ -282,6 +286,10 @@ spec:
                                     rule: self != "kubernetes.io/hostname"
                                   - message: label domain "karpenter.azure.com" is restricted
                                     rule: self in [ "karpenter.azure.com/aksnodeclass", "karpenter.azure.com/sku-name", "karpenter.azure.com/sku-family", "karpenter.azure.com/sku-series", "karpenter.azure.com/sku-version", "karpenter.azure.com/sku-cpu", "karpenter.azure.com/sku-memory", "karpenter.azure.com/sku-networking-accelerated", "karpenter.azure.com/sku-storage-premium-capable", "karpenter.azure.com/sku-storage-ephemeralos-maxsize", "karpenter.azure.com/sku-gpu-name", "karpenter.azure.com/sku-gpu-manufacturer", "karpenter.azure.com/sku-gpu-count" ] || !self.find("^([^/]+)").endsWith("karpenter.azure.com")
+                                  - message: label domain "kubernetes.azure.com" is restricted
+                                    rule: self in [ "kubernetes.azure.com/mode", "kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/fips_enabled", "kubernetes.azure.com/os-sku", "kubernetes.azure.com/cluster", "kubernetes.azure.com/sku-cpu", "kubernetes.azure.com/sku-memory", "kubernetes.azure.com/ebpf-dataplane", "kubernetes.azure.com/cluster-health-monitor-checker-synthetic", ] || !self.find("^([^/]+)").endsWith("kubernetes.azure.com")
+                                  - message: label "agentpool" is restricted
+                                    rule: self != 'agentpool'
                               minValues:
                                 description: |-
                                   This field is ALPHA and can be dropped or replaced at any time
@@ -353,6 +361,7 @@ spec:
                                 type: string
                                 minLength: 1
                                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                maxLength: 253
                               timeAdded:
                                 description: TimeAdded represents the time at which the taint was added.
                                 format: date-time
@@ -366,6 +375,12 @@ spec:
                               - key
                             type: object
                           type: array
+                          x-kubernetes-validations:
+                            - message: taint domain "kubernetes.azure.com" is restricted
+                              rule: self.all(x, x.key in ["egressgateway.kubernetes.azure.com/cni-not-ready"] || !x.key.split("/")[0].endsWith("kubernetes.azure.com"))
+                            - message: taint "egressgateway.kubernetes.azure.com/cni-not-ready" must have value "true" and effect "NoSchedule"
+                              rule: self.all(x, !(x.key == "egressgateway.kubernetes.azure.com/cni-not-ready" && !(x.value == "true" && x.effect == "NoSchedule")))
+                          maxItems: 100
                         taints:
                           description: Taints will be applied to the NodeClaim's node.
                           items:
@@ -388,6 +403,7 @@ spec:
                                 type: string
                                 minLength: 1
                                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                maxLength: 253
                               timeAdded:
                                 description: TimeAdded represents the time at which the taint was added.
                                 format: date-time
@@ -401,6 +417,14 @@ spec:
                               - key
                             type: object
                           type: array
+                          x-kubernetes-validations:
+                            - message: taint domain "kubernetes.azure.com" is restricted
+                              rule: self.all(x, x.key in ["kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/mode"] || !x.key.split("/")[0].endsWith("kubernetes.azure.com"))
+                            - message: taint "kubernetes.azure.com/scalesetpriority" must have value "spot" and effect "NoSchedule"
+                              rule: self.all(x, !(x.key == "kubernetes.azure.com/scalesetpriority" && !(x.value == "spot" && x.effect == "NoSchedule")))
+                            - message: taint "kubernetes.azure.com/mode" must have value "gateway" and effect "NoSchedule"
+                              rule: self.all(x, !(x.key == "kubernetes.azure.com/mode" && !(x.value == "gateway" && x.effect == "NoSchedule")))
+                          maxItems: 100
                         terminationGracePeriod:
                           description: |-
                             TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.

--- a/pkg/apis/v1alpha2/crd_validation_cel_test.go
+++ b/pkg/apis/v1alpha2/crd_validation_cel_test.go
@@ -742,6 +742,36 @@ var _ = Describe("CEL/Validation", func() {
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 			nodePool = oldNodePool.DeepCopy()
 		})
+		It("should not allow restricted kubernetes.azure.com requirements", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{"kubernetes.azure.com/some-random-label", "kubernetes.azure.com/agentpool", "kubernetes.azure.com/custom"} {
+				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+					{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: label, Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}}},
+				}
+				Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should allow special kubernetes.azure.com requirements", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{
+				"kubernetes.azure.com/ebpf-dataplane",
+				"kubernetes.azure.com/cluster-health-monitor-checker-synthetic",
+			} {
+				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+					{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: label, Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}}},
+				}
+				Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+				Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should not allow agentpool requirement", func() {
+			nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+				{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: "agentpool", Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}}},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
 	})
 	Context("Labels", func() {
 		It("should allow restricted domains exceptions", func() {
@@ -768,6 +798,101 @@ var _ = Describe("CEL/Validation", func() {
 				nodePool = oldNodePool.DeepCopy()
 			}
 		})
+		It("should not allow restricted kubernetes.azure.com labels", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{"kubernetes.azure.com/some-random-label", "kubernetes.azure.com/agentpool", "kubernetes.azure.com/custom"} {
+				nodePool.Spec.Template.Labels = map[string]string{
+					label: "test",
+				}
+				Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should allow special kubernetes.azure.com labels", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{
+				"kubernetes.azure.com/ebpf-dataplane",
+				"kubernetes.azure.com/cluster-health-monitor-checker-synthetic",
+			} {
+				nodePool.Spec.Template.Labels = map[string]string{
+					label: "test",
+				}
+				Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+				Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should not allow agentpool label", func() {
+			nodePool.Spec.Template.Labels = map[string]string{
+				"agentpool": "test",
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+	})
+
+	Context("Taints", func() {
+		It("should allow taints with non-kubernetes.azure.com domains", func() {
+			nodePool.Spec.Template.Spec.Taints = []corev1.Taint{
+				{Key: "example.com/custom-taint", Value: "true", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "company.io/another-taint", Value: "value", Effect: corev1.TaintEffectPreferNoSchedule},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+		})
+		It("should allow taints with exact allowed kubernetes.azure.com specifications", func() {
+			nodePool.Spec.Template.Spec.Taints = []corev1.Taint{
+				{Key: "kubernetes.azure.com/scalesetpriority", Value: "spot", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "kubernetes.azure.com/mode", Value: "gateway", Effect: corev1.TaintEffectNoSchedule},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+		})
+		DescribeTable("should reject taints with kubernetes.azure.com domain violations",
+			func(key, value string, effect corev1.TaintEffect) {
+				nodePool.Spec.Template.Spec.Taints = []corev1.Taint{
+					{Key: key, Value: value, Effect: effect},
+				}
+				Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+			},
+			Entry("disallowed custom key", "kubernetes.azure.com/custom-key", "value", corev1.TaintEffectNoSchedule),
+			Entry("subdomain key", "custom.kubernetes.azure.com/key", "value", corev1.TaintEffectNoSchedule),
+			Entry("scalesetpriority with wrong value", "kubernetes.azure.com/scalesetpriority", "regular", corev1.TaintEffectNoSchedule),
+			Entry("scalesetpriority with wrong effect", "kubernetes.azure.com/scalesetpriority", "spot", corev1.TaintEffectPreferNoSchedule),
+			Entry("mode with wrong value", "kubernetes.azure.com/mode", "system", corev1.TaintEffectNoSchedule),
+			Entry("mode with wrong effect", "kubernetes.azure.com/mode", "gateway", corev1.TaintEffectNoExecute),
+		)
+	})
+
+	Context("StartupTaints", func() {
+		It("should allow startup taints with non-kubernetes.azure.com domains", func() {
+			nodePool.Spec.Template.Spec.StartupTaints = []corev1.Taint{
+				{Key: "example.com/startup-taint", Value: "true", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "company.io/initialization", Value: "pending", Effect: corev1.TaintEffectPreferNoSchedule},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+		})
+		It("should allow the specific egressgateway startup taint", func() {
+			nodePool.Spec.Template.Spec.StartupTaints = []corev1.Taint{
+				{Key: "egressgateway.kubernetes.azure.com/cni-not-ready", Value: "true", Effect: corev1.TaintEffectNoSchedule},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+		})
+		DescribeTable("should reject startup taints with kubernetes.azure.com domain",
+			func(key, value string, effect corev1.TaintEffect) {
+				nodePool.Spec.Template.Spec.StartupTaints = []corev1.Taint{
+					{Key: key, Value: value, Effect: effect},
+				}
+				Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+			},
+			Entry("disallowed key kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/scalesetpriority", "spot", corev1.TaintEffectNoSchedule),
+			Entry("disallowed key kubernetes.azure.com/mode", "kubernetes.azure.com/mode", "gateway", corev1.TaintEffectNoSchedule),
+			Entry("custom kubernetes.azure.com key", "kubernetes.azure.com/custom-startup", "value", corev1.TaintEffectPreferNoSchedule),
+			Entry("custom subdomain key", "custom.kubernetes.azure.com/startup", "value", corev1.TaintEffectNoSchedule),
+			Entry("allowed key with wrong value", "egressgateway.kubernetes.azure.com/cni-not-ready", "false", corev1.TaintEffectNoSchedule),
+			Entry("allowed key with wrong effect", "egressgateway.kubernetes.azure.com/cni-not-ready", "true", corev1.TaintEffectPreferNoSchedule),
+		)
 	})
 
 	Context("Tags", func() {

--- a/pkg/apis/v1beta1/crd_validation_cel_test.go
+++ b/pkg/apis/v1beta1/crd_validation_cel_test.go
@@ -753,6 +753,36 @@ var _ = Describe("CEL/Validation", func() {
 				nodePool = oldNodePool.DeepCopy()
 			}
 		})
+		It("should not allow restricted kubernetes.azure.com requirements", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{"kubernetes.azure.com/some-random-label", "kubernetes.azure.com/agentpool", "kubernetes.azure.com/custom"} {
+				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+					{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: label, Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}}},
+				}
+				Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should allow special kubernetes.azure.com requirements", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{
+				"kubernetes.azure.com/ebpf-dataplane",
+				"kubernetes.azure.com/cluster-health-monitor-checker-synthetic",
+			} {
+				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+					{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: label, Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}}},
+				}
+				Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+				Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should not allow agentpool requirement", func() {
+			nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+				{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: "agentpool", Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}}},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
 	})
 	Context("Labels", func() {
 		It("should allow restricted domains exceptions", func() {
@@ -789,6 +819,101 @@ var _ = Describe("CEL/Validation", func() {
 				nodePool = oldNodePool.DeepCopy()
 			}
 		})
+		It("should not allow restricted kubernetes.azure.com labels", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{"kubernetes.azure.com/some-random-label", "kubernetes.azure.com/agentpool", "kubernetes.azure.com/custom"} {
+				nodePool.Spec.Template.Labels = map[string]string{
+					label: "test",
+				}
+				Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should allow special kubernetes.azure.com labels", func() {
+			oldNodePool := nodePool.DeepCopy()
+			for _, label := range []string{
+				"kubernetes.azure.com/ebpf-dataplane",
+				"kubernetes.azure.com/cluster-health-monitor-checker-synthetic",
+			} {
+				nodePool.Spec.Template.Labels = map[string]string{
+					label: "test",
+				}
+				Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+				Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+				nodePool = oldNodePool.DeepCopy()
+			}
+		})
+		It("should not allow agentpool label", func() {
+			nodePool.Spec.Template.Labels = map[string]string{
+				"agentpool": "test",
+			}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+	})
+
+	Context("Taints", func() {
+		It("should allow taints with non-kubernetes.azure.com domains", func() {
+			nodePool.Spec.Template.Spec.Taints = []corev1.Taint{
+				{Key: "example.com/custom-taint", Value: "true", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "company.io/another-taint", Value: "value", Effect: corev1.TaintEffectPreferNoSchedule},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+		})
+		It("should allow taints with exact allowed kubernetes.azure.com specifications", func() {
+			nodePool.Spec.Template.Spec.Taints = []corev1.Taint{
+				{Key: "kubernetes.azure.com/scalesetpriority", Value: "spot", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "kubernetes.azure.com/mode", Value: "gateway", Effect: corev1.TaintEffectNoSchedule},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+		})
+		DescribeTable("should reject taints with kubernetes.azure.com domain violations",
+			func(key, value string, effect corev1.TaintEffect) {
+				nodePool.Spec.Template.Spec.Taints = []corev1.Taint{
+					{Key: key, Value: value, Effect: effect},
+				}
+				Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+			},
+			Entry("disallowed custom key", "kubernetes.azure.com/custom-key", "value", corev1.TaintEffectNoSchedule),
+			Entry("subdomain key", "custom.kubernetes.azure.com/key", "value", corev1.TaintEffectNoSchedule),
+			Entry("scalesetpriority with wrong value", "kubernetes.azure.com/scalesetpriority", "regular", corev1.TaintEffectNoSchedule),
+			Entry("scalesetpriority with wrong effect", "kubernetes.azure.com/scalesetpriority", "spot", corev1.TaintEffectPreferNoSchedule),
+			Entry("mode with wrong value", "kubernetes.azure.com/mode", "system", corev1.TaintEffectNoSchedule),
+			Entry("mode with wrong effect", "kubernetes.azure.com/mode", "gateway", corev1.TaintEffectNoExecute),
+		)
+	})
+
+	Context("StartupTaints", func() {
+		It("should allow startup taints with non-kubernetes.azure.com domains", func() {
+			nodePool.Spec.Template.Spec.StartupTaints = []corev1.Taint{
+				{Key: "example.com/startup-taint", Value: "true", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "company.io/initialization", Value: "pending", Effect: corev1.TaintEffectPreferNoSchedule},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+		})
+		It("should allow the specific egressgateway startup taint", func() {
+			nodePool.Spec.Template.Spec.StartupTaints = []corev1.Taint{
+				{Key: "egressgateway.kubernetes.azure.com/cni-not-ready", Value: "true", Effect: corev1.TaintEffectNoSchedule},
+			}
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+		})
+		DescribeTable("should reject startup taints with kubernetes.azure.com domain",
+			func(key, value string, effect corev1.TaintEffect) {
+				nodePool.Spec.Template.Spec.StartupTaints = []corev1.Taint{
+					{Key: key, Value: value, Effect: effect},
+				}
+				Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+			},
+			Entry("disallowed key kubernetes.azure.com/scalesetpriority", "kubernetes.azure.com/scalesetpriority", "spot", corev1.TaintEffectNoSchedule),
+			Entry("disallowed key kubernetes.azure.com/mode", "kubernetes.azure.com/mode", "gateway", corev1.TaintEffectNoSchedule),
+			Entry("custom kubernetes.azure.com key", "kubernetes.azure.com/custom-startup", "value", corev1.TaintEffectPreferNoSchedule),
+			Entry("custom subdomain key", "custom.kubernetes.azure.com/startup", "value", corev1.TaintEffectNoSchedule),
+			Entry("allowed key with wrong value", "egressgateway.kubernetes.azure.com/cni-not-ready", "false", corev1.TaintEffectNoSchedule),
+			Entry("allowed key with wrong effect", "egressgateway.kubernetes.azure.com/cni-not-ready", "true", corev1.TaintEffectPreferNoSchedule),
+		)
 	})
 
 	Context("Tags", func() {

--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -41,6 +41,12 @@ var (
 		"x64":   karpv1.ArchitectureAmd64,
 		"Arm64": karpv1.ArchitectureArm64,
 	}
+	// RestrictedLabelDomains restricts entire label domains from user requirements.
+	// We don't include kubernetes.azure.com here because there are labels in that domain
+	// that we allow users to set but which are not WellKnownLabels (like
+	// kubernetes.azure.com/ebpf-dataplane). Instead we rely on CEL validation rules
+	// in the CRD to restrict the kubernetes.azure.com domain with an explicit allowlist.
+	// See hack/validation/labels.sh and hack/validation/requirements.sh.
 	RestrictedLabelDomains = []string{
 		Group,
 	}


### PR DESCRIPTION
**Description**

Syncs Karpenter CRD validation with AKS RP Machine API validation rules. This prevents late-binding 400 errors at provisioning time by giving users immediate feedback at `kubectl apply`.

**Labels:**
- Restricts `kubernetes.azure.com/*` domain with an explicit allowlist of labels users may set (mode, scalesetpriority, fips_enabled, os-sku, cluster, sku-cpu, sku-memory, ebpf-dataplane, cluster-health-monitor-checker-synthetic)
- Blocks the `agentpool` label (system-generated)

**Taints:**
- Restricts `kubernetes.azure.com/*` on `taints` to exactly `scalesetpriority=spot:NoSchedule` and `mode=gateway:NoSchedule`
- Restricts `kubernetes.azure.com/*` on `startupTaints` to exactly `egressgateway.kubernetes.azure.com/cni-not-ready=true:NoSchedule`
- Adds `maxItems=100` and `maxLength=253` for CEL cost budget

**Validation source:** AKS RP `utils_agentpool.go` (labels), `nodetaintsvalidator.go` (taints). Machine API reuses the same AgentPool validation pipeline via `ConvertMachineToAgentPool()`.

**Existing art:** Combines and supersedes prior stale PRs:
- #1444 (label restrictions by @matthchr — DONOTMERGE, waiting on notification)
- #1167 (taint restrictions by @charliedmcb — 6 months stale, author left)

Both were correct in approach but stuck. This PR unifies them, adds comprehensive tests for both v1alpha2 and v1beta1, and documents the design rationale.

**Breaking change impact:**
- Users with `kubernetes.azure.com/*` labels (other than the allowlisted ones) in NodePool spec will get CRD rejection on next update
- Users with `kubernetes.azure.com/*` taints (other than spot/gateway) will get CRD rejection on next update
- From production data analysis (Kusto queries in the design wiki): the hit count for non-standard system labels/taints is extremely low
- Existing NodePools with non-compliant values will show a warning on update but continue to function; they will be rejected only if the violating field is re-applied after removal

**How was this change tested?**

* CEL unit tests (v1alpha2: 179 passed, v1beta1: 181 passed)
* Tests cover: allowed labels/taints, blocked labels/taints, subdomain keys, wrong value/effect combinations, special exemptions (ebpf-dataplane, egressgateway), agentpool restriction

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

**Release Note**

```release-note
BREAKING CHANGE: action required
- Labels: restricted `kubernetes.azure.com` domain — only well-known labels (mode, scalesetpriority, fips_enabled, os-sku, cluster, sku-cpu, sku-memory, ebpf-dataplane, cluster-health-monitor-checker-synthetic) are allowed. The `agentpool` label is also restricted.
- Taints: restricted `kubernetes.azure.com` domain — only `kubernetes.azure.com/scalesetpriority=spot:NoSchedule` and `kubernetes.azure.com/mode=gateway:NoSchedule` are allowed on taints. On startupTaints, only `egressgateway.kubernetes.azure.com/cni-not-ready=true:NoSchedule` is allowed.
- Users with non-compliant labels or taints will need to update their NodePool specs.
```