### PR TITLE
feat: add data disk attachment support for AzureNodeClass

### DIFF
--- a/pkg/apis/v1alpha1/azurenodeclass.go
+++ b/pkg/apis/v1alpha1/azurenodeclass.go
@@ -90,6 +90,13 @@ type AzureNodeClassSpec struct {
 	// tags to be applied on Azure resources like instances.
 	// +optional
 	Tags map[string]string `json:"tags,omitempty" hash:"ignore"`
+	// dataDiskSizeGB attaches an additional Premium_LRS managed data disk for container
+	// storage (e.g., containerd data root). The disk is attached at LUN 0 and
+	// auto-deleted when the VM is terminated.
+	// +kubebuilder:validation:Minimum=10
+	// +kubebuilder:validation:Maximum=4096
+	// +optional
+	DataDiskSizeGB *int32 `json:"dataDiskSizeGB,omitempty"`
 	// security contains security-related configuration for provisioned VMs.
 	// +optional
 	Security *AzureNodeClassSecurity `json:"security,omitempty"`
@@ -186,4 +193,9 @@ func (in *AzureNodeClass) GetImageFamily() *string {
 
 func (in *AzureNodeClass) GetKind() string {
 	return "AzureNodeClass"
+}
+
+// GetDataDiskSizeGB returns the data disk size from the spec.
+func (in *AzureNodeClass) GetDataDiskSizeGB() *int32 {
+	return in.Spec.DataDiskSizeGB
 }

--- a/pkg/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1alpha1/zz_generated.deepcopy.go
@@ -124,6 +124,11 @@ func (in *AzureNodeClassSpec) DeepCopyInto(out *AzureNodeClassSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.DataDiskSizeGB != nil {
+		in, out := &in.DataDiskSizeGB, &out.DataDiskSizeGB
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Security != nil {
 		in, out := &in.Security, &out.Security
 		*out = new(AzureNodeClassSecurity)

--- a/pkg/providers/instance/vminstance.go
+++ b/pkg/providers/instance/vminstance.go
@@ -547,6 +547,7 @@ func (p *DefaultVMProvider) beginLaunchInstanceAzure(
 	}
 	configureBillingProfile(vm.Properties, capacityType)
 	configureSecurityProfile(vm.Properties, nodeClass)
+	configureDataDisk(vm.Properties, resourceName, nodeClass.GetDataDiskSizeGB())
 
 	// Shared
 	result, err := p.createVirtualMachine(ctx, resourceName, vm, imageID, instanceType, zone, capacityType, nodeClaim.Labels[karpv1.NodePoolLabelKey])

--- a/pkg/providers/instance/vminstancehelpers.go
+++ b/pkg/providers/instance/vminstancehelpers.go
@@ -451,6 +451,24 @@ func configureSecurityProfile(vmProps *armcompute.VirtualMachineProperties, node
 	}
 }
 
+// configureDataDisk attaches an additional Premium_LRS managed data disk if dataDiskSizeGB is set.
+// The disk is attached at LUN 0, named {vmName}-data-0, and auto-deleted when the VM is terminated.
+func configureDataDisk(vmProps *armcompute.VirtualMachineProperties, vmName string, dataDiskSizeGB *int32) {
+	if dataDiskSizeGB == nil || *dataDiskSizeGB <= 0 {
+		return
+	}
+	vmProps.StorageProfile.DataDisks = append(vmProps.StorageProfile.DataDisks, &armcompute.DataDisk{
+		Lun:          lo.ToPtr(int32(0)),
+		Name:         lo.ToPtr(vmName + "-data-0"),
+		DiskSizeGB:   dataDiskSizeGB,
+		CreateOption: lo.ToPtr(armcompute.DiskCreateOptionTypesEmpty),
+		DeleteOption: lo.ToPtr(armcompute.DiskDeleteOptionTypesDelete),
+		ManagedDisk: &armcompute.ManagedDiskParameters{
+			StorageAccountType: lo.ToPtr(armcompute.StorageAccountTypesPremiumLRS),
+		},
+	})
+}
+
 // buildAKSBillingExtensionSpec returns the AKS billing extension spec.
 func buildAKSBillingExtensionSpec(location string, tags map[string]*string) *armcompute.VirtualMachineExtension {
 	const (


### PR DESCRIPTION
## Summary

Adds optional `dataDiskSizeGB` field to AzureNodeClass. When set, a Premium_LRS managed data disk is attached at LUN 0, auto-deleted when the VM terminates. Suitable for container runtime storage (e.g., containerd data root on a separate disk).

- Field: `dataDiskSizeGB` (int32, range 10-4096)
- Disk config: Premium_LRS, empty create, LUN 0, auto-delete
- Helper: `configureDataDisk()` in vminstancehelpers.go

Stacks on PR #1579.

## Test plan

- [ ] `go build && go vet` pass
- [ ] Unit tests for configureDataDisk (with size, nil, zero)
- [ ] E2E: create VM with data disk, verify disk attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)