### PR TITLE
chore: sync GPU CUDA and GRID driver versions from AgentBaker

### DIFF
--- a/pkg/utils/gpu.go
+++ b/pkg/utils/gpu.go
@@ -28,12 +28,12 @@ import (
 const (
 	Nvidia470CudaDriverVersion = "470.82.01"
 
-	// https://github.com/Azure/AgentBaker/blob/c0e684e5cecebcf61554cc7d2e2d2191972d35ed/parts/common/components.json#L797-L811
-	NvidiaCudaDriverVersion = "550.144.03"
-	AKSGPUCudaVersionSuffix = "20250328201547"
+	// https://github.com/Azure/AgentBaker/blob/12d432b5fea64a6cda718df6e1ab851211b49c74/parts/common/components.json#L740-L752
+	NvidiaCudaDriverVersion = "580.126.09"
+	AKSGPUCudaVersionSuffix = "20260126030251"
 
-	NvidiaGridDriverVersion = "550.144.06"
-	AKSGPUGridVersionSuffix = "20250512225043"
+	NvidiaGridDriverVersion = "570.211.01"
+	AKSGPUGridVersionSuffix = "20260522192315"
 )
 
 type GPUSKUInfo struct {


### PR DESCRIPTION
Fixes # <!-- N/A -->

**Description**

The hardcoded NVIDIA GPU driver constants in `pkg/utils/gpu.go` had drifted behind AgentBaker, the upstream source of truth (per the existing `// TODO: Get these from agentbaker` comment). This PR syncs both the CUDA and GRID driver versions (and their `aks-gpu` image suffixes) to AgentBaker's current `parts/common/components.json`:

- **CUDA:** `550.144.03-20250328201547` → `580.126.09-20260126030251`
- **GRID:** `570` series — `550.144.06-20250512225043` → `570.211.01-20260522192315`

These constants feed `GetGPUDriverVersion` and `GetAKSGPUImageSHA`, which drive the GPU driver version and `aks-gpu` image SHA used by the custom-scripts bootstrap path. The reference permalink in the comment is also updated to the current AgentBaker commit.

**How was this change tested?**

* `go build ./pkg/utils/...` — passes
* `go test ./pkg/utils/` — passes (`ok github.com/Azure/karpenter-provider-azure/pkg/utils`)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

**Release Note**

```release-note
Update bundled NVIDIA GPU driver versions to match AgentBaker: CUDA 580.126.09 and GRID 570.211.01.
```
