### PR TITLE
chore: remove outdated comment about NIC tags not being supported

### DIFF
--- a/pkg/providers/instance/aksmachineinstancehelpers.go
+++ b/pkg/providers/instance/aksmachineinstancehelpers.go
@@ -103,7 +103,6 @@ func (p *DefaultAKSMachineProvider) buildAKSMachineTemplate(ctx context.Context,
 	priority := configurePriority(capacityType)
 
 	// Tags (to be put on AKS machine and all affiliated resources)
-	// Note: as of the time of writing, AKS machine API does not support tags on NICs. This could be fixed server-side.
 	//
 	// BATCH: Tags is a per-machine field (varies per NodeClaim). If you change this,
 	// see batch_field_registry.go — ClearPerMachineFields must cover any new per-machine


### PR DESCRIPTION
(AI-generated)

## Summary
- Remove outdated comment in `aksmachineinstancehelpers.go` stating that AKS Machine API does not support tags on NICs
- AKS Machine API now supports NIC tags, making this caveat obsolete

## Test plan
- [ ] No functional change — comment removal only

🤖 Generated with [Claude Code](https://claude.com/claude-code)