### PR TITLE
fix: validate Azure NodePool requirement values

### DIFF
--- a/pkg/apis/v1alpha2/crd_validation_cel_test.go
+++ b/pkg/apis/v1alpha2/crd_validation_cel_test.go
@@ -778,6 +778,7 @@ var _ = Describe("CEL/Validation", func() {
 			v1beta1.AKSLabelMode,
 			v1beta1.AKSLabelScaleSetPriority,
 			v1beta1.AKSLabelPriority,
+			v1beta1.AKSLabelOSSKU,
 			v1beta1.AKSLabelFIPSEnabled,
 		)
 
@@ -885,6 +886,8 @@ var _ = Describe("CEL/Validation", func() {
 			Entry("AKS mode", v1beta1.AKSLabelMode, v1beta1.ModeSystem, "control-plane"),
 			Entry("AKS scale set priority", v1beta1.AKSLabelScaleSetPriority, v1beta1.ScaleSetPriorityRegular, "low"),
 			Entry("AKS priority", v1beta1.AKSLabelPriority, v1beta1.PriorityRegular, "low"),
+			Entry("AKS OS SKU Ubuntu", v1beta1.AKSLabelOSSKU, v1beta1.OSSKUUbuntu, v1beta1.Ubuntu2204ImageFamily),
+			Entry("AKS OS SKU AzureLinux", v1beta1.AKSLabelOSSKU, v1beta1.OSSKUAzureLinux, "AzureLinux3"),
 			Entry("AKS FIPS enabled", v1beta1.AKSLabelFIPSEnabled, "true", "false"),
 		)
 	})

--- a/pkg/apis/v1alpha2/crd_validation_cel_test.go
+++ b/pkg/apis/v1alpha2/crd_validation_cel_test.go
@@ -768,6 +768,8 @@ var _ = Describe("CEL/Validation", func() {
 	})
 
 	Context("Requirements", func() {
+		// Labels with registered WellKnownValuesForRequirements reject arbitrary In values.
+		// Exclude them from the generic well-known label test below, which uses "test" as a placeholder value.
 		knownValueRequirementLabels := sets.New(
 			karpv1.NodePoolLabelKey,
 			karpv1.CapacityTypeLabelKey,
@@ -839,6 +841,7 @@ var _ = Describe("CEL/Validation", func() {
 		DescribeTable("should validate Azure known requirement values", func(key, validValue, invalidValue string) {
 			oldNodePool := nodePool.DeepCopy()
 
+			By("rejecting a requirement with only invalid values")
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 				Key:      key,
 				Operator: corev1.NodeSelectorOpIn,
@@ -848,6 +851,7 @@ var _ = Describe("CEL/Validation", func() {
 			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 
+			By("accepting a requirement with only valid values")
 			nodePool = oldNodePool.DeepCopy()
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 				Key:      key,
@@ -858,6 +862,7 @@ var _ = Describe("CEL/Validation", func() {
 			Expect(nodePool.RuntimeValidate(ctx)).To(Succeed())
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 
+			By("failing open when valid and invalid values are both present")
 			nodePool = oldNodePool.DeepCopy()
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 				Key:      key,
@@ -868,11 +873,13 @@ var _ = Describe("CEL/Validation", func() {
 			Expect(nodePool.RuntimeValidate(ctx)).To(Succeed())
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 
+			By("rejecting values that differ only by case")
+			upperValue := strings.ToUpper(validValue)
 			nodePool = oldNodePool.DeepCopy()
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 				Key:      key,
 				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{strings.ToUpper(validValue)},
+				Values:   []string{upperValue},
 			})
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
 			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())

--- a/pkg/apis/v1alpha2/crd_validation_cel_test.go
+++ b/pkg/apis/v1alpha2/crd_validation_cel_test.go
@@ -783,6 +783,12 @@ var _ = Describe("CEL/Validation", func() {
 			v1beta1.AKSLabelOSSKU,
 			v1beta1.AKSLabelFIPSEnabled,
 		)
+		expectKnownValueValidationError := func(err error, key string) {
+			Expect(err).To(MatchError(And(
+				ContainSubstring("no valid values found"),
+				ContainSubstring(key),
+			)))
+		}
 
 		It("should allow well known label exceptions", func() {
 			oldNodePool := nodePool.DeepCopy()
@@ -804,7 +810,7 @@ var _ = Describe("CEL/Validation", func() {
 				Values:   []string{capacityType},
 			})
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
-			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
+			expectKnownValueValidationError(nodePool.RuntimeValidate(ctx), karpv1.CapacityTypeLabelKey)
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 			nodePool = oldNodePool.DeepCopy()
 		},
@@ -848,7 +854,7 @@ var _ = Describe("CEL/Validation", func() {
 				Values:   []string{invalidValue},
 			})
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
-			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
+			expectKnownValueValidationError(nodePool.RuntimeValidate(ctx), key)
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 
 			By("accepting a requirement with only valid values")
@@ -882,7 +888,7 @@ var _ = Describe("CEL/Validation", func() {
 				Values:   []string{upperValue},
 			})
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
-			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
+			expectKnownValueValidationError(nodePool.RuntimeValidate(ctx), key)
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 			nodePool = oldNodePool.DeepCopy()
 		},

--- a/pkg/apis/v1alpha2/crd_validation_cel_test.go
+++ b/pkg/apis/v1alpha2/crd_validation_cel_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
+	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Pallinder/go-randomdata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -767,9 +768,22 @@ var _ = Describe("CEL/Validation", func() {
 	})
 
 	Context("Requirements", func() {
+		knownValueRequirementLabels := sets.New(
+			karpv1.NodePoolLabelKey,
+			karpv1.CapacityTypeLabelKey,
+			v1beta1.LabelSKUAcceleratedNetworking,
+			v1beta1.LabelSKUStoragePremiumCapable,
+			v1beta1.LabelSKUGPUManufacturer,
+			v1beta1.LabelPlacementScope,
+			v1beta1.AKSLabelMode,
+			v1beta1.AKSLabelScaleSetPriority,
+			v1beta1.AKSLabelPriority,
+			v1beta1.AKSLabelFIPSEnabled,
+		)
+
 		It("should allow well known label exceptions", func() {
 			oldNodePool := nodePool.DeepCopy()
-			for label := range karpv1.WellKnownLabels.Difference(sets.New(karpv1.NodePoolLabelKey, karpv1.CapacityTypeLabelKey)) {
+			for label := range karpv1.WellKnownLabels.Difference(knownValueRequirementLabels) {
 				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
 					{Key: label, Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
 				}
@@ -779,18 +793,21 @@ var _ = Describe("CEL/Validation", func() {
 				nodePool = oldNodePool.DeepCopy()
 			}
 		})
-		It("should fail validation with only invalid capacity types", func() {
+		DescribeTable("should fail validation with only unsupported capacity types", func(capacityType string) {
 			oldNodePool := nodePool.DeepCopy()
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 				Key:      karpv1.CapacityTypeLabelKey,
 				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{"xspot"}, // Invalid value,
+				Values:   []string{capacityType},
 			})
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
 			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 			nodePool = oldNodePool.DeepCopy()
-		})
+		},
+			Entry("unknown capacity type", "xspot"),
+			Entry("reserved capacity type", karpv1.CapacityTypeReserved),
+		)
 		It("should pass validation with valid capacity types", func() {
 			oldNodePool := nodePool.DeepCopy()
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
@@ -803,18 +820,73 @@ var _ = Describe("CEL/Validation", func() {
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 			nodePool = oldNodePool.DeepCopy()
 		})
-		It("should fail open if invalid and valid capacity types are present", func() {
+		DescribeTable("should fail open if unsupported and valid capacity types are present", func(capacityType string) {
 			oldNodePool := nodePool.DeepCopy()
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 				Key:      karpv1.CapacityTypeLabelKey,
 				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{karpv1.CapacityTypeOnDemand, "xspot"}, // Valid and invalid value,
+				Values:   []string{karpv1.CapacityTypeOnDemand, capacityType},
 			})
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
 			Expect(nodePool.RuntimeValidate(ctx)).To(Succeed())
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 			nodePool = oldNodePool.DeepCopy()
-		})
+		},
+			Entry("unknown capacity type", "xspot"),
+			Entry("reserved capacity type", karpv1.CapacityTypeReserved),
+		)
+		DescribeTable("should validate Azure known requirement values", func(key, validValue, invalidValue string) {
+			oldNodePool := nodePool.DeepCopy()
+
+			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
+				Key:      key,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{invalidValue},
+			})
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+
+			nodePool = oldNodePool.DeepCopy()
+			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
+				Key:      key,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{validValue},
+			})
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(nodePool.RuntimeValidate(ctx)).To(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+
+			nodePool = oldNodePool.DeepCopy()
+			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
+				Key:      key,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{validValue, invalidValue},
+			})
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(nodePool.RuntimeValidate(ctx)).To(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+
+			nodePool = oldNodePool.DeepCopy()
+			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
+				Key:      key,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{strings.ToUpper(validValue)},
+			})
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+			nodePool = oldNodePool.DeepCopy()
+		},
+			Entry("SKU accelerated networking", v1beta1.LabelSKUAcceleratedNetworking, "true", "maybe"),
+			Entry("SKU premium storage", v1beta1.LabelSKUStoragePremiumCapable, "true", "maybe"),
+			Entry("SKU GPU manufacturer", v1beta1.LabelSKUGPUManufacturer, v1beta1.ManufacturerNvidia, "intel"),
+			Entry("placement scope", v1beta1.LabelPlacementScope, v1beta1.PlacementScopeZonal, "global"),
+			Entry("AKS mode", v1beta1.AKSLabelMode, v1beta1.ModeSystem, "control-plane"),
+			Entry("AKS scale set priority", v1beta1.AKSLabelScaleSetPriority, v1beta1.ScaleSetPriorityRegular, "low"),
+			Entry("AKS priority", v1beta1.AKSLabelPriority, v1beta1.PriorityRegular, "low"),
+			Entry("AKS FIPS enabled", v1beta1.AKSLabelFIPSEnabled, "true", "false"),
+		)
 	})
 	Context("Labels", func() {
 		It("should allow well known label exceptions", func() {

--- a/pkg/apis/v1beta1/crd_validation_cel_test.go
+++ b/pkg/apis/v1beta1/crd_validation_cel_test.go
@@ -768,6 +768,8 @@ var _ = Describe("CEL/Validation", func() {
 	})
 
 	Context("Requirements", func() {
+		// Labels with registered WellKnownValuesForRequirements reject arbitrary In values.
+		// Exclude them from the generic well-known label test below, which uses "test" as a placeholder value.
 		knownValueRequirementLabels := sets.New(
 			karpv1.NodePoolLabelKey,
 			karpv1.CapacityTypeLabelKey,
@@ -839,6 +841,7 @@ var _ = Describe("CEL/Validation", func() {
 		DescribeTable("should validate Azure known requirement values", func(key, validValue, invalidValue string) {
 			oldNodePool := nodePool.DeepCopy()
 
+			By("rejecting a requirement with only invalid values")
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 				Key:      key,
 				Operator: corev1.NodeSelectorOpIn,
@@ -848,6 +851,7 @@ var _ = Describe("CEL/Validation", func() {
 			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 
+			By("accepting a requirement with only valid values")
 			nodePool = oldNodePool.DeepCopy()
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 				Key:      key,
@@ -858,6 +862,7 @@ var _ = Describe("CEL/Validation", func() {
 			Expect(nodePool.RuntimeValidate(ctx)).To(Succeed())
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 
+			By("failing open when valid and invalid values are both present")
 			nodePool = oldNodePool.DeepCopy()
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 				Key:      key,
@@ -868,11 +873,13 @@ var _ = Describe("CEL/Validation", func() {
 			Expect(nodePool.RuntimeValidate(ctx)).To(Succeed())
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 
+			By("rejecting values that differ only by case")
+			upperValue := strings.ToUpper(validValue)
 			nodePool = oldNodePool.DeepCopy()
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 				Key:      key,
 				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{strings.ToUpper(validValue)},
+				Values:   []string{upperValue},
 			})
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
 			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())

--- a/pkg/apis/v1beta1/crd_validation_cel_test.go
+++ b/pkg/apis/v1beta1/crd_validation_cel_test.go
@@ -783,6 +783,12 @@ var _ = Describe("CEL/Validation", func() {
 			v1beta1.AKSLabelOSSKU,
 			v1beta1.AKSLabelFIPSEnabled,
 		)
+		expectKnownValueValidationError := func(err error, key string) {
+			Expect(err).To(MatchError(And(
+				ContainSubstring("no valid values found"),
+				ContainSubstring(key),
+			)))
+		}
 
 		It("should allow well known label exceptions", func() {
 			oldNodePool := nodePool.DeepCopy()
@@ -804,7 +810,7 @@ var _ = Describe("CEL/Validation", func() {
 				Values:   []string{capacityType},
 			})
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
-			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
+			expectKnownValueValidationError(nodePool.RuntimeValidate(ctx), karpv1.CapacityTypeLabelKey)
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 			nodePool = oldNodePool.DeepCopy()
 		},
@@ -848,7 +854,7 @@ var _ = Describe("CEL/Validation", func() {
 				Values:   []string{invalidValue},
 			})
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
-			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
+			expectKnownValueValidationError(nodePool.RuntimeValidate(ctx), key)
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 
 			By("accepting a requirement with only valid values")
@@ -882,7 +888,7 @@ var _ = Describe("CEL/Validation", func() {
 				Values:   []string{upperValue},
 			})
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
-			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
+			expectKnownValueValidationError(nodePool.RuntimeValidate(ctx), key)
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 			nodePool = oldNodePool.DeepCopy()
 		},

--- a/pkg/apis/v1beta1/crd_validation_cel_test.go
+++ b/pkg/apis/v1beta1/crd_validation_cel_test.go
@@ -778,6 +778,7 @@ var _ = Describe("CEL/Validation", func() {
 			v1beta1.AKSLabelMode,
 			v1beta1.AKSLabelScaleSetPriority,
 			v1beta1.AKSLabelPriority,
+			v1beta1.AKSLabelOSSKU,
 			v1beta1.AKSLabelFIPSEnabled,
 		)
 
@@ -885,6 +886,8 @@ var _ = Describe("CEL/Validation", func() {
 			Entry("AKS mode", v1beta1.AKSLabelMode, v1beta1.ModeSystem, "control-plane"),
 			Entry("AKS scale set priority", v1beta1.AKSLabelScaleSetPriority, v1beta1.ScaleSetPriorityRegular, "low"),
 			Entry("AKS priority", v1beta1.AKSLabelPriority, v1beta1.PriorityRegular, "low"),
+			Entry("AKS OS SKU Ubuntu", v1beta1.AKSLabelOSSKU, v1beta1.OSSKUUbuntu, v1beta1.Ubuntu2204ImageFamily),
+			Entry("AKS OS SKU AzureLinux", v1beta1.AKSLabelOSSKU, v1beta1.OSSKUAzureLinux, "AzureLinux3"),
 			Entry("AKS FIPS enabled", v1beta1.AKSLabelFIPSEnabled, "true", "false"),
 		)
 		It("should not allow internal labels", func() {

--- a/pkg/apis/v1beta1/crd_validation_cel_test.go
+++ b/pkg/apis/v1beta1/crd_validation_cel_test.go
@@ -768,9 +768,22 @@ var _ = Describe("CEL/Validation", func() {
 	})
 
 	Context("Requirements", func() {
+		knownValueRequirementLabels := sets.New(
+			karpv1.NodePoolLabelKey,
+			karpv1.CapacityTypeLabelKey,
+			v1beta1.LabelSKUAcceleratedNetworking,
+			v1beta1.LabelSKUStoragePremiumCapable,
+			v1beta1.LabelSKUGPUManufacturer,
+			v1beta1.LabelPlacementScope,
+			v1beta1.AKSLabelMode,
+			v1beta1.AKSLabelScaleSetPriority,
+			v1beta1.AKSLabelPriority,
+			v1beta1.AKSLabelFIPSEnabled,
+		)
+
 		It("should allow well known label exceptions", func() {
 			oldNodePool := nodePool.DeepCopy()
-			for label := range karpv1.WellKnownLabels.Difference(sets.New(karpv1.NodePoolLabelKey, karpv1.CapacityTypeLabelKey)) {
+			for label := range karpv1.WellKnownLabels.Difference(knownValueRequirementLabels) {
 				nodePool.Spec.Template.Spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
 					{Key: label, Operator: corev1.NodeSelectorOpIn, Values: []string{"test"}},
 				}
@@ -780,18 +793,21 @@ var _ = Describe("CEL/Validation", func() {
 				nodePool = oldNodePool.DeepCopy()
 			}
 		})
-		It("should fail validation with only invalid capacity types", func() {
+		DescribeTable("should fail validation with only unsupported capacity types", func(capacityType string) {
 			oldNodePool := nodePool.DeepCopy()
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 				Key:      karpv1.CapacityTypeLabelKey,
 				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{"xspot"}, // Invalid value,
+				Values:   []string{capacityType},
 			})
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
 			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 			nodePool = oldNodePool.DeepCopy()
-		})
+		},
+			Entry("unknown capacity type", "xspot"),
+			Entry("reserved capacity type", karpv1.CapacityTypeReserved),
+		)
 		It("should pass validation with valid capacity types", func() {
 			oldNodePool := nodePool.DeepCopy()
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
@@ -804,18 +820,73 @@ var _ = Describe("CEL/Validation", func() {
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 			nodePool = oldNodePool.DeepCopy()
 		})
-		It("should fail open if invalid and valid capacity types are present", func() {
+		DescribeTable("should fail open if unsupported and valid capacity types are present", func(capacityType string) {
 			oldNodePool := nodePool.DeepCopy()
 			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 				Key:      karpv1.CapacityTypeLabelKey,
 				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{karpv1.CapacityTypeOnDemand, "xspot"}, // Valid and invalid value,
+				Values:   []string{karpv1.CapacityTypeOnDemand, capacityType},
 			})
 			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
 			Expect(nodePool.RuntimeValidate(ctx)).To(Succeed())
 			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
 			nodePool = oldNodePool.DeepCopy()
-		})
+		},
+			Entry("unknown capacity type", "xspot"),
+			Entry("reserved capacity type", karpv1.CapacityTypeReserved),
+		)
+		DescribeTable("should validate Azure known requirement values", func(key, validValue, invalidValue string) {
+			oldNodePool := nodePool.DeepCopy()
+
+			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
+				Key:      key,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{invalidValue},
+			})
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+
+			nodePool = oldNodePool.DeepCopy()
+			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
+				Key:      key,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{validValue},
+			})
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(nodePool.RuntimeValidate(ctx)).To(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+
+			nodePool = oldNodePool.DeepCopy()
+			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
+				Key:      key,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{validValue, invalidValue},
+			})
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(nodePool.RuntimeValidate(ctx)).To(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+
+			nodePool = oldNodePool.DeepCopy()
+			test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
+				Key:      key,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{strings.ToUpper(validValue)},
+			})
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+			Expect(nodePool.RuntimeValidate(ctx)).ToNot(Succeed())
+			Expect(env.Client.Delete(ctx, nodePool)).To(Succeed())
+			nodePool = oldNodePool.DeepCopy()
+		},
+			Entry("SKU accelerated networking", v1beta1.LabelSKUAcceleratedNetworking, "true", "maybe"),
+			Entry("SKU premium storage", v1beta1.LabelSKUStoragePremiumCapable, "true", "maybe"),
+			Entry("SKU GPU manufacturer", v1beta1.LabelSKUGPUManufacturer, v1beta1.ManufacturerNvidia, "intel"),
+			Entry("placement scope", v1beta1.LabelPlacementScope, v1beta1.PlacementScopeZonal, "global"),
+			Entry("AKS mode", v1beta1.AKSLabelMode, v1beta1.ModeSystem, "control-plane"),
+			Entry("AKS scale set priority", v1beta1.AKSLabelScaleSetPriority, v1beta1.ScaleSetPriorityRegular, "low"),
+			Entry("AKS priority", v1beta1.AKSLabelPriority, v1beta1.PriorityRegular, "low"),
+			Entry("AKS FIPS enabled", v1beta1.AKSLabelFIPSEnabled, "true", "false"),
+		)
 		It("should not allow internal labels", func() {
 			oldNodePool := nodePool.DeepCopy()
 			for label := range v1beta1.RestrictedLabels {

--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -32,6 +32,16 @@ func init() {
 	// computeRequirements in pkg/providers/instancetype/instancetype.go, because (as far as I can tell)
 	// Karpenter core expects that WellKnownLabels are mapped to requirements.
 	karpv1.WellKnownLabels = karpv1.WellKnownLabels.Union(AzureWellKnownLabels)
+	// Register exact, stable Azure-supported value domains for Karpenter core runtime requirement validation.
+	karpv1.WellKnownValuesForRequirements[karpv1.CapacityTypeLabelKey] = sets.New(karpv1.CapacityTypeOnDemand, karpv1.CapacityTypeSpot)
+	karpv1.WellKnownValuesForRequirements[LabelSKUAcceleratedNetworking] = sets.New("true", "false")
+	karpv1.WellKnownValuesForRequirements[LabelSKUStoragePremiumCapable] = sets.New("true", "false")
+	karpv1.WellKnownValuesForRequirements[LabelSKUGPUManufacturer] = sets.New(ManufacturerNvidia, ManufacturerAMD)
+	karpv1.WellKnownValuesForRequirements[LabelPlacementScope] = sets.New(PlacementScopeZonal, PlacementScopeRegional)
+	karpv1.WellKnownValuesForRequirements[AKSLabelMode] = sets.New(ModeSystem, ModeUser)
+	karpv1.WellKnownValuesForRequirements[AKSLabelScaleSetPriority] = sets.New(ScaleSetPriorityRegular, ScaleSetPrioritySpot)
+	karpv1.WellKnownValuesForRequirements[AKSLabelPriority] = sets.New(PriorityRegular, PrioritySpot)
+	karpv1.WellKnownValuesForRequirements[AKSLabelFIPSEnabled] = sets.New("true")
 }
 
 var (

--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -41,6 +41,7 @@ func init() {
 	karpv1.WellKnownValuesForRequirements[AKSLabelMode] = sets.New(ModeSystem, ModeUser)
 	karpv1.WellKnownValuesForRequirements[AKSLabelScaleSetPriority] = sets.New(ScaleSetPriorityRegular, ScaleSetPrioritySpot)
 	karpv1.WellKnownValuesForRequirements[AKSLabelPriority] = sets.New(PriorityRegular, PrioritySpot)
+	karpv1.WellKnownValuesForRequirements[AKSLabelOSSKU] = sets.New(OSSKUUbuntu, OSSKUAzureLinux)
 	karpv1.WellKnownValuesForRequirements[AKSLabelFIPSEnabled] = sets.New("true")
 }
 
@@ -172,6 +173,11 @@ const (
 )
 
 const (
+	OSSKUUbuntu     = "Ubuntu"
+	OSSKUAzureLinux = "AzureLinux"
+)
+
+const (
 	ScaleSetPriorityRegular = "regular"
 	ScaleSetPrioritySpot    = "spot"
 )
@@ -190,10 +196,10 @@ var UbuntuFamilies = sets.New(
 // imageFamilyToOSSKU maps imageFamily spec values to os-sku label values.
 // These values match what AKS writes for kubernetes.azure.com/os-sku.
 var imageFamilyToOSSKU = map[string]string{
-	UbuntuImageFamily:     "Ubuntu",
-	Ubuntu2204ImageFamily: "Ubuntu",
-	Ubuntu2404ImageFamily: "Ubuntu",
-	AzureLinuxImageFamily: "AzureLinux",
+	UbuntuImageFamily:     OSSKUUbuntu,
+	Ubuntu2204ImageFamily: OSSKUUbuntu,
+	Ubuntu2404ImageFamily: OSSKUUbuntu,
+	AzureLinuxImageFamily: OSSKUAzureLinux,
 }
 
 // GetOSSKUFromImageFamily returns the kuberentes.azure.com/os-sku label value for the given imageFamily.


### PR DESCRIPTION
Fixes #1679 

**Description**

This PR registers Azure-supported known value domains for NodePool requirement runtime validation.

It adds provider-owned value validation for:

- `karpenter.sh/capacity-type`
- `karpenter.azure.com/sku-accelerated-networking`
- `karpenter.azure.com/sku-storage-premium-capable`
- `karpenter.azure.com/sku-gpu-manufacturer`
- `karpenter.azure.com/placement-scope`
- `kubernetes.azure.com/mode`
- `kubernetes.azure.com/scalesetpriority`
- `kubernetes.azure.com/priority`
- `kubernetes.azure.com/os-sku`
- `kubernetes.azure.com/fips_enabled`

For capacity type, Azure now overrides the Karpenter core known values to the currently supported values: `on-demand` and `spot`. `reserved` is intentionally treated as unsupported until Azure reserved capacity support is implemented.

For `kubernetes.azure.com/os-sku`, validation uses the coarse AKS node label values: `Ubuntu` and `AzureLinux`. (Versioned OS values such as `Ubuntu2204`, `Ubuntu2404`, `AzureLinux2`, and `AzureLinux3` are not valid values for this requirement label; they are used by image-family resolution, Machine API/bootstrap OSSKU handling, or the materialized node labels `kubernetes.azure.com/os-sku-requested` and `kubernetes.azure.com/os-sku-effective`.)

**How was this change tested?**

* `go test ./pkg/apis/v1beta1 ./pkg/apis/v1alpha2`
* [E2EMatrixTrigger · Azure/karpenter-provider-azure@3b38db0](https://github.com/Azure/karpenter-provider-azure/actions/runs/25686790464)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note
Validate Azure-specific NodePool requirement values at runtime, including capacity type, placement scope, SKU capability labels, GPU manufacturer, AKS mode/priority labels, OS SKU, and FIPS labels. Azure capacity type validation now accepts only on-demand and spot until reserved capacity support is added.
```