### PR TITLE
fix: refactor instancetypes cache key

### DIFF
--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -117,21 +117,20 @@ func (t TaxBrackets) Calculate(amount float64) float64 {
 	return tax
 }
 
-func NewInstanceType(
+func newInstanceType(
 	ctx context.Context,
 	sku *skewer.SKU,
 	vmsize *skewer.VMSizeType,
-	kc *v1beta1.KubeletConfiguration,
 	region string,
 	offerings cloudprovider.Offerings,
-	nodeClass *v1beta1.AKSNodeClass,
+	params *instanceTypeParameters,
 	architecture string,
 ) *cloudprovider.InstanceType {
 	return &cloudprovider.InstanceType{
 		Name:         sku.GetName(),
-		Requirements: computeRequirements(options.FromContext(ctx), sku, vmsize, architecture, offerings, region, nodeClass),
+		Requirements: computeRequirements(options.FromContext(ctx), sku, vmsize, architecture, offerings, region, params),
 		Offerings:    offerings,
-		Capacity:     computeCapacity(ctx, sku, nodeClass),
+		Capacity:     computeCapacity(ctx, sku, params),
 		Overhead: &cloudprovider.InstanceTypeOverhead{
 			KubeReserved:      KubeReservedResources(lo.Must(sku.VCPU()), lo.Must(sku.Memory())),
 			SystemReserved:    SystemReservedResources(),
@@ -147,7 +146,7 @@ func computeRequirements(
 	architecture string,
 	offerings cloudprovider.Offerings,
 	region string,
-	nodeClass *v1beta1.AKSNodeClass,
+	params *instanceTypeParameters,
 ) scheduling.Requirements {
 	requirements := scheduling.NewRequirements(
 		// Well Known Upstream
@@ -180,7 +179,7 @@ func computeRequirements(
 		scheduling.NewRequirement(v1beta1.AKSLabelMode, corev1.NodeSelectorOpIn, v1beta1.ModeSystem, v1beta1.ModeUser),
 		scheduling.NewRequirement(v1beta1.AKSLabelScaleSetPriority, corev1.NodeSelectorOpIn, v1beta1.ScaleSetPriorityRegular, v1beta1.ScaleSetPrioritySpot),
 		scheduling.NewRequirement(v1beta1.AKSLabelPriority, corev1.NodeSelectorOpIn, v1beta1.PriorityRegular, v1beta1.PrioritySpot),
-		scheduling.NewRequirement(v1beta1.AKSLabelOSSKU, corev1.NodeSelectorOpIn, v1beta1.GetOSSKUFromImageFamily(lo.FromPtr(nodeClass.Spec.ImageFamily))),
+		scheduling.NewRequirement(v1beta1.AKSLabelOSSKU, corev1.NodeSelectorOpIn, v1beta1.GetOSSKUFromImageFamily(params.ImageFamily)),
 		scheduling.NewRequirement(v1beta1.AKSLabelFIPSEnabled, corev1.NodeSelectorOpDoesNotExist), // AKS only sets this label if FIPS is enabled, otherwise it's expected to be empty
 
 		// composites
@@ -210,7 +209,7 @@ func computeRequirements(
 	setRequirementsHyperVGeneration(requirements, sku)
 	setRequirementsGPU(requirements, sku, vmsize)
 	setRequirementsVersion(requirements, vmsize)
-	if lo.FromPtr(nodeClass.Spec.FIPSMode) == v1beta1.FIPSModeFIPS {
+	if params.FIPSMode == v1beta1.FIPSModeFIPS {
 		requirements[v1beta1.AKSLabelFIPSEnabled].Insert("true")
 	}
 
@@ -264,12 +263,12 @@ func getArchitecture(architecture string) string {
 	return architecture // unrecognized
 }
 
-func computeCapacity(ctx context.Context, sku *skewer.SKU, nodeClass *v1beta1.AKSNodeClass) corev1.ResourceList {
+func computeCapacity(ctx context.Context, sku *skewer.SKU, params *instanceTypeParameters) corev1.ResourceList {
 	return corev1.ResourceList{
 		corev1.ResourceCPU:                    *cpu(sku),
 		corev1.ResourceMemory:                 *memoryWithoutOverhead(ctx, sku),
-		corev1.ResourceEphemeralStorage:       *ephemeralStorage(nodeClass),
-		corev1.ResourcePods:                   *pods(ctx, nodeClass),
+		corev1.ResourceEphemeralStorage:       *ephemeralStorage(params),
+		corev1.ResourcePods:                   *pods(params),
 		corev1.ResourceName("nvidia.com/gpu"): *gpuNvidiaCount(sku),
 		corev1.ResourceName("amd.com/gpu"):    *gpuAMDCount(sku),
 	}
@@ -333,13 +332,12 @@ func CalculateMemoryWithoutOverhead(vmMemoryOverheadPercent float64, skuMemoryGi
 	return memory
 }
 
-func ephemeralStorage(nodeClass *v1beta1.AKSNodeClass) *resource.Quantity {
-	return resource.NewScaledQuantity(int64(lo.FromPtr(nodeClass.Spec.OSDiskSizeGB)), resource.Giga)
+func ephemeralStorage(params *instanceTypeParameters) *resource.Quantity {
+	return resource.NewScaledQuantity(int64(params.OSDiskSizeGB), resource.Giga)
 }
 
-func pods(ctx context.Context, nc *v1beta1.AKSNodeClass) *resource.Quantity {
-	networkPlugin, networkPluginMode := options.FromContext(ctx).NetworkPlugin, options.FromContext(ctx).NetworkPluginMode
-	return resource.NewQuantity(int64(utils.GetMaxPods(nc, networkPlugin, networkPluginMode)), resource.DecimalSI)
+func pods(params *instanceTypeParameters) *resource.Quantity {
+	return resource.NewQuantity(int64(params.MaxPods), resource.DecimalSI)
 }
 
 func SystemReservedResources() corev1.ResourceList {

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -56,6 +56,20 @@ const (
 	InstanceTypesCacheTTL = 23 * time.Hour
 )
 
+// instanceTypeParameters contains the resolved set of AKSNodeClass fields that affect
+// instance-type construction. The instance-type cache key is derived by hashing this
+// struct; adding a new field here automatically incorporates it into the key.
+type instanceTypeParameters struct {
+	ImageFamily              string
+	OSDiskSizeGB             int32
+	MaxPods                  int32
+	EncryptionAtHost         bool
+	GPUMode                  v1beta1.GPUMode
+	ArtifactStreamingEnabled bool
+	FIPSMode                 v1beta1.FIPSMode
+	LocalDNSEnabled          bool
+}
+
 type Provider interface {
 	LivenessProbe(*http.Request) error
 	List(context.Context, *v1beta1.AKSNodeClass) ([]*cloudprovider.InstanceType, error)
@@ -122,21 +136,22 @@ func (p *DefaultProvider) List(
 		return nil, fmt.Errorf("no instance types found")
 	}
 
-	kc := nodeClass.Spec.Kubelet
-
 	// Compute fully initialized instance types hash key
-	kcHash, _ := hashstructure.Hash(kc, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
-	key := fmt.Sprintf("%d-%d-%016x-%s-%d-%d-%t-%t-%s-%t",
+	instanceTypeParams := &instanceTypeParameters{
+		ImageFamily:              lo.FromPtr(nodeClass.Spec.ImageFamily),
+		OSDiskSizeGB:             lo.FromPtr(nodeClass.Spec.OSDiskSizeGB),
+		MaxPods:                  utils.GetMaxPods(nodeClass, options.FromContext(ctx).NetworkPlugin, options.FromContext(ctx).NetworkPluginMode),
+		EncryptionAtHost:         nodeClass.GetEncryptionAtHost(),
+		GPUMode:                  nodeClass.GetGPUMode(),
+		ArtifactStreamingEnabled: nodeClass.IsArtifactStreamingExplicitlyEnabled(),
+		FIPSMode:                 lo.FromPtr(nodeClass.Spec.FIPSMode),
+		LocalDNSEnabled:          nodeClass.IsLocalDNSEnabled(),
+	}
+	paramsHash, _ := hashstructure.Hash(instanceTypeParams, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+	key := fmt.Sprintf("%d-%d-%016x",
 		p.instanceTypesSeqNum,
 		p.unavailableOfferings.SeqNum,
-		kcHash,
-		lo.FromPtr(nodeClass.Spec.ImageFamily),
-		lo.FromPtr(nodeClass.Spec.OSDiskSizeGB),
-		utils.GetMaxPods(nodeClass, options.FromContext(ctx).NetworkPlugin, options.FromContext(ctx).NetworkPluginMode),
-		nodeClass.GetEncryptionAtHost(),
-		nodeClass.IsLocalDNSEnabled(),
-		string(nodeClass.GetGPUMode()),
-		nodeClass.IsArtifactStreamingExplicitlyEnabled(),
+		paramsHash,
 	)
 	if item, ok := p.instanceTypesCache.Get(key); ok {
 		// Ensure what's returned from this function is a shallow-copy of the slice (not a deep-copy of the data itself)
@@ -159,16 +174,12 @@ func (p *DefaultProvider) List(
 			continue
 		}
 		instanceTypeZones := p.instanceTypeZones(sku)
-		// !!! Important !!!
-		// Any changes to the values passed into the NewInstanceType method will require making updates to the cache key
-		// so that Karpenter is able to cache the set of InstanceTypes based on values that alter the set of instance types
-		// !!! Important !!!
-		instanceType := NewInstanceType(ctx, sku, vmsize, kc, p.region, p.createOfferings(sku, instanceTypeZones), nodeClass, architecture)
+		instanceType := newInstanceType(ctx, sku, vmsize, p.region, p.createOfferings(sku, instanceTypeZones), instanceTypeParams, architecture)
 		if len(instanceType.Offerings) == 0 {
 			continue
 		}
 
-		if !p.isInstanceTypeSupportedByFilters(sku, architecture, nodeClass) {
+		if !p.isInstanceTypeSupportedByFilters(sku, architecture, instanceTypeParams) {
 			continue
 		}
 
@@ -280,12 +291,12 @@ func (p *DefaultProvider) createOfferings(sku *skewer.SKU, offeringZones sets.Se
 
 // isInstanceTypeSupportedByFilters consolidates all per-NodeClass instance type
 // filters into a single call to keep the List() method's cyclomatic complexity low.
-func (p *DefaultProvider) isInstanceTypeSupportedByFilters(sku *skewer.SKU, architecture string, nodeClass *v1beta1.AKSNodeClass) bool {
-	return p.isInstanceTypeSupportedByImageFamily(sku.GetName(), lo.FromPtr(nodeClass.Spec.ImageFamily)) &&
-		p.isInstanceTypeSupportedByEncryptionAtHost(sku, nodeClass) &&
-		p.isInstanceTypeSupportedByLocalDNS(sku, nodeClass) &&
-		p.isInstanceTypeSupportedByGPUDriverMode(sku, nodeClass) &&
-		p.isInstanceTypeSupportedByArtifactStreaming(architecture, nodeClass)
+func (p *DefaultProvider) isInstanceTypeSupportedByFilters(sku *skewer.SKU, architecture string, params *instanceTypeParameters) bool {
+	return p.isInstanceTypeSupportedByImageFamily(sku.GetName(), params.ImageFamily) &&
+		p.isInstanceTypeSupportedByEncryptionAtHost(sku, params) &&
+		p.isInstanceTypeSupportedByLocalDNS(sku, params) &&
+		p.isInstanceTypeSupportedByGPUDriverMode(sku, params) &&
+		p.isInstanceTypeSupportedByArtifactStreaming(architecture, params)
 }
 
 func (p *DefaultProvider) isInstanceTypeSupportedByImageFamily(skuName, imageFamily string) bool {
@@ -304,9 +315,9 @@ func (p *DefaultProvider) isInstanceTypeSupportedByImageFamily(skuName, imageFam
 	}
 }
 
-func (p *DefaultProvider) isInstanceTypeSupportedByEncryptionAtHost(sku *skewer.SKU, nodeClass *v1beta1.AKSNodeClass) bool {
+func (p *DefaultProvider) isInstanceTypeSupportedByEncryptionAtHost(sku *skewer.SKU, params *instanceTypeParameters) bool {
 	// If EncryptionAtHost is not enabled in the nodeclass, all instance types are supported
-	if !nodeClass.GetEncryptionAtHost() {
+	if !params.EncryptionAtHost {
 		return true
 	}
 	// If EncryptionAtHost is enabled, only include instance types that support it
@@ -322,11 +333,11 @@ func (p *DefaultProvider) supportsEncryptionAtHost(sku *skewer.SKU) bool {
 	return strings.EqualFold(value, "True")
 }
 
-func (p *DefaultProvider) isInstanceTypeSupportedByLocalDNS(sku *skewer.SKU, nodeClass *v1beta1.AKSNodeClass) bool {
+func (p *DefaultProvider) isInstanceTypeSupportedByLocalDNS(sku *skewer.SKU, params *instanceTypeParameters) bool {
 	// Read the resolved state from Status.LocalDNSState. The
 	// nodeclass.localdns sub-reconciler is the sole writer.
 	// If LocalDNS won't be enabled, all instance types are supported
-	if !nodeClass.IsLocalDNSEnabled() {
+	if !params.LocalDNSEnabled {
 		return true
 	}
 
@@ -339,10 +350,10 @@ func (p *DefaultProvider) isInstanceTypeSupportedByLocalDNS(sku *skewer.SKU, nod
 	return memoryMiB(sku) >= 244 // 256 MB = 244.140625 MiB
 }
 
-func (p *DefaultProvider) isInstanceTypeSupportedByGPUDriverMode(sku *skewer.SKU, nodeClass *v1beta1.AKSNodeClass) bool {
+func (p *DefaultProvider) isInstanceTypeSupportedByGPUDriverMode(sku *skewer.SKU, params *instanceTypeParameters) bool {
 	// Only "Driver" mode filters out GPU SKUs without driver installation support.
 	// "None" mode allows all GPU SKUs.
-	if nodeClass.GetGPUMode() != v1beta1.GPUModeDriver {
+	if params.GPUMode != v1beta1.GPUModeDriver {
 		return true
 	}
 	name := sku.GetName()
@@ -357,9 +368,9 @@ func (p *DefaultProvider) isInstanceTypeSupportedByGPUDriverMode(sku *skewer.SKU
 // isInstanceTypeSupportedByArtifactStreaming filters out ARM64 instance types when artifact streaming
 // is explicitly enabled, since ARM64 does not support artifact streaming.
 // When artifact streaming is not set (nil/default) or explicitly disabled, all architectures are allowed.
-func (p *DefaultProvider) isInstanceTypeSupportedByArtifactStreaming(architecture string, nodeClass *v1beta1.AKSNodeClass) bool {
+func (p *DefaultProvider) isInstanceTypeSupportedByArtifactStreaming(architecture string, params *instanceTypeParameters) bool {
 	// Only filter when the user explicitly requested artifact streaming enabled
-	if !nodeClass.IsArtifactStreamingExplicitlyEnabled() {
+	if !params.ArtifactStreamingEnabled {
 		return true
 	}
 	// Artifact streaming is explicitly enabled; exclude ARM64 since it doesn't support it


### PR DESCRIPTION
* Include fips mode in the instance type cache.
* Make the cache key harder to get wrong in the future.

**How was this change tested?**

* Unit tests
* E2E tests: https://github.com/Azure/karpenter-provider-azure/actions/runs/26797869240

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
