### PR TITLE
fix: don't create empty-zone offerings for zone-restricted SKUs

### DIFF
--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -204,6 +204,21 @@ func (p *DefaultProvider) Get(ctx context.Context, instanceType string) (*skewer
 	return nil, fmt.Errorf("instance type %s not found", instanceType)
 }
 
+// hasRawZonesInRegion returns true if the SKU has zones defined in locationInfo for the given region,
+// regardless of subscription restrictions. This distinguishes zone-restricted SKUs (zones exist but
+// blocked by NotAvailableForSubscription) from truly non-zonal SKUs (no zones defined at all).
+func hasRawZonesInRegion(sku *skewer.SKU, region string) bool {
+	if sku.LocationInfo == nil {
+		return false
+	}
+	for _, li := range *sku.LocationInfo {
+		if li.Location != nil && strings.EqualFold(*li.Location, region) {
+			return li.Zones != nil && len(*li.Zones) > 0
+		}
+	}
+	return false
+}
+
 // instanceTypeZones generates the set of all supported zones for a given SKU
 // The strings have to match Zone labels that will be placed on Node
 func (p *DefaultProvider) instanceTypeZones(sku *skewer.SKU) sets.Set[string] {
@@ -217,7 +232,15 @@ func (p *DefaultProvider) instanceTypeZones(sku *skewer.SKU) sets.Set[string] {
 			return utils.MakeAKSLabelZoneFromARMZone(p.region, zone)
 		})...)
 	}
-	return sets.New("") // empty string means non-zonal offering
+	// If the SKU has zones defined in this region but they're all restricted for this subscription
+	// (NotAvailableForSubscription), return an empty set so no offerings are created.
+	// The sets.New("") fallback was intended for truly non-zonal regions (e.g. westcentralus),
+	// not for zone-restricted SKUs in zonal regions — those cannot be provisioned and should
+	// not appear as available offerings.
+	if hasRawZonesInRegion(sku, p.region) {
+		return sets.New[string]()
+	}
+	return sets.New("") // truly non-zonal region: no zones defined at all
 }
 
 // TODO: review; switch to controller-driven updates

--- a/pkg/providers/instancetype/instancetypes_test.go
+++ b/pkg/providers/instancetype/instancetypes_test.go
@@ -1,0 +1,87 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancetype
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute" //nolint:staticcheck
+	"github.com/Azure/skewer"
+)
+
+func TestInstanceTypeZones(t *testing.T) {
+	p := &DefaultProvider{region: "westus2"}
+
+	t.Run("zone-restricted SKU returns empty set", func(t *testing.T) {
+		// SKU supports zones 1/2/3 but subscription is blocked from all of them via
+		// NotAvailableForSubscription. Before the fix, this returned sets.New(""),
+		// injecting "" as a valid topology domain and breaking TopologySpreadConstraints.
+		zones := []string{"1", "2", "3"}
+		sku := (*skewer.SKU)(&compute.ResourceSku{
+			LocationInfo: &[]compute.ResourceSkuLocationInfo{{
+				Location: toStringPtr("westus2"),
+				Zones:    &zones,
+			}},
+			Restrictions: &[]compute.ResourceSkuRestrictions{{
+				Type:       compute.Zone,
+				ReasonCode: compute.NotAvailableForSubscription,
+				Values:     &[]string{"westus2"},
+				RestrictionInfo: &compute.ResourceSkuRestrictionInfo{
+					Zones: &zones,
+				},
+			}},
+		})
+		result := p.instanceTypeZones(sku)
+		if result.Len() != 0 {
+			t.Errorf("expected empty zone set for zone-restricted SKU, got %v", result)
+		}
+	})
+
+	t.Run("truly non-zonal SKU returns set with empty string", func(t *testing.T) {
+		// SKU has no zones defined in this region at all — preserve existing behavior
+		// so non-zonal regions like westcentralus continue to work.
+		zones := []string{}
+		sku := (*skewer.SKU)(&compute.ResourceSku{
+			LocationInfo: &[]compute.ResourceSkuLocationInfo{{
+				Location: toStringPtr("westus2"),
+				Zones:    &zones,
+			}},
+		})
+		result := p.instanceTypeZones(sku)
+		if !result.Has("") {
+			t.Errorf(`expected zone="" for truly non-zonal SKU, got %v`, result)
+		}
+	})
+
+	t.Run("zonal SKU returns correct AKS zone labels", func(t *testing.T) {
+		zones := []string{"1", "2", "3"}
+		sku := (*skewer.SKU)(&compute.ResourceSku{
+			LocationInfo: &[]compute.ResourceSkuLocationInfo{{
+				Location: toStringPtr("westus2"),
+				Zones:    &zones,
+			}},
+		})
+		result := p.instanceTypeZones(sku)
+		for _, expected := range []string{"westus2-1", "westus2-2", "westus2-3"} {
+			if !result.Has(expected) {
+				t.Errorf("expected zone %q in result, got %v", expected, result)
+			}
+		}
+	})
+}
+
+func toStringPtr(s string) *string { return &s }


### PR DESCRIPTION
## Problem

Fixes #1384

When using `TopologySpreadConstraints` with `whenUnsatisfiable: DoNotSchedule`, Karpenter refuses to provision new nodes even when valid zones are available.

The root cause is that some VM SKUs have `NotAvailableForSubscription` zone restrictions covering all zones in a region. `skewer` correctly strips those blocked zones, leaving an empty zone set. `instanceTypeZones()` then falls through to `sets.New("")` — a fallback originally intended for truly non-zonal regions — causing these SKUs to appear as available with `zone=""`.

Karpenter core treats `""` as a valid topology domain, so instead of seeing zone counts `[2, 1, 1]` across 3 real zones, the scheduler sees `[0, 2, 1, 1]` across 4 domains. With `maxSkew: 1`, this makes the constraint unsatisfiable even though valid zones exist.

See https://github.com/kubernetes-sigs/karpenter/pull/2864 for an attempt to fix this in the upstream karpenter, this PR is an attempt to fix this here in the azure provider by not offering these instances in the first place.

## Fix

Add `hasRawZonesInRegion()` to check `locationInfo` directly (before restriction filtering). If a SKU has zones defined in the region but none are available after restrictions are applied, return an empty set instead of `sets.New("")`. This causes the SKU to produce no offerings and be dropped from the instance type list. The `sets.New("")` path for truly non-zonal regions is preserved.

## Verification

In affected subscriptions, SKUs like `Standard_L48s_v3` report zone support in `locationInfo` but carry `NotAvailableForSubscription` restrictions covering all zones. After the fix, instance type count in westus2 drops from 507 → 496, `zone=""` offerings drop to 0, and TSC scheduling with `whenUnsatisfiable: DoNotSchedule` works correctly.

<details>
<summary>Inspecting a zone-restricted SKU with <code>az vm list-skus</code></summary>

```bash
az vm list-skus \
  --location westus2 \
  --resource-type virtualMachines \
  --query "[?name=='Standard_L48s_v3'].{name:name,locationInfo:locationInfo,restrictions:restrictions}" \
  --output json
```

```json
{
  "locationInfo": [{ "zones": ["1", "2", "3"] }],
  "restrictions": [{
    "reasonCode": "NotAvailableForSubscription",
    "type": "Zone",
    "restrictionInfo": { "zones": ["1", "2", "3"] }
  }]
}
```

</details>
