### PR TITLE
chore: update supported Kubernetes versions

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
       matrix:
-        k8sVersion: ["1.28.x", "1.29.x", "1.30.x", "1.31.x", "1.32.x", "1.33.x", "1.34.x", "1.35.x"]
+        k8sVersion: ["1.30.x", "1.31.x", "1.32.x", "1.33.x", "1.34.x", "1.35.x", "1.36.x"]
     env:
       K8S_VERSION: ${{ matrix.k8sVersion }}
     steps:

--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -21,14 +21,13 @@ on:
         description: "Kubernetes version ('default' = AKS default)"
         options:
           - "default"
-          - "1.28"
-          - "1.29"
           - "1.30"
           - "1.31"
           - "1.32"
           - "1.33"
           - "1.34"
           - "1.35"
+          - "1.36"
       azure_vm_size:
         type: string
         description: "the azure vm size to use for the e2e test (set to empty string to allow AKS to default)"

--- a/.github/workflows/e2e-version-compatibility-trigger.yaml
+++ b/.github/workflows/e2e-version-compatibility-trigger.yaml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        k8s_version: ["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34", "1.35"]
+        k8s_version: ["1.30", "1.31", "1.32", "1.33", "1.34", "1.35", "1.36"]
     uses: ./.github/workflows/e2e-matrix.yaml
     with:
       git_ref: ${{ needs.resolve.outputs.GIT_REF }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -68,14 +68,13 @@ on:
         description: "Kubernetes version ('default' = AKS default)"
         options:
           - "default"
-          - "1.28"
-          - "1.29"
           - "1.30"
           - "1.31"
           - "1.32"
           - "1.33"
           - "1.34"
           - "1.35"
+          - "1.36"
       provision_mode:
         type: choice
         description: "Karpenter provisioning mode"


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Update the list of supported/tested Kubernetes versions. Add 1.36, drop 1.28 and 1.29 from the text matrix (aligning with [AKS LTS supported versions](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#lts-versions) for reference)

**How was this change tested?**

* `make presubmit`
* CI (unit tests)

Note that it is not yet possible to create 1.36 AKS cluster, so E2E requesting this version will fail for now

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
