### PR TITLE
test: robustify Machine E2E suite

### DIFF
--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -791,6 +791,21 @@ func (env *Environment) EventuallyExpectCreatedNodeCount(comparator string, coun
 	return createdNodes
 }
 
+func (env *Environment) EventuallyExpectCreatedNodeCountWithSelector(comparator string, count int, selector labels.Selector) []*corev1.Node {
+	GinkgoHelper()
+	By(fmt.Sprintf("waiting for created nodes with selector %v to be %s to %d", selector, comparator, count))
+	var createdNodes []*corev1.Node
+	Eventually(func(g Gomega) {
+		createdNodes = env.Monitor.CreatedNodes()
+		createdNodes = lo.Filter(createdNodes, func(n *corev1.Node, _ int) bool {
+			return selector.Matches(labels.Set(n.Labels))
+		})
+		g.Expect(len(createdNodes)).To(BeNumerically(comparator, count),
+			fmt.Sprintf("expected %d created nodes, had %d (%v)", count, len(createdNodes), NodeNames(createdNodes)))
+	}).Should(Succeed())
+	return createdNodes
+}
+
 func (env *Environment) EventuallyExpectDeletedNodeCount(comparator string, count int) []*corev1.Node {
 	GinkgoHelper()
 	By(fmt.Sprintf("waiting for deleted nodes to be %s to %d", comparator, count))

--- a/test/suites/machine/machine_test.go
+++ b/test/suites/machine/machine_test.go
@@ -172,6 +172,10 @@ var _ = Describe("Machine Tests", func() {
 
 			By("updating the kubelet identity on the managed cluster")
 			poller := env.ExpectUpdatedManagedClusterKubeletIdentityAsync(env.Context, newIdentity)
+			defer func() {
+				// Ensure the cluster operation completes even if the test fails partway through
+				_, _ = poller.PollUntilDone(env.Context, nil)
+			}()
 
 			By("verifying the kubelet identity was updated")
 			updatedKubeletIdentity := env.GetKubeletIdentity(env.Context)
@@ -199,13 +203,12 @@ var _ = Describe("Machine Tests", func() {
 			env.EventuallyExpectNotFound(lo.Map(nodes, func(n *corev1.Node, _ int) client.Object { return n })...)
 			env.EventuallyExpectNotFound(lo.Map(nodeClaims, func(n *karpv1.NodeClaim, _ int) client.Object { return n })...)
 			env.EventuallyExpectHealthyPodCount(selector, int(numPods))
-			env.EventuallyExpectCreatedNodeCount("==", 3)
+			// Focus created nodes on only those with "test-name": "karpenter-machine-test", as there are some cases where updating cluster can result in
+			// AKS RP rolling system nodes which could make other nodes appear in the list of created nodes, which we don't want to count.
+			env.EventuallyExpectCreatedNodeCountWithSelector("==", 3,
+				labels.SelectorFromSet(map[string]string{"test-name": "karpenter-machine-test"}))
 			env.EventuallyExpectRegisteredNodeClaimCount("==", 3)
 			env.EventuallyExpectCreatedMachineCount("==", 3)
-
-			// Make sure to wait til cluster is done updating before proceeding to next test
-			_, err := poller.PollUntilDone(env.Context, nil)
-			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should be able to scale machines during an ongoing managed cluster operation", func() {

--- a/test/suites/machine/suite_test.go
+++ b/test/suites/machine/suite_test.go
@@ -38,8 +38,8 @@ func TestMachine(t *testing.T) {
 	// Using t.Skip() instead of Ginkgo's Skip() because in Ginkgo if you skip all tests in the suite it
 	// counts it as a failure
 	provisionMode := os.Getenv("PROVISION_MODE")
-	if provisionMode != consts.ProvisionModeAKSMachineAPI {
-		t.Skipf("Skipping machine suite: provision mode %q is not %s", provisionMode, consts.ProvisionModeAKSMachineAPI)
+	if provisionMode != consts.ProvisionModeAKSMachineAPI && provisionMode != consts.ProvisionModeAKSMachineAPIHeaderBatch {
+		t.Skipf("Skipping machine suite: provision mode %q is not %s or %s", provisionMode, consts.ProvisionModeAKSMachineAPI, consts.ProvisionModeAKSMachineAPIHeaderBatch)
 	}
 
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
* Fix issue where previous test PUT ManagedCluster could pollute subsequent test if the previous test failed.
* Fix issue where system VMSS nodes were counted as nodes of interest when we should only have been looking at Karpenter nodes.


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
