### PR TITLE
fix(ci): temp pre-pull base images for skaffold/ko build

### DIFF
--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -40,7 +40,8 @@ runs:
       # space than the OS disk. 1ES pool VMs can run out of disk on / during large builds.
       GOTMPDIR: /mnt/go-tmp
       GOCACHE: /mnt/go-cache
+      KOCACHE: /mnt/ko-cache
     run: |
-      sudo mkdir -p "$GOTMPDIR" "$GOCACHE"
-      sudo chown "$(id -u):$(id -g)" "$GOTMPDIR" "$GOCACHE"
+      sudo mkdir -p "$GOTMPDIR" "$GOCACHE" "$KOCACHE"
+      sudo chown "$(id -u):$(id -g)" "$GOTMPDIR" "$GOCACHE" "$KOCACHE"
       make ci-install

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -31,6 +31,7 @@ CUSTOM_SUBNET_NAME ?= nodesubnet
 
 PROVISION_MODE ?= aksscriptless
 AKS_MACHINES_POOL_NAME ?= testmpool
+# pre-pull base images for skaffold/ko build, as a workaround for https://github.com/GoogleContainerTools/skaffold/issues/10106
 KO_BASE_IMAGE ?= mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:138fe2905465e384b232ffe8ba3147de04c633a83f29d8df00d6817e3eacb0d2
 KO_BASE_IMAGE_AMD64 ?= mcr.microsoft.com/azurelinux/distroless/minimal@sha256:fbe9982049f312a0ae6421599b0a33629369c919abe3564893a5405776fc6266
 KO_BASE_IMAGE_ARM64 ?= mcr.microsoft.com/azurelinux/distroless/minimal@sha256:ffcf415e6a14221e4d91b29445e33650062650095569407ea29a4315983721df

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -339,6 +339,8 @@ az-aks-check-acr:
 
 az-build: ## Build the Karpenter controller and webhook images using skaffold build (which uses ko build)
 	az acr login -n $(AZURE_ACR_NAME)
+	# https://github.com/GoogleContainerTools/skaffold/issues/10106
+	docker pull mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:138fe2905465e384b232ffe8ba3147de04c633a83f29d8df00d6817e3eacb0d2
 	skaffold build
 
 az-creds: ## Get cluster credentials

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -31,6 +31,10 @@ CUSTOM_SUBNET_NAME ?= nodesubnet
 
 PROVISION_MODE ?= aksscriptless
 AKS_MACHINES_POOL_NAME ?= testmpool
+KO_BASE_IMAGE ?= mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:138fe2905465e384b232ffe8ba3147de04c633a83f29d8df00d6817e3eacb0d2
+KO_BASE_IMAGE_AMD64 ?= mcr.microsoft.com/azurelinux/distroless/minimal@sha256:fbe9982049f312a0ae6421599b0a33629369c919abe3564893a5405776fc6266
+KO_BASE_IMAGE_ARM64 ?= mcr.microsoft.com/azurelinux/distroless/minimal@sha256:ffcf415e6a14221e4d91b29445e33650062650095569407ea29a4315983721df
+export KOCACHE ?= $(or $(RUNNER_TEMP),/tmp)/ko-cache
 
 .DEFAULT_GOAL := help	# make without arguments will show help
 
@@ -339,9 +343,14 @@ az-aks-check-acr:
 
 az-build: ## Build the Karpenter controller and webhook images using skaffold build (which uses ko build)
 	az acr login -n $(AZURE_ACR_NAME)
-	# https://github.com/GoogleContainerTools/skaffold/issues/10106
-	docker pull mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:138fe2905465e384b232ffe8ba3147de04c633a83f29d8df00d6817e3eacb0d2
+	$(MAKE) az-ko-prewarm-base
 	skaffold build
+
+az-ko-prewarm-base: ## Prewarm ko's base image cache for skaffold/ko builds
+	mkdir -p $(KOCACHE)
+	crane pull --format=oci $(KO_BASE_IMAGE) $(KOCACHE)/img
+	crane pull --format=oci $(KO_BASE_IMAGE_AMD64) $(KOCACHE)/img
+	crane pull --format=oci $(KO_BASE_IMAGE_ARM64) $(KOCACHE)/img
 
 az-creds: ## Get cluster credentials
 	az aks get-credentials --name $(AZURE_CLUSTER_NAME) --resource-group $(AZURE_RESOURCE_GROUP) --overwrite-existing


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Temporarily pre-pull base MCR images for skaffold/ko build with crane, to work around https://github.com/GoogleContainerTools/skaffold/issues/10106. Crane/ko compatibility comes from using the same library ecosystem (google/go-containerregistry), ko image cache location ($KOCACHE/img) from ko source. 

Same build logic used for local development, but should be harmless. Could also switch to different base temporarily. To be removed once fixed on either skaffold or MCR side.

**How was this change tested?**

* [E2E · Azure/karpenter-provider-azure@0549b9c](https://github.com/Azure/karpenter-provider-azure/actions/runs/27428526839)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
