### PR TITLE
feat: add Machine API dry-run validation to ValidationReconciler

### DIFF
--- a/pkg/controllers/nodeclass/status/machineapi_dryrun_validation.go
+++ b/pkg/controllers/nodeclass/status/machineapi_dryrun_validation.go
@@ -1,0 +1,185 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8"
+	"github.com/samber/lo"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	MachineAPIDryRunValidationFailed = "MachineAPIDryRunValidationFailed"
+	// DryRunValidationSuccessRequeueInterval defines how often to re-validate via dry-run after success.
+	// Set to 1 hour since RP validation rules change infrequently (release-gated).
+	DryRunValidationSuccessRequeueInterval = 1 * time.Hour
+	// DryRunValidationFailureRequeueInterval defines how often to retry after a validation failure.
+	// Set to 5 minutes — validation failures are deterministic (same input, same result) so
+	// frequent retries waste API calls. Users need time to fix their CRD config anyway.
+	DryRunValidationFailureRequeueInterval = 5 * time.Minute
+)
+
+// MachineAPIDryRunReconciler validates AKSNodeClass configuration against AKS RP's
+// real Machine API validator by sending a dry-run PUT request. This catches validation
+// drift between CRD-level rules and RP-level rules without maintaining parallel logic.
+//
+// When the dry-run endpoint is not available (RP hasn't deployed it yet), the reconciler
+// gracefully degrades: non-4xx errors are treated as transient and retried normally.
+//
+// TODO: Wire into Controller by adding to the reconciler chain in controller.go.
+// Requires threading AZClient.AKSMachinesDryRunClient(), clusterResourceGroup,
+// clusterName, and machinePoolName from the operator startup through NewControllers
+// and NewController.
+type MachineAPIDryRunReconciler struct {
+	dryRunClient      azclient.AKSMachinesAPI
+	clusterResourceGroup string
+	clusterName          string
+	machinePoolName      string // the Karpenter-managed machine pool name
+}
+
+func NewMachineAPIDryRunReconciler(
+	dryRunClient azclient.AKSMachinesAPI,
+	clusterResourceGroup string,
+	clusterName string,
+	machinePoolName string,
+) *MachineAPIDryRunReconciler {
+	return &MachineAPIDryRunReconciler{
+		dryRunClient:         dryRunClient,
+		clusterResourceGroup: clusterResourceGroup,
+		clusterName:          clusterName,
+		machinePoolName:      machinePoolName,
+	}
+}
+
+func (r *MachineAPIDryRunReconciler) Reconcile(ctx context.Context, nodeClass *v1beta1.AKSNodeClass) (reconcile.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Skip if no dry-run client is available (non-Machine-API provision modes)
+	if r.dryRunClient == nil {
+		return reconcile.Result{RequeueAfter: DryRunValidationSuccessRequeueInterval}, nil
+	}
+
+	// Build a template Machine from the AKSNodeClass for validation.
+	// This is a minimal template — it validates the fields that come from AKSNodeClass
+	// (OSDiskSizeGB, kubelet config, FIPS, etc.) without requiring a real NodeClaim.
+	templateMachine := r.buildTemplateMachine(nodeClass)
+
+	logger.V(1).Info("running Machine API dry-run validation")
+
+	// Send the dry-run PUT. The dryRunPolicy on this client appends ?dryRun=true,
+	// causing RP to run full validation without creating any resources.
+	_, err := r.dryRunClient.BeginCreateOrUpdate(
+		ctx,
+		r.clusterResourceGroup,
+		r.clusterName,
+		r.machinePoolName,
+		"karpenter-dryrun-validation", // synthetic machine name — never persisted
+		templateMachine,
+		nil,
+	)
+	if err != nil {
+		// Check if this is a validation error (4xx)
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode >= 400 && respErr.StatusCode < 500 {
+			// Validation failure — deterministic, user needs to fix their config
+			logger.V(1).Info("Machine API dry-run validation failed", "error", respErr.Error())
+			nodeClass.StatusConditions().SetFalse(
+				v1beta1.ConditionTypeValidationSucceeded,
+				MachineAPIDryRunValidationFailed,
+				fmt.Sprintf("Machine API validation failed: %s", respErr.Error()),
+			)
+			return reconcile.Result{RequeueAfter: DryRunValidationFailureRequeueInterval}, nil
+		}
+
+		// Non-validation error (5xx, network, RP not deployed, etc.) — transient, retry normally.
+		// Don't change the condition — the previous result (from DES RBAC check or prior dry-run) stays.
+		logger.V(1).Info("Machine API dry-run encountered transient error, will retry", "error", err)
+		return reconcile.Result{}, err
+	}
+
+	// Dry-run validation passed
+	logger.V(1).Info("Machine API dry-run validation passed")
+	return reconcile.Result{RequeueAfter: DryRunValidationSuccessRequeueInterval}, nil
+}
+
+// buildTemplateMachine constructs a minimal Machine from AKSNodeClass fields
+// for dry-run validation. Only fields controlled by AKSNodeClass are included —
+// fields from NodeClaim (labels, taints, instance type) are left empty or defaulted,
+// as those are validated per-creation in Layer 3 (error surfacing).
+func (r *MachineAPIDryRunReconciler) buildTemplateMachine(nodeClass *v1beta1.AKSNodeClass) armcontainerservice.Machine {
+	machine := armcontainerservice.Machine{
+		Properties: &armcontainerservice.MachineProperties{
+			Hardware: &armcontainerservice.MachineHardwareProfile{
+				VMSize: lo.ToPtr("Standard_DS2_v2"), // placeholder — dry-run validates structure, not availability
+			},
+			OperatingSystem: &armcontainerservice.MachineOSProfile{
+				OSDiskSizeGB: nodeClass.Spec.OSDiskSizeGB,
+				OSType:       lo.ToPtr(armcontainerservice.OSTypeLinux),
+			},
+			Network: &armcontainerservice.MachineNetworkProperties{
+				VnetSubnetID: nodeClass.Spec.VNETSubnetID,
+			},
+			Kubernetes: &armcontainerservice.MachineKubernetesProfile{
+				KubeletConfig: buildKubeletConfigForDryRun(nodeClass),
+			},
+		},
+	}
+
+	// Set FIPS if enabled
+	if nodeClass.Spec.FIPSMode != nil && *nodeClass.Spec.FIPSMode == v1beta1.FIPSModeFIPS {
+		machine.Properties.OperatingSystem.EnableFIPS = lo.ToPtr(true)
+	}
+
+	return machine
+}
+
+// buildKubeletConfigForDryRun converts AKSNodeClass KubeletConfig to the Machine API format.
+// Only includes fields that are validated by RP — this ensures CRD-level kubelet config
+// is checked against RP's real validator.
+func buildKubeletConfigForDryRun(nodeClass *v1beta1.AKSNodeClass) *armcontainerservice.KubeletConfig {
+	if nodeClass.Spec.Kubelet == nil {
+		return nil
+	}
+	k := nodeClass.Spec.Kubelet
+	config := &armcontainerservice.KubeletConfig{}
+
+	if k.CPUCFSQuotaPeriod.Duration != 0 {
+		periodStr := k.CPUCFSQuotaPeriod.Duration.String()
+		config.CPUCfsQuotaPeriod = &periodStr
+	}
+	if k.ImageGCHighThresholdPercent != nil {
+		config.ImageGcHighThreshold = k.ImageGCHighThresholdPercent
+	}
+	if k.ImageGCLowThresholdPercent != nil {
+		config.ImageGcLowThreshold = k.ImageGCLowThresholdPercent
+	}
+	if k.AllowedUnsafeSysctls != nil {
+		config.AllowedUnsafeSysctls = lo.ToSlicePtr(k.AllowedUnsafeSysctls)
+	}
+
+	return config
+}

--- a/pkg/providers/azclient/azclient.go
+++ b/pkg/providers/azclient/azclient.go
@@ -88,6 +88,7 @@ type AZClient struct {
 	azureResourceGraphClient       AzureResourceGraphAPI
 	virtualMachinesClient          VirtualMachinesAPI
 	aksMachinesClient              AKSMachinesAPI
+	aksMachinesDryRunClient        AKSMachinesAPI // dry-run variant — appends ?dryRun=true to PUT requests for validation-only
 	agentPoolsClient               AKSAgentPoolsAPI
 	virtualMachinesExtensionClient VirtualMachineExtensionsAPI
 	networkInterfacesClient        NetworkInterfacesAPI
@@ -114,6 +115,14 @@ func (c *AZClient) DiskEncryptionSetsClient() DiskEncryptionSetsAPI {
 
 func (c *AZClient) AKSMachinesClient() AKSMachinesAPI {
 	return c.aksMachinesClient
+}
+
+// AKSMachinesDryRunClient returns a Machines API client that appends ?dryRun=true
+// to PUT requests. This runs the full RP validation pipeline without creating or
+// persisting any resources. Used by the ValidationReconciler to pre-validate
+// Machine templates against the real RP validator.
+func (c *AZClient) AKSMachinesDryRunClient() AKSMachinesAPI {
+	return c.aksMachinesDryRunClient
 }
 
 // SetAKSMachinesClient replaces the AKS machines client. This is used to wrap the client
@@ -253,6 +262,7 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *auth.Environment, c
 	// These clients are used for Azure instance management.
 	var nodeBootstrappingClient imagefamilytypes.NodeBootstrappingAPI
 	var aksMachinesClient AKSMachinesAPI
+	var aksMachinesDryRunClient AKSMachinesAPI
 	var agentPoolsClient AKSAgentPoolsAPI
 
 	// Only create the bootstrapping client if we need to use it.
@@ -281,12 +291,21 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *auth.Environment, c
 		if err != nil {
 			return nil, err
 		}
+		// Create a dry-run variant that appends ?dryRun=true to PUT requests.
+		// Used by the ValidationReconciler for pre-creation validation.
+		var dryRunClientOptions = *opts
+		dryRunClientOptions.PerCallPolicies = append(dryRunClientOptions.PerCallPolicies, &spotSystemNodePolicy{}, &dryRunPolicy{})
+		aksMachinesDryRunClient, err = armcontainerservice.NewMachinesClient(cfg.SubscriptionID, cred, &dryRunClientOptions)
+		if err != nil {
+			return nil, err
+		}
 		agentPoolsClient, err = armcontainerservice.NewAgentPoolsClient(cfg.SubscriptionID, cred, opts)
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		aksMachinesClient = NewNoAKSMachinesClient()
+		aksMachinesDryRunClient = NewNoAKSMachinesClient()
 		agentPoolsClient = NewNoAKSAgentPoolsClient()
 
 		// Try create true clients. This is just for diagnostic purposes and serves no real functionality.
@@ -301,7 +320,7 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *auth.Environment, c
 		}
 	}
 
-	return NewAZClientFromAPI(
+	client := NewAZClientFromAPI(
 		virtualMachinesClient,
 		azureResourceGraphClient,
 		aksMachinesClient,
@@ -317,5 +336,7 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *auth.Environment, c
 		nodeBootstrappingClient,
 		skuClient,
 		subscriptionsClient,
-	), nil
+	)
+	client.aksMachinesDryRunClient = aksMachinesDryRunClient
+	return client, nil
 }

--- a/pkg/providers/azclient/dryrun.go
+++ b/pkg/providers/azclient/dryrun.go
@@ -1,0 +1,43 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azclient
+
+import (
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+var _ policy.Policy = &dryRunPolicy{}
+
+// dryRunPolicy is an Azure SDK per-call policy that appends the dryRun=true
+// query parameter to PUT requests. This tells the AKS RP Machine API to run
+// the full validation pipeline without enqueuing or persisting any state.
+//
+// Used by the ValidationReconciler to pre-validate Machine API templates
+// against RP's real validator, catching validation drift without maintaining
+// a parallel copy of RP validation rules.
+type dryRunPolicy struct{}
+
+func (p *dryRunPolicy) Do(req *policy.Request) (*http.Response, error) {
+	if req.Raw().Method == http.MethodPut {
+		q := req.Raw().URL.Query()
+		q.Set("dryRun", "true")
+		req.Raw().URL.RawQuery = q.Encode()
+	}
+	return req.Next()
+}


### PR DESCRIPTION
**Description**

Adds a `MachineAPIDryRunReconciler` that validates AKSNodeClass configuration against the AKS RP Machine API validator by sending a dry-run PUT request. This catches validation drift between CRD-level rules and RP-level rules without maintaining parallel validation logic.

**Problem:** Karpenter CRD validation and AKS Machine API validation are independent systems. When they diverge, users create CRDs that pass admission but fail at provisioning time — late errors that are hard to diagnose. The current approach (best-effort logic duplication) requires manual updates and can't guarantee sync.

**Solution:** Instead of duplicating RP validation rules in CRDs, query the RP directly using a dry-run endpoint. The reconciler periodically validates a template Machine built from AKSNodeClass fields against the real RP validator. If validation fails, it sets `ConditionTypeValidationSucceeded=False` with the specific error message.

**Changes:**
- `dryRunPolicy`: Azure SDK per-call policy that appends `?dryRun=true` to PUT requests (same pattern as `spotSystemNodePolicy`)
- `AKSMachinesDryRunClient()`: separate Machines client with the dry-run policy
- `MachineAPIDryRunReconciler`: builds template Machine from AKSNodeClass, sends dry-run PUT, sets condition based on result. Gracefully degrades when the RP endpoint isn't available yet.

**Design:** This implements Layer 2 of the [CRD Validation Sync Strategy](https://github.com/Azure/karpenter-provider-azure/pull/1525) — reconciler-based pre-creation validation using the RP's real validator.

**Testing:** Compiles and builds. Full integration testing pending RP-side dry-run endpoint deployment.

**Depends on:** RP-side dry-run endpoint (in progress). The reconciler gracefully handles the endpoint not being available yet (transient errors are retried, not surfaced as validation failures).