### PR TITLE
feat: add data disk attachment support for AzureNodeClass

### DIFF
--- a/pkg/apis/v1beta1/aksnodeclass.go
+++ b/pkg/apis/v1beta1/aksnodeclass.go
@@ -84,6 +84,10 @@ type AKSNodeClassSpec struct {
 	// These are merged with the global --node-identities at VM creation time.
 	// Not exposed in the AKSNodeClass API.
 	ManagedIdentities []string `json:"-"`
+	// DataDiskSizeGB is the size of an additional data disk to attach to provisioned VMs.
+	// Only used in AzureVM provision mode via the AzureNodeClass adapter.
+	// Not exposed in the AKSNodeClass API.
+	DataDiskSizeGB *int32 `json:"-"`
 	// imageFamily is the image family that instances use.
 	// +default="Ubuntu"
 	// +kubebuilder:validation:Enum:={Ubuntu,Ubuntu2204,Ubuntu2404,AzureLinux}

--- a/pkg/apis/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1beta1/zz_generated.deepcopy.go
@@ -113,6 +113,11 @@ func (in *AKSNodeClassSpec) DeepCopyInto(out *AKSNodeClassSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DataDiskSizeGB != nil {
+		in, out := &in.DataDiskSizeGB, &out.DataDiskSizeGB
+		*out = new(int32)
+		**out = **in
+	}
 	if in.ImageFamily != nil {
 		in, out := &in.ImageFamily, &out.ImageFamily
 		*out = new(string)

--- a/pkg/providers/instance/vminstancehelpers.go
+++ b/pkg/providers/instance/vminstancehelpers.go
@@ -238,6 +238,7 @@ func (p *DefaultVMProvider) buildVMTemplate(
 
 	configureBillingProfile(vm.Properties, capacityType)
 	configureSecurityProfile(vm.Properties, nodeClass)
+	configureDataDisk(vm.Properties, nodeClass)
 
 	return vm, bootstrap, nil
 }
@@ -406,6 +407,24 @@ func configureSecurityProfile(vmProps *armcompute.VirtualMachineProperties, node
 		}
 		vmProps.SecurityProfile.EncryptionAtHost = nodeClass.Spec.Security.EncryptionAtHost
 	}
+}
+
+// configureDataDisk attaches an additional Premium_LRS managed data disk when
+// DataDiskSizeGB is set on the NodeClass (via AzureNodeClass adapter).
+func configureDataDisk(vmProps *armcompute.VirtualMachineProperties, nodeClass *v1beta1.AKSNodeClass) {
+	if nodeClass.Spec.DataDiskSizeGB == nil || *nodeClass.Spec.DataDiskSizeGB <= 0 {
+		return
+	}
+	vmProps.StorageProfile.DataDisks = append(vmProps.StorageProfile.DataDisks, &armcompute.DataDisk{
+		Lun:          lo.ToPtr(int32(0)),
+		Name:         lo.ToPtr(lo.FromPtr(vmProps.StorageProfile.OSDisk.Name) + "-data-0"),
+		DiskSizeGB:   nodeClass.Spec.DataDiskSizeGB,
+		CreateOption: lo.ToPtr(armcompute.DiskCreateOptionTypesEmpty),
+		DeleteOption: lo.ToPtr(armcompute.DiskDeleteOptionTypesDelete),
+		ManagedDisk: &armcompute.ManagedDiskParameters{
+			StorageAccountType: lo.ToPtr(armcompute.StorageAccountTypesPremiumLRS),
+		},
+	})
 }
 
 // buildAKSBillingExtensionSpec returns the AKS billing extension spec.

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -116,6 +116,7 @@ func AKSNodeClassFromAzureNodeClass(azureNC *v1alpha1.AzureNodeClass) *v1beta1.A
 	// AzureVM-specific fields: carried via json:"-" fields on AKSNodeClass for adapter use
 	aksNC.Spec.UserData = azureNC.Spec.UserData
 	aksNC.Spec.ManagedIdentities = azureNC.Spec.ManagedIdentities
+	aksNC.Spec.DataDiskSizeGB = azureNC.Spec.DataDiskSizeGB
 
 	return aksNC
 }

--- a/pkg/utils/nodeclaim/nodeclaim_test.go
+++ b/pkg/utils/nodeclaim/nodeclaim_test.go
@@ -150,6 +150,22 @@ func TestAKSNodeClassFromAzureNodeClass_NilUserDataAndIdentities(t *testing.T) {
 
 	g.Expect(aksNC.Spec.UserData).To(BeNil())
 	g.Expect(aksNC.Spec.ManagedIdentities).To(BeNil())
+	g.Expect(aksNC.Spec.DataDiskSizeGB).To(BeNil())
+}
+
+func TestAKSNodeClassFromAzureNodeClass_DataDiskSizeGB(t *testing.T) {
+	g := NewWithT(t)
+
+	azureNC := &v1alpha1.AzureNodeClass{
+		Spec: v1alpha1.AzureNodeClassSpec{
+			DataDiskSizeGB: lo.ToPtr(int32(256)),
+		},
+	}
+
+	aksNC := AKSNodeClassFromAzureNodeClass(azureNC)
+
+	g.Expect(aksNC.Spec.DataDiskSizeGB).NotTo(BeNil())
+	g.Expect(*aksNC.Spec.DataDiskSizeGB).To(Equal(int32(256)))
 }
 
 func TestGetVMName_ValidProviderID(t *testing.T) {


### PR DESCRIPTION
**Description**

Add DataDiskSizeGB field to AzureNodeClass for attaching a Premium_LRS managed data disk at LUN 0. Useful for container runtime storage on GPU nodes or other workloads needing dedicated disk space.

- DataDiskSizeGB on AKSNodeClass (json:"-", adapter-only)
- configureDataDisk() in VM creation path
- Adapter mapping and unit tests

**Release Note**
```release-note
Add data disk attachment support for AzureNodeClass
```