### PR TITLE
feat: add Dals_v5 (Standard_D*als_v5) SKUs to known SKUs allowlist

### DIFF
--- a/pkg/providers/instancetype/known_skus.yaml
+++ b/pkg/providers/instancetype/known_skus.yaml
@@ -248,6 +248,9 @@
 - name: Standard_D16alds_v7
   family: StandardDaldsv7Family
   discoveredOn: "2026-03-31"
+- name: Standard_D16als_v5
+  family: standardDALSv5Family
+  discoveredOn: "2025-05-15"
 - name: Standard_D16als_v6
   family: standardDalv6Family
   discoveredOn: "2025-05-15"
@@ -374,6 +377,9 @@
 - name: Standard_D2alds_v7
   family: StandardDaldsv7Family
   discoveredOn: "2026-03-31"
+- name: Standard_D2als_v5
+  family: standardDALSv5Family
+  discoveredOn: "2025-05-15"
 - name: Standard_D2als_v6
   family: standardDalv6Family
   discoveredOn: "2025-05-15"
@@ -485,6 +491,9 @@
 - name: Standard_D32alds_v7
   family: StandardDaldsv7Family
   discoveredOn: "2026-03-31"
+- name: Standard_D32als_v5
+  family: standardDALSv5Family
+  discoveredOn: "2025-05-15"
 - name: Standard_D32als_v6
   family: standardDalv6Family
   discoveredOn: "2025-05-15"
@@ -602,6 +611,9 @@
 - name: Standard_D48alds_v7
   family: StandardDaldsv7Family
   discoveredOn: "2026-03-31"
+- name: Standard_D48als_v5
+  family: standardDALSv5Family
+  discoveredOn: "2025-05-15"
 - name: Standard_D48als_v6
   family: standardDalv6Family
   discoveredOn: "2025-05-15"
@@ -716,6 +728,9 @@
 - name: Standard_D4alds_v7
   family: StandardDaldsv7Family
   discoveredOn: "2026-03-31"
+- name: Standard_D4als_v5
+  family: standardDALSv5Family
+  discoveredOn: "2025-05-15"
 - name: Standard_D4als_v6
   family: standardDalv6Family
   discoveredOn: "2025-05-15"
@@ -830,6 +845,9 @@
 - name: Standard_D64alds_v7
   family: StandardDaldsv7Family
   discoveredOn: "2026-03-31"
+- name: Standard_D64als_v5
+  family: standardDALSv5Family
+  discoveredOn: "2025-05-15"
 - name: Standard_D64als_v6
   family: standardDalv6Family
   discoveredOn: "2025-05-15"
@@ -938,6 +956,9 @@
 - name: Standard_D8alds_v7
   family: StandardDaldsv7Family
   discoveredOn: "2026-03-31"
+- name: Standard_D8als_v5
+  family: standardDALSv5Family
+  discoveredOn: "2025-05-15"
 - name: Standard_D8als_v6
   family: standardDalv6Family
   discoveredOn: "2025-05-15"
@@ -1040,6 +1061,9 @@
 - name: Standard_D96alds_v7
   family: StandardDaldsv7Family
   discoveredOn: "2026-03-31"
+- name: Standard_D96als_v5
+  family: standardDALSv5Family
+  discoveredOn: "2025-05-15"
 - name: Standard_D96als_v6
   family: standardDalv6Family
   discoveredOn: "2025-05-15"


### PR DESCRIPTION
Add the AMD low-memory diskless D-series v5 family (standardDALSv5Family) to the embedded known_skus.yaml allowlist so Karpenter/NAP can provision Standard_D{2,4,8,16,32,48,64,96}als_v5 instances.

These SKUs are GA and physically available but were missing from the generated allowlist. Added manually (additive only) because hack/codegen.sh requires live Azure API credentials to regenerate.

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
