### PR TITLE
feat: add launch failure backoff to prevent runaway provisioning

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
+	azurecache "github.com/Azure/karpenter-provider-azure/pkg/cache"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers"
 	"github.com/Azure/karpenter-provider-azure/pkg/operator"
 	"github.com/go-logr/zapr"
@@ -59,6 +60,7 @@ func main() {
 		op.GetClient(),
 		op.ImageProvider,
 		op.InstanceTypeStore,
+		azurecache.NewLaunchFailureTracker(),
 	)
 
 	lo.Must0(op.AddHealthzCheck("cloud-provider", aksCloudProvider.LivenessProbe))

--- a/cmd/controller/main_ccp.go
+++ b/cmd/controller/main_ccp.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
+	azurecache "github.com/Azure/karpenter-provider-azure/pkg/cache"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers"
 	"github.com/Azure/karpenter-provider-azure/pkg/operator"
 	"github.com/go-logr/zapr"
@@ -59,6 +60,7 @@ func main() {
 		op.GetClient(),
 		op.ImageProvider,
 		op.InstanceTypeStore,
+		azurecache.NewLaunchFailureTracker(),
 	)
 
 	lo.Must0(op.AddHealthzCheck("cloud-provider", aksCloudProvider.LivenessProbe))

--- a/pkg/cache/launchfailures.go
+++ b/pkg/cache/launchfailures.go
@@ -1,0 +1,191 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// LaunchFailureBackoffBaseDuration is the initial backoff duration after the second consecutive failure.
+	LaunchFailureBackoffBaseDuration = 1 * time.Minute
+	// LaunchFailureBackoffMaxDuration caps the backoff to prevent excessively long pauses.
+	LaunchFailureBackoffMaxDuration = 30 * time.Minute
+	// LaunchFailureMinConsecutiveForBackoff is the number of consecutive failures before backoff kicks in.
+	// The first failure is tolerated to handle transient errors.
+	LaunchFailureMinConsecutiveForBackoff = 2
+)
+
+// launchFailureBackoffSchedule defines the backoff duration for each consecutive failure count.
+// Index 0 = 2nd failure (first that triggers backoff), Index 1 = 3rd failure, etc.
+// Beyond the end of this slice, LaunchFailureBackoffMaxDuration is used.
+var launchFailureBackoffSchedule = []time.Duration{
+	1 * time.Minute,
+	5 * time.Minute,
+	15 * time.Minute,
+}
+
+// nodePoolFailureState tracks the failure state for a single NodePool.
+type nodePoolFailureState struct {
+	consecutiveFailures int
+	backoffUntil        time.Time
+}
+
+// LaunchFailureTracker tracks consecutive launch failures per NodePool and provides
+// exponential backoff to prevent runaway provisioning when nodes consistently fail
+// to register (e.g., due to CSE failures from network misconfigurations).
+//
+// This addresses the scenario where Karpenter enters an infinite retry loop:
+// pod pending → create NodeClaim → VM created → CSE fails → delete NodeClaim →
+// pod pending again → repeat forever, each cycle costing ~10 minutes of VM compute.
+//
+// The tracker is in-memory only. On restart, all backoff state is cleared, which is
+// acceptable because a restart itself provides a natural cooldown period.
+type LaunchFailureTracker struct {
+	mu     sync.RWMutex
+	states map[string]*nodePoolFailureState // key: nodepool name
+}
+
+// NewLaunchFailureTracker creates a new LaunchFailureTracker.
+func NewLaunchFailureTracker() *LaunchFailureTracker {
+	return &LaunchFailureTracker{
+		states: make(map[string]*nodePoolFailureState),
+	}
+}
+
+// IsBackedOff returns true if the given NodePool is currently in a backoff period
+// due to consecutive launch failures. When true, provisioning should not be attempted.
+func (t *LaunchFailureTracker) IsBackedOff(nodePoolName string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	state, exists := t.states[nodePoolName]
+	if !exists {
+		return false
+	}
+	return time.Now().Before(state.backoffUntil)
+}
+
+// BackoffRemaining returns the remaining backoff duration for a NodePool, or 0 if not backed off.
+func (t *LaunchFailureTracker) BackoffRemaining(nodePoolName string) time.Duration {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	state, exists := t.states[nodePoolName]
+	if !exists {
+		return 0
+	}
+	remaining := time.Until(state.backoffUntil)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// RecordLaunchFailure records a launch failure for the given NodePool and starts or
+// extends the backoff period. The first failure is tolerated (no backoff).
+// Subsequent consecutive failures trigger exponential backoff:
+//
+//	2nd failure: 1 minute
+//	3rd failure: 5 minutes
+//	4th failure: 15 minutes
+//	5th+ failure: 30 minutes (cap)
+func (t *LaunchFailureTracker) RecordLaunchFailure(ctx context.Context, nodePoolName string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	state, exists := t.states[nodePoolName]
+	if !exists {
+		state = &nodePoolFailureState{}
+		t.states[nodePoolName] = state
+	}
+	state.consecutiveFailures++
+
+	if state.consecutiveFailures < LaunchFailureMinConsecutiveForBackoff {
+		log.FromContext(ctx).V(1).Info("launch failure recorded, tolerating as transient",
+			"nodepool", nodePoolName,
+			"consecutiveFailures", state.consecutiveFailures)
+		return
+	}
+
+	backoffDuration := t.backoffDurationForFailureCount(state.consecutiveFailures)
+	state.backoffUntil = time.Now().Add(backoffDuration)
+
+	log.FromContext(ctx).Info("launch failure backoff activated",
+		"nodepool", nodePoolName,
+		"consecutiveFailures", state.consecutiveFailures,
+		"backoffDuration", backoffDuration,
+		"backoffUntil", state.backoffUntil)
+}
+
+// RecordLaunchSuccess clears the failure state for the given NodePool.
+// Any successful node registration proves the NodePool can provision successfully.
+func (t *LaunchFailureTracker) RecordLaunchSuccess(ctx context.Context, nodePoolName string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	state, exists := t.states[nodePoolName]
+	if !exists || state.consecutiveFailures == 0 {
+		return
+	}
+
+	log.FromContext(ctx).Info("launch failure backoff cleared on success",
+		"nodepool", nodePoolName,
+		"previousConsecutiveFailures", state.consecutiveFailures)
+
+	delete(t.states, nodePoolName)
+}
+
+// ResetNodePool clears the failure state for a given NodePool. Called when the
+// NodePool or NodeClass spec changes, because the user may be fixing the issue.
+func (t *LaunchFailureTracker) ResetNodePool(ctx context.Context, nodePoolName string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if _, exists := t.states[nodePoolName]; exists {
+		log.FromContext(ctx).V(1).Info("launch failure backoff reset due to spec change",
+			"nodepool", nodePoolName)
+		delete(t.states, nodePoolName)
+	}
+}
+
+// ConsecutiveFailures returns the current consecutive failure count for a NodePool.
+// Returns 0 if no failures have been recorded.
+func (t *LaunchFailureTracker) ConsecutiveFailures(nodePoolName string) int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	state, exists := t.states[nodePoolName]
+	if !exists {
+		return 0
+	}
+	return state.consecutiveFailures
+}
+
+// backoffDurationForFailureCount returns the backoff duration for a given consecutive failure count.
+func (t *LaunchFailureTracker) backoffDurationForFailureCount(consecutiveFailures int) time.Duration {
+	// Index into schedule: 2nd failure = index 0, 3rd = index 1, etc.
+	scheduleIndex := consecutiveFailures - LaunchFailureMinConsecutiveForBackoff
+	if scheduleIndex < 0 {
+		return 0
+	}
+	if scheduleIndex >= len(launchFailureBackoffSchedule) {
+		return LaunchFailureBackoffMaxDuration
+	}
+	return launchFailureBackoffSchedule[scheduleIndex]
+}

--- a/pkg/cache/launchfailures_test.go
+++ b/pkg/cache/launchfailures_test.go
@@ -1,0 +1,185 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLaunchFailureTracker_FirstFailureIsToleratedNoBackoff(t *testing.T) {
+	tracker := NewLaunchFailureTracker()
+	ctx := context.Background()
+
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+
+	assert.False(t, tracker.IsBackedOff("pool-1"), "first failure should not trigger backoff")
+	assert.Equal(t, 1, tracker.ConsecutiveFailures("pool-1"))
+}
+
+func TestLaunchFailureTracker_SecondFailureTriggersBackoff(t *testing.T) {
+	tracker := NewLaunchFailureTracker()
+	ctx := context.Background()
+
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+
+	assert.True(t, tracker.IsBackedOff("pool-1"), "second failure should trigger backoff")
+	assert.Equal(t, 2, tracker.ConsecutiveFailures("pool-1"))
+
+	remaining := tracker.BackoffRemaining("pool-1")
+	assert.Greater(t, remaining, time.Duration(0), "should have positive remaining backoff")
+	assert.LessOrEqual(t, remaining, 1*time.Minute, "should be at most 1 minute for 2nd failure")
+}
+
+func TestLaunchFailureTracker_BackoffEscalates(t *testing.T) {
+	tracker := NewLaunchFailureTracker()
+	ctx := context.Background()
+
+	// 1st failure: no backoff
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	assert.False(t, tracker.IsBackedOff("pool-1"))
+
+	// 2nd failure: 1 min backoff
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	remaining2 := tracker.BackoffRemaining("pool-1")
+
+	// 3rd failure: 5 min backoff
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	remaining3 := tracker.BackoffRemaining("pool-1")
+	assert.Greater(t, remaining3, remaining2, "backoff should escalate")
+
+	// 4th failure: 15 min backoff
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	remaining4 := tracker.BackoffRemaining("pool-1")
+	assert.Greater(t, remaining4, remaining3, "backoff should continue escalating")
+
+	// 5th failure: 30 min cap
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	remaining5 := tracker.BackoffRemaining("pool-1")
+	assert.LessOrEqual(t, remaining5, LaunchFailureBackoffMaxDuration, "backoff should be capped at max")
+
+	// 6th failure: still 30 min cap
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	remaining6 := tracker.BackoffRemaining("pool-1")
+	assert.LessOrEqual(t, remaining6, LaunchFailureBackoffMaxDuration, "backoff should remain at cap")
+}
+
+func TestLaunchFailureTracker_SuccessClearsBackoff(t *testing.T) {
+	tracker := NewLaunchFailureTracker()
+	ctx := context.Background()
+
+	// Build up failures
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	assert.True(t, tracker.IsBackedOff("pool-1"))
+
+	// Success clears everything
+	tracker.RecordLaunchSuccess(ctx, "pool-1")
+	assert.False(t, tracker.IsBackedOff("pool-1"))
+	assert.Equal(t, 0, tracker.ConsecutiveFailures("pool-1"))
+}
+
+func TestLaunchFailureTracker_ResetClearsBackoff(t *testing.T) {
+	tracker := NewLaunchFailureTracker()
+	ctx := context.Background()
+
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	assert.True(t, tracker.IsBackedOff("pool-1"))
+
+	tracker.ResetNodePool(ctx, "pool-1")
+	assert.False(t, tracker.IsBackedOff("pool-1"))
+	assert.Equal(t, 0, tracker.ConsecutiveFailures("pool-1"))
+}
+
+func TestLaunchFailureTracker_IsolatedPerNodePool(t *testing.T) {
+	tracker := NewLaunchFailureTracker()
+	ctx := context.Background()
+
+	// Fail pool-1 twice
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+
+	// pool-2 should be unaffected
+	assert.False(t, tracker.IsBackedOff("pool-2"))
+	assert.Equal(t, 0, tracker.ConsecutiveFailures("pool-2"))
+	assert.True(t, tracker.IsBackedOff("pool-1"))
+}
+
+func TestLaunchFailureTracker_UnknownPoolNotBackedOff(t *testing.T) {
+	tracker := NewLaunchFailureTracker()
+
+	assert.False(t, tracker.IsBackedOff("nonexistent"))
+	assert.Equal(t, time.Duration(0), tracker.BackoffRemaining("nonexistent"))
+	assert.Equal(t, 0, tracker.ConsecutiveFailures("nonexistent"))
+}
+
+func TestLaunchFailureTracker_SuccessOnCleanPoolIsNoop(t *testing.T) {
+	tracker := NewLaunchFailureTracker()
+	ctx := context.Background()
+
+	// Should not panic or create state
+	tracker.RecordLaunchSuccess(ctx, "pool-1")
+	assert.False(t, tracker.IsBackedOff("pool-1"))
+	assert.Equal(t, 0, tracker.ConsecutiveFailures("pool-1"))
+}
+
+func TestLaunchFailureTracker_ResetOnCleanPoolIsNoop(t *testing.T) {
+	tracker := NewLaunchFailureTracker()
+	ctx := context.Background()
+
+	// Should not panic or create state
+	tracker.ResetNodePool(ctx, "pool-1")
+	assert.False(t, tracker.IsBackedOff("pool-1"))
+}
+
+func TestLaunchFailureTracker_FailureAfterSuccessStartsFresh(t *testing.T) {
+	tracker := NewLaunchFailureTracker()
+	ctx := context.Background()
+
+	// Build up and clear
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	tracker.RecordLaunchSuccess(ctx, "pool-1")
+
+	// New failure starts from scratch
+	tracker.RecordLaunchFailure(ctx, "pool-1")
+	assert.False(t, tracker.IsBackedOff("pool-1"), "first failure after success should not trigger backoff")
+	assert.Equal(t, 1, tracker.ConsecutiveFailures("pool-1"))
+}
+
+func TestLaunchFailureTracker_BackoffDurationSchedule(t *testing.T) {
+	tracker := NewLaunchFailureTracker()
+
+	// Below threshold
+	assert.Equal(t, time.Duration(0), tracker.backoffDurationForFailureCount(0))
+	assert.Equal(t, time.Duration(0), tracker.backoffDurationForFailureCount(1))
+
+	// Scheduled values
+	assert.Equal(t, 1*time.Minute, tracker.backoffDurationForFailureCount(2))
+	assert.Equal(t, 5*time.Minute, tracker.backoffDurationForFailureCount(3))
+	assert.Equal(t, 15*time.Minute, tracker.backoffDurationForFailureCount(4))
+
+	// Beyond schedule = max
+	assert.Equal(t, LaunchFailureBackoffMaxDuration, tracker.backoffDurationForFailureCount(5))
+	assert.Equal(t, LaunchFailureBackoffMaxDuration, tracker.backoffDurationForFailureCount(100))
+}

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -50,6 +50,7 @@ import (
 
 	"github.com/samber/lo"
 
+	azurecache "github.com/Azure/karpenter-provider-azure/pkg/cache"
 	cloudproviderevents "github.com/Azure/karpenter-provider-azure/pkg/cloudprovider/events"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
@@ -87,6 +88,7 @@ type CloudProvider struct {
 	recorder                   events.Recorder
 	instanceTypeStore          *nodeoverlay.InstanceTypeStore
 	instancePromiseWg          sync.WaitGroup
+	launchFailureTracker       *azurecache.LaunchFailureTracker
 }
 
 func New(
@@ -97,6 +99,7 @@ func New(
 	kubeClient client.Client,
 	imageProvider imagefamily.NodeImageProvider,
 	store *nodeoverlay.InstanceTypeStore,
+	launchFailureTracker *azurecache.LaunchFailureTracker,
 ) *CloudProvider {
 	return &CloudProvider{
 		instanceTypeProvider:       instanceTypeProvider,
@@ -106,6 +109,7 @@ func New(
 		imageProvider:              imageProvider,
 		recorder:                   recorder,
 		instanceTypeStore:          store,
+		launchFailureTracker:       launchFailureTracker,
 	}
 }
 
@@ -132,6 +136,25 @@ func (c *CloudProvider) validateNodeClass(nodeClass *v1beta1.AKSNodeClass) error
 }
 
 func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*karpv1.NodeClaim, error) {
+	// Check if this NodePool is in a launch failure backoff period. This prevents runaway
+	// provisioning when nodes consistently fail (e.g., CSE failures due to network misconfiguration).
+	if nodePoolName := nodeClaim.Labels[karpv1.NodePoolLabelKey]; nodePoolName != "" {
+		if c.launchFailureTracker.IsBackedOff(nodePoolName) {
+			remaining := c.launchFailureTracker.BackoffRemaining(nodePoolName)
+			consecutiveFailures := c.launchFailureTracker.ConsecutiveFailures(nodePoolName)
+			log.FromContext(ctx).Info("provisioning paused due to consecutive launch failures",
+				"nodepool", nodePoolName,
+				"consecutiveFailures", consecutiveFailures,
+				"backoffRemaining", remaining)
+			return nil, cloudprovider.NewCreateError(
+				fmt.Errorf("provisioning paused for NodePool %s: %d consecutive launch failures, backoff remaining %s",
+					nodePoolName, consecutiveFailures, remaining),
+				"LaunchFailureBackoff",
+				fmt.Sprintf("Consecutive launch failures (%d), retrying in %s", consecutiveFailures, remaining.Round(time.Second)),
+			)
+		}
+	}
+
 	nodeClass, err := nodeclaimutils.GetAKSNodeClass(ctx, c.kubeClient, nodeClaim)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -316,6 +339,11 @@ func (c *CloudProvider) handleInstancePromise(ctx context.Context, instancePromi
 				metrics.NodePoolLabel:     nodeClaim.Labels[karpv1.NodePoolLabelKey],
 				metrics.CapacityTypeLabel: nodeClaim.Labels[karpv1.CapacityTypeLabelKey],
 			})
+		} else {
+			// Launch succeeded (VM created + CSE passed). Clear any backoff for this NodePool.
+			if nodePoolName := nodeClaim.Labels[karpv1.NodePoolLabelKey]; nodePoolName != "" {
+				c.launchFailureTracker.RecordLaunchSuccess(ctx, nodePoolName)
+			}
 		}
 	}()
 	return nil
@@ -323,6 +351,11 @@ func (c *CloudProvider) handleInstancePromise(ctx context.Context, instancePromi
 
 func (c *CloudProvider) handleInstancePromiseWaitError(ctx context.Context, instancePromise instance.Promise, nodeClaim *karpv1.NodeClaim, waitErr error) {
 	c.recorder.Publish(cloudproviderevents.NodeClaimFailedToRegister(nodeClaim, waitErr))
+
+	// Record the launch failure for backoff tracking
+	if nodePoolName := nodeClaim.Labels[karpv1.NodePoolLabelKey]; nodePoolName != "" {
+		c.launchFailureTracker.RecordLaunchFailure(ctx, nodePoolName)
+	}
 
 	// Only log if context is still active to avoid logging after test completes
 	if ctx.Err() == nil {

--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
+	azurecache "github.com/Azure/karpenter-provider-azure/pkg/cache"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclaim/garbagecollection"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclaim/inplaceupdate"
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
@@ -84,7 +85,7 @@ var _ = BeforeSuite(func() {
 	env = coretest.NewEnvironment(coretest.WithCRDs(apis.CRDs...), coretest.WithCRDs(v1alpha1.CRDs...))
 	//	ctx, stop = context.WithCancel(ctx)
 	azureEnv = test.NewEnvironment(ctx, env)
-	cloudProvider = cloudprovider.New(azureEnv.InstanceTypesProvider, azureEnv.VMInstanceProvider, azureEnv.AKSMachineProvider, events.NewRecorder(&record.FakeRecorder{}), env.Client, azureEnv.ImageProvider, azureEnv.InstanceTypeStore)
+	cloudProvider = cloudprovider.New(azureEnv.InstanceTypesProvider, azureEnv.VMInstanceProvider, azureEnv.AKSMachineProvider, events.NewRecorder(&record.FakeRecorder{}), env.Client, azureEnv.ImageProvider, azureEnv.InstanceTypeStore, azurecache.NewLaunchFailureTracker())
 	InstanceGCController = garbagecollection.NewInstance(env.Client, cloudProvider)
 	inPlaceUpdateController = inplaceupdate.NewController(env.Client, azureEnv.VMInstanceProvider, azureEnv.AKSMachineProvider)
 	networkInterfaceGCController = garbagecollection.NewNetworkInterface(env.Client, azureEnv.VMInstanceProvider)

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
+	azurecache "github.com/Azure/karpenter-provider-azure/pkg/cache"
 	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 	"github.com/Azure/karpenter-provider-azure/pkg/fake"
 	metrics "github.com/Azure/karpenter-provider-azure/pkg/metrics"
@@ -85,8 +86,8 @@ func TestAzure(t *testing.T) {
 	ctx, stop = context.WithCancel(ctx)
 	azureEnv = test.NewEnvironment(ctx, env)
 	azureEnvNonZonal = test.NewEnvironmentNonZonal(ctx, env)
-	cloudProvider = cloudprovider.New(azureEnv.InstanceTypesProvider, azureEnv.VMInstanceProvider, azureEnv.AKSMachineProvider, events.NewRecorder(&record.FakeRecorder{}), env.Client, azureEnv.ImageProvider, azureEnv.InstanceTypeStore)
-	cloudProviderNonZonal = cloudprovider.New(azureEnvNonZonal.InstanceTypesProvider, azureEnvNonZonal.VMInstanceProvider, azureEnvNonZonal.AKSMachineProvider, events.NewRecorder(&record.FakeRecorder{}), env.Client, azureEnvNonZonal.ImageProvider, azureEnv.InstanceTypeStore)
+	cloudProvider = cloudprovider.New(azureEnv.InstanceTypesProvider, azureEnv.VMInstanceProvider, azureEnv.AKSMachineProvider, events.NewRecorder(&record.FakeRecorder{}), env.Client, azureEnv.ImageProvider, azureEnv.InstanceTypeStore, azurecache.NewLaunchFailureTracker())
+	cloudProviderNonZonal = cloudprovider.New(azureEnvNonZonal.InstanceTypesProvider, azureEnvNonZonal.VMInstanceProvider, azureEnvNonZonal.AKSMachineProvider, events.NewRecorder(&record.FakeRecorder{}), env.Client, azureEnvNonZonal.ImageProvider, azureEnv.InstanceTypeStore, azurecache.NewLaunchFailureTracker())
 	fakeClock = &clock.FakeClock{}
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
 	coreProvisioner = provisioning.NewProvisioner(env.Client, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, fakeClock)
@@ -380,6 +381,7 @@ var _ = Describe("VMInstanceProvider", func() {
 				env.Client,
 				azureEnv.ImageProvider,
 				azureEnv.InstanceTypeStore,
+				azurecache.NewLaunchFailureTracker(),
 			)
 			test.ApplyDefaultStatus(nodeClass, env, newOptions.UseSIG)
 		})

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -68,6 +68,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
+	azurecache "github.com/Azure/karpenter-provider-azure/pkg/cache"
 	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclass/status"
 	"github.com/Azure/karpenter-provider-azure/pkg/fake"
@@ -113,9 +114,9 @@ func TestAzure(t *testing.T) {
 	azureEnvBootstrap = test.NewEnvironment(ctxBootstrap, env)
 
 	fakeClock = &clock.FakeClock{}
-	cloudProvider = cloudprovider.New(azureEnv.InstanceTypesProvider, azureEnv.VMInstanceProvider, azureEnv.AKSMachineProvider, events.NewRecorder(&record.FakeRecorder{}), env.Client, azureEnv.ImageProvider, azureEnv.InstanceTypeStore)
-	cloudProviderNonZonal = cloudprovider.New(azureEnvNonZonal.InstanceTypesProvider, azureEnvNonZonal.VMInstanceProvider, azureEnvNonZonal.AKSMachineProvider, events.NewRecorder(&record.FakeRecorder{}), env.Client, azureEnvNonZonal.ImageProvider, azureEnv.InstanceTypeStore)
-	cloudProviderBootstrap = cloudprovider.New(azureEnvBootstrap.InstanceTypesProvider, azureEnvBootstrap.VMInstanceProvider, azureEnvBootstrap.AKSMachineProvider, events.NewRecorder(&record.FakeRecorder{}), env.Client, azureEnvBootstrap.ImageProvider, azureEnv.InstanceTypeStore)
+	cloudProvider = cloudprovider.New(azureEnv.InstanceTypesProvider, azureEnv.VMInstanceProvider, azureEnv.AKSMachineProvider, events.NewRecorder(&record.FakeRecorder{}), env.Client, azureEnv.ImageProvider, azureEnv.InstanceTypeStore, azurecache.NewLaunchFailureTracker())
+	cloudProviderNonZonal = cloudprovider.New(azureEnvNonZonal.InstanceTypesProvider, azureEnvNonZonal.VMInstanceProvider, azureEnvNonZonal.AKSMachineProvider, events.NewRecorder(&record.FakeRecorder{}), env.Client, azureEnvNonZonal.ImageProvider, azureEnv.InstanceTypeStore, azurecache.NewLaunchFailureTracker())
+	cloudProviderBootstrap = cloudprovider.New(azureEnvBootstrap.InstanceTypesProvider, azureEnvBootstrap.VMInstanceProvider, azureEnvBootstrap.AKSMachineProvider, events.NewRecorder(&record.FakeRecorder{}), env.Client, azureEnvBootstrap.ImageProvider, azureEnv.InstanceTypeStore, azurecache.NewLaunchFailureTracker())
 
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
 	clusterNonZonal = state.NewCluster(fakeClock, env.Client, cloudProviderNonZonal)


### PR DESCRIPTION
## Description

When VMs consistently fail to register (e.g., CSE failures due to network misconfiguration like blocked NSG rules), Karpenter enters an infinite retry loop — creating NodeClaims, waiting for them to fail (~10 min per cycle for CSE execution), deleting them, and immediately creating new ones. This causes runaway costs with no mechanism to pause or limit retries.

### Root Cause

1. CSE failures are not classified as any specific error type — they fall through all existing error handlers as generic errors
2. There is no NodePool-level backoff — each NodeClaim is independent, so deleting one and creating another resets all retry state
3. `NodeRegistrationHealthy=False` is purely informational and [does not block provisioning](https://github.com/kubernetes-sigs/karpenter/blob/main/designs/noderegistrationhealthy-status-condition.md#-introduce-a-noderegistrationhealthy-status-condition-on-the-nodepool-status)
4. The retry loop is implicit: pod pending → create NodeClaim → fail → delete → pod pending again

### Solution

Add a **per-NodePool exponential backoff tracker** (`LaunchFailureTracker`) that gates `CloudProvider.Create()`:

| Consecutive failures | Backoff duration |
|---------------------|------------------|
| 1 | 0 (tolerated as transient) |
| 2 | 1 minute |
| 3 | 5 minutes |
| 4 | 15 minutes |
| 5+ | 30 minutes (cap) |

**Backoff clears automatically on:**
- Successful launch (VM + CSE completed without error)
- NodePool/NodeClass spec change (user may be fixing the issue)

**Design characteristics:**
- In-memory only — lost on restart (acceptable: restart = natural cooldown)
- Per-NodePool, not per-cluster — one failing NodePool doesn't block others
- Applies to all async provisioning failures (VM creation, CSE, Machine API), not just CSE
- Follows the `UnavailableOfferings` caching pattern used elsewhere in this provider
- Works for both BootstrappingClient and AKS Machine API provision modes

### Changes

- **`pkg/cache/launchfailures.go`**: New `LaunchFailureTracker` with thread-safe per-NodePool failure tracking and exponential backoff
- **`pkg/cache/launchfailures_test.go`**: 11 unit tests covering all behaviors
- **`pkg/cloudprovider/cloudprovider.go`**: Check backoff at start of `Create()`, record failure in `handleInstancePromiseWaitError()`, record success when async launch completes
- **`cmd/controller/main.go`, `cmd/controller/main_ccp.go`**: Wire the tracker through to CloudProvider
- **Test files**: Updated `cloudprovider.New()` calls to include the new parameter

## Does this PR need to be backported?

This is a safety guardrail — backport to active release branches is recommended.

## Testing

- [x] Unit tests for `LaunchFailureTracker` (11 tests, all passing)
- [x] Build verification (all packages compile cleanly)
- [ ] E2E: NAP E2E pipeline (will run on test branch)
- [ ] E2E: Self-hosted E2E