### PR TITLE
fix: default artifact streaming to false on AzureLinux

### DIFF
--- a/pkg/apis/v1beta1/aksnodeclass.go
+++ b/pkg/apis/v1beta1/aksnodeclass.go
@@ -43,15 +43,19 @@ type ArtifactStreaming struct {
 	Enabled *bool `json:"enabled,omitempty"`
 }
 
-// IsEnabled returns whether artifact streaming should be enabled for the given architecture.
+// IsEnabled returns whether artifact streaming should be enabled for the given architecture and image family.
 // ARM64 does not support artifact streaming and always returns false.
-// For AMD64, returns the explicit value if set, otherwise defaults to true.
-func (a *ArtifactStreaming) IsEnabled(arch string) bool {
+// For AMD64, returns the explicit value if set; otherwise defaults to true for Ubuntu and false for AzureLinux.
+func (a *ArtifactStreaming) IsEnabled(arch string, imageFamily string) bool {
 	if arch == karpv1.ArchitectureArm64 {
 		return false
 	}
 	if a != nil && a.Enabled != nil {
 		return *a.Enabled
+	}
+	// Default: disabled for AzureLinux, enabled for everything else
+	if imageFamily == AzureLinuxImageFamily {
+		return false
 	}
 	return true
 }
@@ -689,11 +693,11 @@ func (in *AKSNodeClass) GetEncryptionAtHost() bool {
 }
 
 // IsArtifactStreamingEnabled returns whether artifact streaming should be enabled for this node class
-// based on the architecture. ARM64 nodes do not support artifact streaming and will always return false,
-// even if the user explicitly enables it in the spec.
-// For AMD64, if not explicitly specified (nil), defaults to true.
+// based on the architecture and image family. ARM64 nodes do not support artifact streaming and will
+// always return false. For AMD64, defaults to true for Ubuntu and false for AzureLinux, unless
+// explicitly set in the spec.
 func (in *AKSNodeClass) IsArtifactStreamingEnabled(arch string) bool {
-	return in.Spec.ArtifactStreaming.IsEnabled(arch)
+	return in.Spec.ArtifactStreaming.IsEnabled(arch, lo.FromPtr(in.Spec.ImageFamily))
 }
 
 // IsArtifactStreamingExplicitlyEnabled returns true only when the user has explicitly

--- a/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
@@ -107,8 +107,8 @@ func (p *ProvisionClientBootstrap) ConstructProvisionValues(ctx context.Context)
 
 	// Artifact streaming is configurable through the AKSNodeClass spec
 	// ARM64 does not support artifact streaming and is always disabled
-	// If not specified, defaults to enabled for AMD64
-	enableArtifactStreaming := p.ArtifactStreaming.IsEnabled(p.Arch)
+	// If not specified, defaults to enabled for Ubuntu, disabled for AzureLinux
+	enableArtifactStreaming := p.ArtifactStreaming.IsEnabled(p.Arch, osSKUToImageFamily(p.OSSKU))
 
 	// unspecified FIPSMode is effectively no FIPS for now
 	enableFIPS := lo.FromPtr(p.FIPSMode) == v1beta1.FIPSModeFIPS
@@ -210,4 +210,14 @@ func (p *ProvisionClientBootstrap) ConstructProvisionValues(ctx context.Context)
 		ProvisionProfile:      provisionProfile,
 		ProvisionHelperValues: provisionHelperValues,
 	}, nil
+}
+
+// osSKUToImageFamily maps OSSKU to the corresponding image family constant
+func osSKUToImageFamily(ossku string) string {
+	switch ossku {
+	case ImageFamilyOSSKUAzureLinux2, ImageFamilyOSSKUAzureLinux3:
+		return v1beta1.AzureLinuxImageFamily
+	default:
+		return v1beta1.UbuntuImageFamily
+	}
 }

--- a/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap_test.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap_test.go
@@ -337,8 +337,8 @@ func TestConstructProvisionValues(t *testing.T) {
 				// Check system mode
 				g.Expect(*profile.Mode).To(Equal(models.AgentPoolModeSystem))
 
-				// Check artifact streaming defaults to enabled (nil ArtifactStreaming)
-				g.Expect(*profile.ArtifactStreamingProfile.Enabled).To(BeTrue())
+				// Check artifact streaming defaults to disabled for AzureLinux (nil ArtifactStreaming)
+				g.Expect(*profile.ArtifactStreamingProfile.Enabled).To(BeFalse())
 
 				// Check FIPS enablement (unset/nil FIPSMode is effectively false for now)
 				g.Expect(*profile.EnableFIPS).To(BeFalse())
@@ -378,8 +378,8 @@ func TestConstructProvisionValues(t *testing.T) {
 				g.Expect(*profile.Distro).To(Equal("aks-azurelinux-v3-gen2"))
 				g.Expect(*profile.Mode).To(Equal(models.AgentPoolModeUser))
 
-				// Check artifact streaming defaults to enabled (nil ArtifactStreaming)
-				g.Expect(*profile.ArtifactStreamingProfile.Enabled).To(BeTrue())
+				// Check artifact streaming defaults to disabled for AzureLinux (nil ArtifactStreaming)
+				g.Expect(*profile.ArtifactStreamingProfile.Enabled).To(BeFalse())
 
 				// Check FIPS enablement (unset/nil FIPSMode is effectively false for now)
 				g.Expect(*profile.EnableFIPS).To(BeFalse())
@@ -729,20 +729,20 @@ func TestArtifactStreamingEnablement(t *testing.T) {
 			expectedArtifactStreamingEnabled: true,
 		},
 		{
-			name:                             "AMD64 AzureLinux2 - Artifact streaming enabled (default)",
+			name:                             "AMD64 AzureLinux2 - Artifact streaming disabled (default)",
 			arch:                             karpv1.ArchitectureAmd64,
 			ossku:                            customscriptsbootstrap.ImageFamilyOSSKUAzureLinux2,
 			kubernetesVersion:                "1.31.0",
 			imageDistro:                      "aks-azurelinux-v2-gen2",
-			expectedArtifactStreamingEnabled: true,
+			expectedArtifactStreamingEnabled: false,
 		},
 		{
-			name:                             "AMD64 AzureLinux3 - Artifact streaming enabled (default)",
+			name:                             "AMD64 AzureLinux3 - Artifact streaming disabled (default)",
 			arch:                             karpv1.ArchitectureAmd64,
 			ossku:                            customscriptsbootstrap.ImageFamilyOSSKUAzureLinux3,
 			kubernetesVersion:                "1.32.0",
 			imageDistro:                      "aks-azurelinux-v3-gen2",
-			expectedArtifactStreamingEnabled: true,
+			expectedArtifactStreamingEnabled: false,
 		},
 		{
 			name:                             "ARM64 Ubuntu2204 - Artifact streaming disabled",


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Default artifact streaming to false on AzureLinux - until fully supported

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
