### PR TITLE
fix: set ArtifactStreamingProfile on AKS Machine API path

### DIFF
--- a/pkg/cloudprovider/suite_aksmachineapi_features_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_features_test.go
@@ -948,8 +948,7 @@ var _ = Describe("CloudProvider", func() {
 				Expect(lo.FromPtr(aksMachine.Properties.Kubernetes.ArtifactStreamingProfile.Enabled)).To(BeTrue())
 			})
 
-			It("should set ArtifactStreamingProfile when not specified (defaults to enabled for AMD64 Ubuntu)", func() {
-				// ArtifactStreaming not set — defaults to enabled for AMD64
+			It("should not set ArtifactStreamingProfile when not specified (defaults to disabled)", func() {
 				nodeClass.Spec.ArtifactStreaming = nil
 				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 				ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
@@ -963,8 +962,7 @@ var _ = Describe("CloudProvider", func() {
 				aksMachine := createInput.AKSMachine
 
 				Expect(aksMachine.Properties.Kubernetes).ToNot(BeNil())
-				Expect(aksMachine.Properties.Kubernetes.ArtifactStreamingProfile).ToNot(BeNil())
-				Expect(lo.FromPtr(aksMachine.Properties.Kubernetes.ArtifactStreamingProfile.Enabled)).To(BeTrue())
+				Expect(aksMachine.Properties.Kubernetes.ArtifactStreamingProfile).To(BeNil())
 			})
 
 			It("should not set ArtifactStreamingProfile when explicitly disabled", func() {

--- a/pkg/cloudprovider/suite_aksmachineapi_features_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_features_test.go
@@ -926,5 +926,75 @@ var _ = Describe("CloudProvider", func() {
 				Expect(aksMachine.Properties.OperatingSystem.LinuxProfile).To(BeNil())
 			})
 		})
+
+		Context("Create - ArtifactStreaming", func() {
+			It("should set ArtifactStreamingProfile when explicitly enabled", func() {
+				nodeClass.Spec.ArtifactStreaming = &v1beta1.ArtifactStreaming{
+					Enabled: lo.ToPtr(true),
+				}
+				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+				ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
+
+				pod := coretest.UnschedulablePod(coretest.PodOptions{})
+				ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
+				ExpectScheduled(ctx, env.Client, pod)
+
+				Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+				createInput := azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Pop()
+				aksMachine := createInput.AKSMachine
+
+				Expect(aksMachine.Properties.Kubernetes).ToNot(BeNil())
+				Expect(aksMachine.Properties.Kubernetes.ArtifactStreamingProfile).ToNot(BeNil())
+				Expect(lo.FromPtr(aksMachine.Properties.Kubernetes.ArtifactStreamingProfile.Enabled)).To(BeTrue())
+			})
+
+			It("should set ArtifactStreamingProfile when not specified (defaults to enabled for AMD64 Ubuntu)", func() {
+				// ArtifactStreaming not set — defaults to enabled for AMD64
+				nodeClass.Spec.ArtifactStreaming = nil
+				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+				ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
+
+				pod := coretest.UnschedulablePod(coretest.PodOptions{})
+				ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
+				ExpectScheduled(ctx, env.Client, pod)
+
+				Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+				createInput := azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Pop()
+				aksMachine := createInput.AKSMachine
+
+				Expect(aksMachine.Properties.Kubernetes).ToNot(BeNil())
+				Expect(aksMachine.Properties.Kubernetes.ArtifactStreamingProfile).ToNot(BeNil())
+				Expect(lo.FromPtr(aksMachine.Properties.Kubernetes.ArtifactStreamingProfile.Enabled)).To(BeTrue())
+			})
+
+			It("should not set ArtifactStreamingProfile when explicitly disabled", func() {
+				nodeClass.Spec.ArtifactStreaming = &v1beta1.ArtifactStreaming{
+					Enabled: lo.ToPtr(false),
+				}
+				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+				ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
+
+				pod := coretest.UnschedulablePod(coretest.PodOptions{})
+				ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
+				ExpectScheduled(ctx, env.Client, pod)
+
+				Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+				createInput := azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Pop()
+				aksMachine := createInput.AKSMachine
+
+				Expect(aksMachine.Properties.Kubernetes).ToNot(BeNil())
+				Expect(aksMachine.Properties.Kubernetes.ArtifactStreamingProfile).To(BeNil())
+			})
+
+			It("should not set ArtifactStreamingProfile for ARM64 instance types even when enabled", func() {
+				nodeClass.Spec.ArtifactStreaming = &v1beta1.ArtifactStreaming{
+					Enabled: lo.ToPtr(true),
+				}
+				// ARM64 does not support artifact streaming; IsArtifactStreamingEnabled returns false for arm64.
+				// Verify through the NodeClass API directly since the test environment may not have ARM64 instance types.
+				Expect(nodeClass.IsArtifactStreamingEnabled("arm64")).To(BeFalse())
+				Expect(nodeClass.IsArtifactStreamingEnabled("amd64")).To(BeTrue())
+			})
+		})
 	})
 })

--- a/pkg/providers/instance/aksmachineinstancehelpers.go
+++ b/pkg/providers/instance/aksmachineinstancehelpers.go
@@ -142,7 +142,7 @@ func (p *DefaultAKSMachineProvider) buildAKSMachineTemplate(ctx context.Context,
 				NodeTaints:               nodeTaints,
 				MaxPods:                  nodeClass.Spec.MaxPods, // AKS machine API defaults it per network plugins if nil.
 				// WorkloadRuntime:          nil,
-				// ArtifactStreamingProfile: nil,
+				ArtifactStreamingProfile: configureArtifactStreamingProfile(nodeClass, instanceType),
 			},
 
 			Mode: modePtr,
@@ -165,6 +165,16 @@ func configureGPUProfile(instanceType *corecloudprovider.InstanceType) *armconta
 		return &armcontainerservice.GPUProfile{
 			Driver: lo.ToPtr(armcontainerservice.GPUDriverInstall),
 			// DriverType: nil,
+		}
+	}
+	return nil
+}
+
+func configureArtifactStreamingProfile(nodeClass *v1beta1.AKSNodeClass, instanceType *corecloudprovider.InstanceType) *armcontainerservice.AgentPoolArtifactStreamingProfile {
+	arch := instanceType.Requirements.Get(v1.LabelArchStable).Any()
+	if nodeClass.IsArtifactStreamingEnabled(arch) {
+		return &armcontainerservice.AgentPoolArtifactStreamingProfile{
+			Enabled: lo.ToPtr(true),
 		}
 	}
 	return nil

--- a/pkg/providers/instance/aksmachineinstancehelpers.go
+++ b/pkg/providers/instance/aksmachineinstancehelpers.go
@@ -171,7 +171,7 @@ func configureGPUProfile(instanceType *corecloudprovider.InstanceType) *armconta
 }
 
 func configureArtifactStreamingProfile(nodeClass *v1beta1.AKSNodeClass, instanceType *corecloudprovider.InstanceType) *armcontainerservice.AgentPoolArtifactStreamingProfile {
-	arch := instanceType.Requirements.Get(v1.LabelArchStable).Any()
+	arch := instanceType.Requirements.Get(v1.LabelArchStable).Values()[0]
 	if nodeClass.IsArtifactStreamingEnabled(arch) {
 		return &armcontainerservice.AgentPoolArtifactStreamingProfile{
 			Enabled: lo.ToPtr(true),


### PR DESCRIPTION
Fixes # <!-- issue number -->

**Description**

The artifact streaming feature (#1397) added support for the `bootstrappingclient` provision mode via labels and bootstrap scripts, but did not update the AKS Machine API (`aksmachineapi`) path. 

**How was this change tested?**

* Unit tests (4 new tests in `suite_aksmachineapi_features_test.go`)
* Integration E2E suite (NAP)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

**Release Note**

```release-note
```