### PR TITLE
chore: Update version of go-licenses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,9 @@ vulncheck: ## Verify code vulnerabilities
 	@trivy filesystem --ignore-unfixed --scanners vuln --exit-code 1 go.mod
 
 licenses: download ## Verifies dependency licenses
-	! go-licenses csv ./... | grep -v -e 'MIT' -e 'Apache-2.0' -e 'BSD-3-Clause' -e 'BSD-2-Clause' -e 'ISC' -e 'MPL-2.0'
+	LICENSEFILE=$$(mktemp /tmp/licenses-XXXXXX.csv) && \
+	go-licenses csv ./... > $$LICENSEFILE && \
+	! grep -v -e 'MIT' -e 'Apache-2.0' -e 'BSD-3-Clause' -e 'BSD-2-Clause' -e 'ISC' -e 'MPL-2.0' $$LICENSEFILE
 
 codegen: codegen-pricing codegen-locations codegen-skugen codegen-allazureskus ## Auto generate files based on Azure API responses
 

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -63,7 +63,7 @@ crosscompilers() {
 }
 
 tools() {
-    go-install go-licenses github.com/google/go-licenses@v1.6.0
+    go-install go-licenses github.com/google/go-licenses/v2@3e084b0caf710f7bfead967567539214f598c0a2 // v2.0.1
     go-install ko github.com/google/ko@v0.17.1
     go-install yq github.com/mikefarah/yq/v4@v4.45.1
     go-install helm-docs github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2


### PR DESCRIPTION
**Description**

As a follow-up to `karpenter` [PR#2952](https://github.com/kubernetes-sigs/karpenter/pull/2952), making a similar change here to maintain cross-project consistency.

Note that we didn't have the same error situation. Upstream was using `go tool` to download and run `go-licenses` in one go, which was silently failing due to issues with Go 1.24. Here, we preinstall `go-licenses` using `go install` and that seems to work.

**How was this change tested?**

CLI invocation.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note
NONE
```
