### PR TITLE
fix: type-safety issues in fakes packages

### DIFF
--- a/pkg/cloudprovider/suite_aksmachineapi_drift_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_drift_test.go
@@ -150,7 +150,7 @@ var _ = Describe("CloudProvider", func() {
 					existingMachine, ok := azureEnv.AKSDataStorage.AKSMachines.Load(aksMachineID)
 					Expect(ok).To(BeTrue(), "AKS machine should exist in fake store")
 
-					aksMachine := existingMachine.(armcontainerservice.Machine)
+					aksMachine := existingMachine
 
 					// Set DriftAction to "Recreate" to trigger drift
 					if aksMachine.Properties == nil {

--- a/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
@@ -414,7 +414,7 @@ func runSharedAKSMachineAPITests() {
 			machineID := fake.MkMachineID(testOptions.NodeResourceGroup, testOptions.ClusterName, testOptions.AKSMachinesPoolName, aksMachineName)
 			existingMachine, ok := azureEnv.AKSDataStorage.AKSMachines.Load(machineID)
 			Expect(ok).To(BeTrue(), "AKS machine should exist in fake store")
-			aksMachine := existingMachine.(armcontainerservice.Machine)
+			aksMachine := existingMachine
 			Expect(aksMachine.Properties).ToNot(BeNil())
 
 			// Validate AKS machine properties match the conflicted configuration

--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -186,7 +186,7 @@ var _ = Describe("Instance Garbage Collection", func() {
 								TimeCreated: lo.ToPtr(time.Now().Add(-time.Minute * 10)),
 							},
 						})
-						azureEnv.VirtualMachinesAPI.Instances.Store(lo.FromPtr(newVM.ID), newVM)
+						azureEnv.VirtualMachinesAPI.Instances.Store(lo.FromPtr(newVM.ID), *newVM)
 						ids = append(ids, *vm.ID)
 					}
 				}
@@ -227,7 +227,7 @@ var _ = Describe("Instance Garbage Collection", func() {
 								TimeCreated: lo.ToPtr(time.Now().Add(-time.Minute * 10)),
 							},
 						})
-						azureEnv.VirtualMachinesAPI.Instances.Store(lo.FromPtr(newVM.ID), newVM)
+						azureEnv.VirtualMachinesAPI.Instances.Store(lo.FromPtr(newVM.ID), *newVM)
 						nodeClaim := coretest.NodeClaim(karpv1.NodeClaim{
 							Status: karpv1.NodeClaimStatus{
 								ProviderID: utils.VMResourceIDToProviderID(ctx, *vm.ID),

--- a/pkg/fake/aksagentpoolsapi.go
+++ b/pkg/fake/aksagentpoolsapi.go
@@ -95,10 +95,7 @@ func NewAKSAgentPoolsAPI(aksDataStorage *AKSDataStorage) *AKSAgentPoolsAPI {
 func (c *AKSAgentPoolsAPI) Reset() {
 	c.AgentPoolDeleteMachinesBehavior.Reset()
 	c.AgentPoolGetBehavior.Reset()
-	c.aksDataStorage.AgentPools.Range(func(k, v any) bool {
-		c.aksDataStorage.AgentPools.Delete(k)
-		return true
-	})
+	c.aksDataStorage.AgentPools.Clear()
 }
 
 func (c *AKSAgentPoolsAPI) Get(ctx context.Context, resourceGroupName string, resourceName string, agentPoolName string, options *armcontainerservice.AgentPoolsClientGetOptions) (armcontainerservice.AgentPoolsClientGetResponse, error) {
@@ -116,7 +113,7 @@ func (c *AKSAgentPoolsAPI) Get(ctx context.Context, resourceGroupName string, re
 			return armcontainerservice.AgentPoolsClientGetResponse{}, AKSAgentPoolsAPIErrorFromAKSAgentPoolNotFound
 		}
 		return armcontainerservice.AgentPoolsClientGetResponse{
-			AgentPool: agentPool.(armcontainerservice.AgentPool),
+			AgentPool: agentPool,
 		}, nil
 	})
 }
@@ -154,8 +151,7 @@ func (c *AKSAgentPoolsAPI) BeginDeleteMachines(
 
 		// Collect all existing machines in the agent pool for error message
 		if c.aksDataStorage != nil && c.aksDataStorage.AKSMachines != nil {
-			c.aksDataStorage.AKSMachines.Range(func(key, value interface{}) bool {
-				machineID := key.(string)
+			c.aksDataStorage.AKSMachines.Range(func(machineID string, value armcontainerservice.Machine) bool {
 				// Check if this machine belongs to the same agent pool
 				expectedPrefix := fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s/agentPools/%s/machines/",
 					input.ResourceGroupName, input.ResourceName, input.AgentPoolName)

--- a/pkg/fake/aksmachinesapi.go
+++ b/pkg/fake/aksmachinesapi.go
@@ -24,13 +24,13 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
 	"github.com/Azure/karpenter-provider-azure/pkg/consts"
+	fakesync "github.com/Azure/karpenter-provider-azure/pkg/fake/sync"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient/aksmachinesheaderbatch"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient/azapi"
 	"github.com/samber/lo"
@@ -38,15 +38,15 @@ import (
 
 // AKSDataStorage contains the shared data stores for both AKS agent pools and machines
 type AKSDataStorage struct {
-	AgentPools  *sync.Map
-	AKSMachines *sync.Map
+	AgentPools  *fakesync.Map[string, armcontainerservice.AgentPool]
+	AKSMachines *fakesync.Map[string, armcontainerservice.Machine]
 }
 
 // NewAKSDataStorage creates a new instance of shared data stores
 func NewAKSDataStorage() *AKSDataStorage {
 	return &AKSDataStorage{
-		AgentPools:  &sync.Map{},
-		AKSMachines: &sync.Map{},
+		AgentPools:  &fakesync.Map[string, armcontainerservice.AgentPool]{},
+		AKSMachines: &fakesync.Map[string, armcontainerservice.Machine]{},
 	}
 }
 
@@ -268,10 +268,7 @@ func (c *AKSMachinesAPI) Reset() {
 	c.AKSMachineCreateOrUpdateBehavior.Reset()
 	c.AKSMachineGetBehavior.Reset()
 	c.AKSMachineNewListPagerBehavior.Reset()
-	c.aksDataStorage.AKSMachines.Range(func(k, v any) bool {
-		c.aksDataStorage.AKSMachines.Delete(k)
-		return true
-	})
+	c.aksDataStorage.AKSMachines.Clear()
 	c.AfterPollProvisioningErrorOverride = nil
 	c.BatchMachineErrorFunc = nil
 }
@@ -319,7 +316,7 @@ func (c *AKSMachinesAPI) createSingleMachine(input *AKSMachineCreateOrUpdateInpu
 	// Check if AKS machine already exists, if so, consider this an update than a create
 	existingMachine, ok := c.aksDataStorage.AKSMachines.Load(id)
 	if ok {
-		return c.updateExistingAKSMachine(input, existingMachine.(armcontainerservice.Machine), aksMachine)
+		return c.updateExistingAKSMachine(input, existingMachine, aksMachine)
 	}
 
 	// Default values + update status, for sync phase
@@ -430,8 +427,7 @@ func (c *AKSMachinesAPI) createOneBatchMachine(input *AKSMachineCreateOrUpdateIn
 	}
 
 	// Check if AKS machine already exists — if so, check for immutable property conflicts
-	if existingRaw, ok := c.aksDataStorage.AKSMachines.Load(id); ok {
-		existing := existingRaw.(armcontainerservice.Machine)
+	if existing, ok := c.aksDataStorage.AKSMachines.Load(id); ok {
 		if c.doImmutablePropertiesChanged(&existing, &machine) {
 			return armcontainerservice.Machine{}, AKSMachineAPIErrorFromAKSMachineImmutablePropertyChangeAttempted
 		}
@@ -598,7 +594,7 @@ func (c *AKSMachinesAPI) Get(
 		aksMachine, ok := c.aksDataStorage.AKSMachines.Load(MkMachineID(input.ResourceGroupName, input.ResourceName, input.AgentPoolName, input.AKSMachineName))
 		if ok {
 			return armcontainerservice.MachinesClientGetResponse{
-				Machine: aksMachine.(armcontainerservice.Machine),
+				Machine: aksMachine,
 			}, nil
 		} else {
 			return armcontainerservice.MachinesClientGetResponse{}, AKSMachineAPIErrorFromAKSMachineNotFound
@@ -634,10 +630,8 @@ func (c *AKSMachinesAPI) NewListPager(
 				var aksMachines []*armcontainerservice.Machine
 				expectedIDPrefix := fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s/agentPools/%s/machines/",
 					input.ResourceGroupName, input.ResourceName, input.AgentPoolName)
-				c.aksDataStorage.AKSMachines.Range(func(key, value any) bool {
-					machineID := key.(string)
+				c.aksDataStorage.AKSMachines.Range(func(machineID string, aksMachine armcontainerservice.Machine) bool {
 					if strings.HasPrefix(machineID, expectedIDPrefix) {
-						aksMachine := value.(armcontainerservice.Machine)
 						aksMachines = append(aksMachines, &aksMachine)
 					}
 					return true

--- a/pkg/fake/aksmachinesapi_batch_test.go
+++ b/pkg/fake/aksmachinesapi_batch_test.go
@@ -44,7 +44,7 @@ import (
 
 func setupBatchFake() (*AKSMachinesAPI, context.Context) {
 	storage := NewAKSDataStorage()
-	storage.AgentPools.Store(MkAgentPoolID("rg", "cluster", "pool"), struct{}{})
+	storage.AgentPools.Store(MkAgentPoolID("rg", "cluster", "pool"), armcontainerservice.AgentPool{})
 	return NewAKSMachinesAPI(storage), context.Background()
 }
 

--- a/pkg/fake/azureresourcegraphapi.go
+++ b/pkg/fake/azureresourcegraphapi.go
@@ -109,18 +109,16 @@ func (c *AzureResourceGraphAPI) getResourceList(query string) []interface{} {
 }
 
 func (c *AzureResourceGraphAPI) loadVMObjects() (vmList []armcompute.VirtualMachine) {
-	c.VirtualMachinesAPI.Instances.Range(func(k, v any) bool {
-		vm, _ := c.VirtualMachinesAPI.Instances.Load(k)
-		vmList = append(vmList, vm.(armcompute.VirtualMachine))
+	c.VirtualMachinesAPI.Instances.Range(func(k string, v armcompute.VirtualMachine) bool {
+		vmList = append(vmList, v)
 		return true
 	})
 	return vmList
 }
 
 func (c *AzureResourceGraphAPI) loadNicObjects() (nicList []armnetwork.Interface) {
-	c.NetworkInterfacesAPI.NetworkInterfaces.Range(func(k, v any) bool {
-		nic, _ := c.NetworkInterfacesAPI.NetworkInterfaces.Load(k)
-		nicList = append(nicList, nic.(armnetwork.Interface))
+	c.NetworkInterfacesAPI.NetworkInterfaces.Range(func(k string, v armnetwork.Interface) bool {
+		nicList = append(nicList, v)
 		return true
 	})
 	return nicList

--- a/pkg/fake/loadbalancerapi.go
+++ b/pkg/fake/loadbalancerapi.go
@@ -20,16 +20,16 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	fakesync "github.com/Azure/karpenter-provider-azure/pkg/fake/sync"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
 	"github.com/samber/lo"
 )
 
 type LoadBalancersBehavior struct {
-	LoadBalancers sync.Map
+	LoadBalancers fakesync.Map[string, armnetwork.LoadBalancer]
 }
 
 // assert that the fake implements the interface
@@ -41,10 +41,7 @@ type LoadBalancersAPI struct {
 
 // Reset must be called between tests otherwise tests will pollute each other.
 func (api *LoadBalancersAPI) Reset() {
-	api.LoadBalancers.Range(func(k, v any) bool {
-		api.LoadBalancers.Delete(k)
-		return true
-	})
+	api.LoadBalancers.Clear()
 }
 
 func (api *LoadBalancersAPI) Get(_ context.Context, resourceGroupName string, loadBalancerName string, _ *armnetwork.LoadBalancersClientGetOptions) (armnetwork.LoadBalancersClientGetResponse, error) {
@@ -54,7 +51,7 @@ func (api *LoadBalancersAPI) Get(_ context.Context, resourceGroupName string, lo
 		return armnetwork.LoadBalancersClientGetResponse{}, fmt.Errorf("not found")
 	}
 	return armnetwork.LoadBalancersClientGetResponse{
-		LoadBalancer: lb.(armnetwork.LoadBalancer),
+		LoadBalancer: lb,
 	}, nil
 }
 
@@ -67,9 +64,8 @@ func (api *LoadBalancersAPI) NewListPager(_ string, _ *armnetwork.LoadBalancersC
 			output := armnetwork.LoadBalancerListResult{
 				Value: []*armnetwork.LoadBalancer{},
 			}
-			api.LoadBalancers.Range(func(key, value any) bool {
-				cast := value.(armnetwork.LoadBalancer)
-				output.Value = append(output.Value, &cast)
+			api.LoadBalancers.Range(func(key string, value armnetwork.LoadBalancer) bool {
+				output.Value = append(output.Value, &value)
 
 				return true
 			})

--- a/pkg/fake/networkinterfaceapi.go
+++ b/pkg/fake/networkinterfaceapi.go
@@ -21,13 +21,13 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
-	"sync"
 
 	"github.com/samber/lo"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	fakesync "github.com/Azure/karpenter-provider-azure/pkg/fake/sync"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient/azapi"
 )
 
@@ -53,7 +53,7 @@ type NetworkInterfacesBehavior struct {
 	NetworkInterfacesCreateOrUpdateBehavior MockedLRO[NetworkInterfaceCreateOrUpdateInput, armnetwork.InterfacesClientCreateOrUpdateResponse]
 	NetworkInterfacesDeleteBehavior         MockedLRO[NetworkInterfaceDeleteInput, armnetwork.InterfacesClientDeleteResponse]
 	NetworkInterfacesUpdateTagsBehavior     MockedFunction[NetworkInterfaceUpdateTagsInput, armnetwork.InterfacesClientUpdateTagsResponse]
-	NetworkInterfaces                       sync.Map
+	NetworkInterfaces                       fakesync.Map[string, armnetwork.Interface]
 }
 
 // assert that the fake implements the interface
@@ -69,10 +69,7 @@ func (c *NetworkInterfacesAPI) Reset() {
 	c.NetworkInterfacesCreateOrUpdateBehavior.Reset()
 	c.NetworkInterfacesDeleteBehavior.Reset()
 	c.NetworkInterfacesUpdateTagsBehavior.Reset()
-	c.NetworkInterfaces.Range(func(k, v any) bool {
-		c.NetworkInterfaces.Delete(k)
-		return true
-	})
+	c.NetworkInterfaces.Clear()
 }
 
 func (c *NetworkInterfacesAPI) BeginCreateOrUpdate(_ context.Context, resourceGroupName string, interfaceName string, iface armnetwork.Interface, options *armnetwork.InterfacesClientBeginCreateOrUpdateOptions) (*runtime.Poller[armnetwork.InterfacesClientCreateOrUpdateResponse], error) {
@@ -102,7 +99,7 @@ func (c *NetworkInterfacesAPI) Get(_ context.Context, resourceGroupName string, 
 		return armnetwork.InterfacesClientGetResponse{}, &azcore.ResponseError{StatusCode: http.StatusNotFound}
 	}
 	return armnetwork.InterfacesClientGetResponse{
-		Interface: iface.(armnetwork.Interface),
+		Interface: iface,
 	}, nil
 }
 
@@ -138,7 +135,7 @@ func (c *NetworkInterfacesAPI) UpdateTags(
 			return armnetwork.InterfacesClientUpdateTagsResponse{}, &azcore.ResponseError{StatusCode: http.StatusNotFound}
 		}
 
-		iface := instance.(armnetwork.Interface)
+		iface := instance
 
 		if input.Tags.Tags != nil {
 			// Tags are full-replace if they're specified

--- a/pkg/fake/networksecuritygroupapi.go
+++ b/pkg/fake/networksecuritygroupapi.go
@@ -20,16 +20,16 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	fakesync "github.com/Azure/karpenter-provider-azure/pkg/fake/sync"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/networksecuritygroup"
 	"github.com/samber/lo"
 )
 
 type NetworkSecurityGroupBevhavior struct {
-	NSGs sync.Map
+	NSGs fakesync.Map[string, armnetwork.SecurityGroup]
 }
 
 // assert that the fake implements the interface
@@ -41,10 +41,7 @@ type NetworkSecurityGroupAPI struct {
 
 // Reset must be called between tests otherwise tests will pollute each other.
 func (api *NetworkSecurityGroupAPI) Reset() {
-	api.NSGs.Range(func(k, v any) bool {
-		api.NSGs.Delete(k)
-		return true
-	})
+	api.NSGs.Clear()
 }
 
 // Get implements networksecuritygroup.API.
@@ -60,7 +57,7 @@ func (api *NetworkSecurityGroupAPI) Get(
 		return armnetwork.SecurityGroupsClientGetResponse{}, fmt.Errorf("not found")
 	}
 	return armnetwork.SecurityGroupsClientGetResponse{
-		SecurityGroup: nsg.(armnetwork.SecurityGroup),
+		SecurityGroup: nsg,
 	}, nil
 }
 
@@ -74,9 +71,8 @@ func (api *NetworkSecurityGroupAPI) NewListPager(resourceGroupName string, optio
 			output := armnetwork.SecurityGroupListResult{
 				Value: []*armnetwork.SecurityGroup{},
 			}
-			api.NSGs.Range(func(key, value any) bool {
-				cast := value.(armnetwork.SecurityGroup)
-				output.Value = append(output.Value, &cast)
+			api.NSGs.Range(func(key string, value armnetwork.SecurityGroup) bool {
+				output.Value = append(output.Value, &value)
 
 				return true
 			})

--- a/pkg/fake/subscriptionsapi.go
+++ b/pkg/fake/subscriptionsapi.go
@@ -22,10 +22,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	fakesync "github.com/Azure/karpenter-provider-azure/pkg/fake/sync"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/zone"
 	"github.com/samber/lo"
 )
@@ -40,7 +40,7 @@ type ListLocationsInput struct {
 
 type SubscriptionsAPIBehavior struct {
 	NewListLocationsPagerBehavior MockedFunction[ListLocationsInput, armsubscriptions.ClientListLocationsResponse]
-	Locations                     sync.Map
+	Locations                     fakesync.Map[string, armsubscriptions.Location]
 	UseFakeData                   bool
 }
 
@@ -54,7 +54,7 @@ func NewSubscriptionsAPI() (*SubscriptionsAPI, error) {
 	result := &SubscriptionsAPI{
 		SubscriptionsAPIBehavior: SubscriptionsAPIBehavior{
 			NewListLocationsPagerBehavior: MockedFunction[ListLocationsInput, armsubscriptions.ClientListLocationsResponse]{},
-			Locations:                     sync.Map{},
+			Locations:                     fakesync.Map[string, armsubscriptions.Location]{},
 			UseFakeData:                   true,
 		},
 	}
@@ -68,10 +68,7 @@ func NewSubscriptionsAPI() (*SubscriptionsAPI, error) {
 
 func (api *SubscriptionsAPI) Reset() {
 	api.NewListLocationsPagerBehavior.Reset()
-	api.Locations.Range(func(k, v any) bool {
-		api.Locations.Delete(k)
-		return true
-	})
+	api.Locations.Clear()
 	if api.UseFakeData {
 		err := loadLocationsFromFile(api)
 		if err != nil {
@@ -99,9 +96,8 @@ func (api *SubscriptionsAPI) NewListLocationsPager(
 					Value: []*armsubscriptions.Location{},
 				}
 
-				api.Locations.Range(func(key, value any) bool {
-					cast := value.(armsubscriptions.Location)
-					output.Value = append(output.Value, &cast)
+				api.Locations.Range(func(key string, value armsubscriptions.Location) bool {
+					output.Value = append(output.Value, &value)
 					return true
 				})
 

--- a/pkg/fake/sync/map.go
+++ b/pkg/fake/sync/map.go
@@ -1,0 +1,137 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import "sync"
+
+// Map is a typesafe wrapper around a map with sync.RWMutex.
+// It exposes the same methods as sync.Map but with generic type parameters.
+// NOTE: This lives here for now because most of the time you may want to enforce some other invariants while under the RWMutex (not just the map invaraints),
+// so this helper exists primarily for the fake pkg which is only used for tests. We can think about promoting this to a more general utility package if we
+// find more use cases for it.
+type Map[K comparable, V any] struct {
+	mu sync.RWMutex
+	m  map[K]V
+}
+
+func (m *Map[K, V]) init() {
+	if m.m == nil {
+		m.m = make(map[K]V)
+	}
+}
+
+func (m *Map[K, V]) Load(key K) (value V, ok bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.m == nil {
+		var zero V
+		return zero, false
+	}
+	value, ok = m.m[key]
+	return value, ok
+}
+
+func (m *Map[K, V]) Store(key K, value V) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.init()
+	m.m[key] = value
+}
+
+func (m *Map[K, V]) Delete(key K) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.m != nil {
+		delete(m.m, key)
+	}
+}
+
+func (m *Map[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.init()
+	if existing, ok := m.m[key]; ok {
+		return existing, true
+	}
+	m.m[key] = value
+	return value, false
+}
+
+func (m *Map[K, V]) LoadAndDelete(key K) (value V, loaded bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.m == nil {
+		var zero V
+		return zero, false
+	}
+	value, ok := m.m[key]
+	if ok {
+		delete(m.m, key)
+	}
+	return value, ok
+}
+
+func (m *Map[K, V]) Swap(key K, value V) (previous V, loaded bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.init()
+	previous, loaded = m.m[key]
+	m.m[key] = value
+	return previous, loaded
+}
+
+func (m *Map[K, V]) CompareAndSwap(key K, old, new V) (swapped bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.m == nil {
+		return false
+	}
+	if existing, ok := m.m[key]; ok && any(existing) == any(old) {
+		m.m[key] = new
+		return true
+	}
+	return false
+}
+
+func (m *Map[K, V]) CompareAndDelete(key K, old V) (deleted bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.m == nil {
+		return false
+	}
+	if existing, ok := m.m[key]; ok && any(existing) == any(old) {
+		delete(m.m, key)
+		return true
+	}
+	return false
+}
+
+func (m *Map[K, V]) Range(f func(key K, value V) bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for k, v := range m.m {
+		if !f(k, v) {
+			break
+		}
+	}
+}
+
+func (m *Map[K, V]) Clear() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.m = nil
+}

--- a/pkg/fake/sync/map_test.go
+++ b/pkg/fake/sync/map_test.go
@@ -1,0 +1,93 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMap_StoreAndLoad(t *testing.T) {
+	var m Map[string, int]
+	m.Store("a", 1)
+	v, ok := m.Load("a")
+	assert.True(t, ok)
+	assert.Equal(t, 1, v)
+
+	_, ok = m.Load("missing")
+	assert.False(t, ok)
+}
+
+func TestMap_Delete(t *testing.T) {
+	var m Map[string, int]
+	m.Store("a", 1)
+	m.Delete("a")
+	_, ok := m.Load("a")
+	assert.False(t, ok)
+}
+
+func TestMap_LoadOrStore(t *testing.T) {
+	var m Map[string, int]
+	v, loaded := m.LoadOrStore("a", 1)
+	assert.False(t, loaded)
+	assert.Equal(t, 1, v)
+
+	v, loaded = m.LoadOrStore("a", 2)
+	assert.True(t, loaded)
+	assert.Equal(t, 1, v)
+}
+
+func TestMap_LoadAndDelete(t *testing.T) {
+	var m Map[string, int]
+	m.Store("a", 1)
+	v, loaded := m.LoadAndDelete("a")
+	assert.True(t, loaded)
+	assert.Equal(t, 1, v)
+
+	_, loaded = m.LoadAndDelete("a")
+	assert.False(t, loaded)
+}
+
+func TestMap_Range(t *testing.T) {
+	var m Map[string, int]
+	m.Store("a", 1)
+	m.Store("b", 2)
+
+	seen := map[string]int{}
+	m.Range(func(k string, v int) bool {
+		seen[k] = v
+		return true
+	})
+	assert.Equal(t, map[string]int{"a": 1, "b": 2}, seen)
+}
+
+func TestMap_Clear(t *testing.T) {
+	var m Map[string, int]
+	m.Store("a", 1)
+	m.Clear()
+	_, ok := m.Load("a")
+	assert.False(t, ok)
+}
+
+func TestMap_ZeroValue(t *testing.T) {
+	var m Map[string, int]
+	_, ok := m.Load("x")
+	assert.False(t, ok)
+	m.Delete("x") // should not panic
+	m.Range(func(k string, v int) bool { return true })
+}

--- a/pkg/fake/virtualmachineextensionsapi.go
+++ b/pkg/fake/virtualmachineextensionsapi.go
@@ -21,13 +21,13 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
-	"sync"
 
 	"github.com/samber/lo"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+	fakesync "github.com/Azure/karpenter-provider-azure/pkg/fake/sync"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient/azapi"
 )
 
@@ -50,7 +50,7 @@ type VirtualMachineExtensionUpdateInput struct {
 type VirtualMachineExtensionsBehavior struct {
 	VirtualMachineExtensionsCreateOrUpdateBehavior MockedLRO[VirtualMachineExtensionCreateOrUpdateInput, armcompute.VirtualMachineExtensionsClientCreateOrUpdateResponse]
 	VirtualMachineExtensionsUpdateBehavior         MockedLRO[VirtualMachineExtensionUpdateInput, armcompute.VirtualMachineExtensionsClientUpdateResponse]
-	Extensions                                     sync.Map
+	Extensions                                     fakesync.Map[string, armcompute.VirtualMachineExtension]
 }
 
 // assert that ComputeAPI implements ARMComputeAPI
@@ -65,10 +65,7 @@ type VirtualMachineExtensionsAPI struct {
 func (c *VirtualMachineExtensionsAPI) Reset() {
 	c.VirtualMachineExtensionsCreateOrUpdateBehavior.Reset()
 	c.VirtualMachineExtensionsUpdateBehavior.Reset()
-	c.Extensions.Range(func(k, v any) bool {
-		c.Extensions.Delete(k)
-		return true
-	})
+	c.Extensions.Clear()
 }
 
 func (c *VirtualMachineExtensionsAPI) BeginCreateOrUpdate(
@@ -114,22 +111,20 @@ func (c *VirtualMachineExtensionsAPI) BeginUpdate(
 	}
 
 	return c.VirtualMachineExtensionsUpdateBehavior.Invoke(input, func(input *VirtualMachineExtensionUpdateInput) (*armcompute.VirtualMachineExtensionsClientUpdateResponse, error) {
-		result := input.VirtualMachineExtensionUpdate
-
 		id := MakeVMExtensionID(input.ResourceGroupName, input.VirtualMachineName, input.VirtualMachineExtensionName)
 
 		instance, ok := c.Extensions.Load(id)
 		if !ok {
 			return nil, &azcore.ResponseError{StatusCode: http.StatusNotFound}
 		}
-		ext := instance.(armcompute.VirtualMachineExtension)
+		ext := instance
 
 		if updates.Tags != nil {
 			// VM tags are full-replace if they're specified
 			ext.Tags = maps.Clone(updates.Tags)
 		}
 
-		c.Extensions.Store(input.VirtualMachineExtensionName, result)
+		c.Extensions.Store(input.VirtualMachineExtensionName, ext)
 		return &armcompute.VirtualMachineExtensionsClientUpdateResponse{
 			VirtualMachineExtension: ext,
 		}, nil

--- a/pkg/fake/virtualmachinesapi.go
+++ b/pkg/fake/virtualmachinesapi.go
@@ -23,13 +23,13 @@ import (
 	"io"
 	"maps"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/Azure/karpenter-provider-azure/pkg/auth"
+	fakesync "github.com/Azure/karpenter-provider-azure/pkg/fake/sync"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient/azapi"
 	"github.com/samber/lo"
 )
@@ -65,7 +65,7 @@ type VirtualMachinesBehavior struct {
 	VirtualMachineUpdateBehavior         MockedLRO[VirtualMachineUpdateInput, armcompute.VirtualMachinesClientUpdateResponse]
 	VirtualMachineDeleteBehavior         MockedLRO[VirtualMachineDeleteInput, armcompute.VirtualMachinesClientDeleteResponse]
 	VirtualMachineGetBehavior            MockedFunction[VirtualMachineGetInput, armcompute.VirtualMachinesClientGetResponse]
-	Instances                            sync.Map
+	Instances                            fakesync.Map[string, armcompute.VirtualMachine]
 }
 
 // assert that the fake implements the interface
@@ -84,10 +84,7 @@ func (c *VirtualMachinesAPI) Reset() {
 	c.VirtualMachineDeleteBehavior.Reset()
 	c.VirtualMachineGetBehavior.Reset()
 	c.VirtualMachineUpdateBehavior.Reset()
-	c.Instances.Range(func(k, v any) bool {
-		c.Instances.Delete(k)
-		return true
-	})
+	c.Instances.Clear()
 }
 
 // UseAuxiliaryTokenPolicy simulates AuxiliaryTokenPolicy.Do() method being called at the beginning of each API call
@@ -134,7 +131,7 @@ func (c *VirtualMachinesAPI) BeginCreateOrUpdate(ctx context.Context, resourceGr
 		existingVM, ok := c.Instances.Load(id)
 		if ok {
 			incomingZone := vm.Zones[0] // Note: this assumes at least 1 zone and only one zone is put on our vm
-			existingZone := existingVM.(armcompute.VirtualMachine).Zones[0]
+			existingZone := existingVM.Zones[0]
 			if incomingZone != existingZone {
 				// Currently only returning for zones, but osProfile.customData will also return this error
 				errCode := "PropertyChangeNotAllowed"
@@ -159,7 +156,7 @@ ERROR CODE: PropertyChangeNotAllowed
 				}
 			}
 			// Use existing vm rather than restoring
-			return &armcompute.VirtualMachinesClientCreateOrUpdateResponse{VirtualMachine: existingVM.(armcompute.VirtualMachine)}, nil
+			return &armcompute.VirtualMachinesClientCreateOrUpdateResponse{VirtualMachine: existingVM}, nil
 		}
 
 		vm.Name = lo.ToPtr(input.VMName)
@@ -191,7 +188,7 @@ func (c *VirtualMachinesAPI) BeginUpdate(_ context.Context, resourceGroupName st
 		if !ok {
 			return nil, &azcore.ResponseError{StatusCode: http.StatusNotFound}
 		}
-		vm := instance.(armcompute.VirtualMachine)
+		vm := instance
 
 		// If other fields need to be updated in the future, you can similarly
 		// update the VM object by merging with updates.<New Field>.
@@ -239,7 +236,7 @@ func (c *VirtualMachinesAPI) Get(_ context.Context, resourceGroupName string, vm
 			return armcompute.VirtualMachinesClientGetResponse{}, &azcore.ResponseError{StatusCode: http.StatusNotFound}
 		}
 		return armcompute.VirtualMachinesClientGetResponse{
-			VirtualMachine: instance.(armcompute.VirtualMachine),
+			VirtualMachine: instance,
 		}, nil
 	})
 }

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -333,7 +333,7 @@ var _ = Describe("InstanceType Provider", func() {
 				// The nic we used in the vm create, should be cleaned up if the vm call fails
 				nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop()
 				Expect(nic).NotTo(BeNil())
-				_, ok := azureEnv.NetworkInterfacesAPI.NetworkInterfaces.Load(nic.Interface.ID)
+				_, ok := azureEnv.NetworkInterfacesAPI.NetworkInterfaces.Load(lo.FromPtr(nic.Interface.ID))
 				Expect(ok).To(Equal(false))
 
 				azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(nil)
@@ -555,7 +555,7 @@ var _ = Describe("InstanceType Provider", func() {
 				// The nic we used in the vm create, should be cleaned up if the vm call fails
 				nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop()
 				Expect(nic).NotTo(BeNil())
-				_, ok := azureEnv.NetworkInterfacesAPI.NetworkInterfaces.Load(nic.Interface.ID)
+				_, ok := azureEnv.NetworkInterfacesAPI.NetworkInterfaces.Load(lo.FromPtr(nic.Interface.ID))
 				Expect(ok).To(Equal(false))
 
 				azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(nil)
@@ -582,7 +582,7 @@ var _ = Describe("InstanceType Provider", func() {
 				// The nic we used in the vm create, should be cleaned up if the vm call fails
 				nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop()
 				Expect(nic).NotTo(BeNil())
-				_, ok := azureEnv.NetworkInterfacesAPI.NetworkInterfaces.Load(nic.Interface.ID)
+				_, ok := azureEnv.NetworkInterfacesAPI.NetworkInterfaces.Load(lo.FromPtr(nic.Interface.ID))
 				Expect(ok).To(Equal(false))
 
 				azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(nil)
@@ -1748,8 +1748,8 @@ var _ = Describe("InstanceType Provider", func() {
 				standardLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBName, true)
 				internalLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.InternalSLBName, false)
 
-				azureEnv.LoadBalancersAPI.LoadBalancers.Store(standardLB.ID, standardLB)
-				azureEnv.LoadBalancersAPI.LoadBalancers.Store(internalLB.ID, internalLB)
+				azureEnv.LoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
+				azureEnv.LoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(internalLB.ID), internalLB)
 
 				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 				pod := coretest.UnschedulablePod()

--- a/pkg/providers/loadbalancer/suite_test.go
+++ b/pkg/providers/loadbalancer/suite_test.go
@@ -72,9 +72,9 @@ var _ = Describe("LoadBalancer Provider", func() {
 			internalLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.InternalSLBName, false)
 			otherLB := test.MakeStandardLoadBalancer(resourceGroup, "some-lb", true)
 
-			fakeLoadBalancersAPI.LoadBalancers.Store(standardLB.ID, standardLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(internalLB.ID, internalLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(otherLB.ID, otherLB)
+			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
+			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(internalLB.ID), internalLB)
+			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(otherLB.ID), otherLB)
 
 			pools, err := loadBalancerProvider.LoadBalancerBackendPools(ctx)
 			Expect(err).ToNot(HaveOccurred())
@@ -92,10 +92,10 @@ var _ = Describe("LoadBalancer Provider", func() {
 			otherLB := test.MakeStandardLoadBalancer(resourceGroup, "some-lb", true)
 			ipv6LB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBNameIPv6, true)
 
-			fakeLoadBalancersAPI.LoadBalancers.Store(standardLB.ID, standardLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(internalLB.ID, internalLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(otherLB.ID, otherLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(ipv6LB.ID, ipv6LB)
+			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
+			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(internalLB.ID), internalLB)
+			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(otherLB.ID), otherLB)
+			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(ipv6LB.ID), ipv6LB)
 
 			pools, err := loadBalancerProvider.LoadBalancerBackendPools(ctx)
 			Expect(err).ToNot(HaveOccurred())
@@ -118,8 +118,8 @@ var _ = Describe("LoadBalancer Provider", func() {
 			}
 			internalLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.InternalSLBName, false)
 
-			fakeLoadBalancersAPI.LoadBalancers.Store(standardLB.ID, standardLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(internalLB.ID, internalLB)
+			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
+			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(internalLB.ID), internalLB)
 
 			pools, err := loadBalancerProvider.LoadBalancerBackendPools(ctx)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -83,7 +83,7 @@ func ExpectCSEProvisioned(env *test.Environment) armcompute.VirtualMachineExtens
 		GinkgoHelper()
 		cseRaw, ok := env.VirtualMachineExtensionsAPI.Extensions.Load("cse-agent-karpenter")
 		if ok {
-			cse = cseRaw.(armcompute.VirtualMachineExtension)
+			cse = cseRaw
 			return true
 		}
 		return false


### PR DESCRIPTION
Dropped sync.Map in favor a well-typed approach with RWLock and an underlying map[K]V.

**How was this change tested?**

* Unit tests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
