### PR TITLE
feat: support dual-stack (IPv4 + IPv6) clusters for self-hosted nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Karpenter provider for AKS can be used in two modes:
 The following AKS features are not supported:
 * Windows nodes.
 * Kubenet and Calico.
-* IPv6 clusters.
+* Single-stack IPv6 clusters. Dual-stack (IPv4 + IPv6) Azure CNI clusters are supported, and nodes provisioned by Karpenter are configured with both IPv4 and IPv6 addresses.
 * [Service Principal](https://learn.microsoft.com/azure/aks/kubernetes-service-principal) based clusters. A system-assigned or user-assigned managed identity must be used.
 * Clusters running Karpenter should not be [stopped](https://learn.microsoft.com/azure/aks/start-stop-cluster).
 * All cluster egress [outbound types](https://learn.microsoft.com/azure/aks/egress-outboundtype) are supported, however the type can't be changed after the cluster is created.

--- a/hack/deploy/configure-values.sh
+++ b/hack/deploy/configure-values.sh
@@ -72,6 +72,8 @@ NETWORK_PLUGIN=$(jq -r ".networkProfile.networkPlugin // empty | if . == \"none\
 NETWORK_PLUGIN_MODE=$(jq -r ".networkProfile.networkPluginMode // empty | if . == \"none\" then \"\" else . end" <<< "$AKS_JSON")
 NETWORK_POLICY=$(jq -r ".networkProfile.networkPolicy // empty | if . == \"none\" then \"\" else . end" <<< "$AKS_JSON")
 NETWORK_DATAPLANE=$(jq -r ".networkProfile.networkDataplane // empty | if . == \"none\" then \"\" else . end" <<< "$AKS_JSON")
+# Cluster IP families (e.g. ["IPv4"] or ["IPv4","IPv6"] for dual-stack), joined as a CSV.
+NODE_IP_FAMILIES=$(jq -r '(.networkProfile.ipFamilies // ["IPv4"]) | join(",")' <<< "$AKS_JSON")
 
 NODE_IDENTITIES=$(jq -r ".identityProfile.kubeletidentity.resourceId" <<< "$AKS_JSON")
 
@@ -87,7 +89,7 @@ if [[ "${PROVISION_MODE:-}" == "aksmachineapi" || "${PROVISION_MODE:-}" == "aksm
 fi
 
 export CLUSTER_NAME AZURE_LOCATION AZURE_RESOURCE_GROUP AZURE_RESOURCE_GROUP_MC KARPENTER_SERVICE_ACCOUNT_NAME \
-    CLUSTER_ENDPOINT BOOTSTRAP_TOKEN SSH_PUBLIC_KEY VNET_SUBNET_ID KARPENTER_USER_ASSIGNED_CLIENT_ID NODE_IDENTITIES AZURE_SUBSCRIPTION_ID NETWORK_PLUGIN NETWORK_PLUGIN_MODE NETWORK_POLICY NETWORK_DATAPLANE \
+    CLUSTER_ENDPOINT BOOTSTRAP_TOKEN SSH_PUBLIC_KEY VNET_SUBNET_ID KARPENTER_USER_ASSIGNED_CLIENT_ID NODE_IDENTITIES AZURE_SUBSCRIPTION_ID NETWORK_PLUGIN NETWORK_PLUGIN_MODE NETWORK_POLICY NETWORK_DATAPLANE NODE_IP_FAMILIES \
     LOG_LEVEL VNET_GUID KUBELET_IDENTITY_CLIENT_ID ENABLE_AZURE_SDK_LOGGING PROVISION_MODE USE_SIG AZURE_SIG_SUBSCRIPTION_ID AKS_MACHINES_POOL_NAME
 
 # get karpenter-values-template.yaml, if not already present (e.g. outside of repo context)

--- a/karpenter-values-template.yaml
+++ b/karpenter-values-template.yaml
@@ -30,6 +30,8 @@ controller:
       value: ${VNET_GUID}
     - name: NODE_IDENTITIES
       value: ${NODE_IDENTITIES}
+    - name: NODE_IP_FAMILIES
+      value: ${NODE_IP_FAMILIES}
 
     # Azure client settings
     - name: AZURE_SUBSCRIPTION_ID

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -59,6 +59,25 @@ func (s *nodeIdentitiesValue) Get() any { return []string(*s) }
 
 func (s *nodeIdentitiesValue) String() string { return strings.Join(*s, ",") }
 
+type nodeIPFamiliesValue []string
+
+func newNodeIPFamiliesValue(val string, p *[]string) *nodeIPFamiliesValue {
+	*p = []string{}
+	if val != "" {
+		*p = strings.Split(val, ",")
+	}
+	return (*nodeIPFamiliesValue)(p)
+}
+
+func (s *nodeIPFamiliesValue) Set(val string) error {
+	*s = nodeIPFamiliesValue(strings.Split(val, ","))
+	return nil
+}
+
+func (s *nodeIPFamiliesValue) Get() any { return []string(*s) }
+
+func (s *nodeIPFamiliesValue) String() string { return strings.Join(*s, ",") }
+
 type optionsKey struct{}
 
 type Options struct {
@@ -79,6 +98,7 @@ type Options struct {
 	KubeletIdentityClientID string   `json:"kubeletIdentityClientID,omitempty"` // => Flows to bootstrap and used in drift
 	VnetGUID                string   `json:"vnetGuid,omitempty"`                // resource guid used by azure cni for identifying the right vnet
 	SubnetID                string   `json:"subnetId,omitempty"`                // => VnetSubnetID to use (for nodes in Azure CNI Overlay and Azure CNI + pod subnet; for for nodes and pods in Azure CNI), unless overridden via AKSNodeClass
+	NodeIPFamilies          []string `json:"nodeIPFamilies,omitempty"`          // => The cluster IP families (IPv4, IPv6). Determines whether provisioned nodes are dual-stack. Mirrors the cluster networkProfile.ipFamilies.
 	setFlags                map[string]bool
 
 	ProvisionMode              string            `json:"provisionMode,omitempty"`
@@ -118,6 +138,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.VnetGUID, "vnet-guid", env.WithDefaultString("VNET_GUID", ""), "The vnet guid of the clusters vnet, only required by azure cni with overlay + byo vnet")
 	fs.StringVar(&o.SubnetID, "vnet-subnet-id", env.WithDefaultString("VNET_SUBNET_ID", ""), "[REQUIRED] The default subnet ID to use for new nodes. This must be a valid ARM resource ID for subnet that does not overlap with the service CIDR or the pod CIDR.")
 	fs.Var(newNodeIdentitiesValue(env.WithDefaultString("NODE_IDENTITIES", ""), &o.NodeIdentities), "node-identities", "User assigned identities for nodes.")
+	fs.Var(newNodeIPFamiliesValue(env.WithDefaultString("NODE_IP_FAMILIES", "IPv4"), &o.NodeIPFamilies), "node-ip-families", "Comma-separated cluster IP families (IPv4, IPv6). Set to \"IPv4,IPv6\" for dual-stack clusters; mirrors the cluster networkProfile.ipFamilies.")
 	fs.StringVar(&o.ProvisionMode, "provision-mode", env.WithDefaultString("PROVISION_MODE", consts.ProvisionModeAKSScriptless), "[UNSUPPORTED] The provision mode for the cluster.")
 	fs.StringVar(&o.NodeBootstrappingServerURL, "nodebootstrapping-server-url", env.WithDefaultString("NODEBOOTSTRAPPING_SERVER_URL", ""), "[UNSUPPORTED] The url for the node bootstrapping provider server.")
 	fs.StringVar(&o.NodeResourceGroup, "node-resource-group", env.WithDefaultString("AZURE_NODE_RESOURCE_GROUP", ""), "[REQUIRED] the resource group created and managed by AKS where the nodes live")

--- a/pkg/operator/options/options_extensions.go
+++ b/pkg/operator/options/options_extensions.go
@@ -17,11 +17,25 @@ limitations under the License.
 package options
 
 import (
+	"strings"
+
 	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 )
 
 func (o *Options) IsAzureCNIOverlay() bool {
 	return o.NetworkPlugin == consts.NetworkPluginAzure && o.NetworkPluginMode == consts.NetworkPluginModeOverlay
+}
+
+// IsIPv6Enabled reports whether the cluster is dual-stack (its IP families include IPv6),
+// in which case provisioned nodes must be configured with an IPv6 NIC IP configuration.
+// Mirrors the AKS RP's IsIPv6Enabled signal, which is derived from networkProfile.ipFamilies.
+func (o *Options) IsIPv6Enabled() bool {
+	for _, family := range o.NodeIPFamilies {
+		if strings.EqualFold(family, "IPv6") {
+			return true
+		}
+	}
+	return false
 }
 
 func (o *Options) IsCiliumNodeSubnet() bool {

--- a/pkg/operator/options/options_extensions_test.go
+++ b/pkg/operator/options/options_extensions_test.go
@@ -1,0 +1,47 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options_test
+
+import (
+	"testing"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
+	. "github.com/onsi/gomega"
+)
+
+func TestIsIPv6Enabled(t *testing.T) {
+	cases := []struct {
+		name       string
+		ipFamilies []string
+		expected   bool
+	}{
+		{name: "nil families", ipFamilies: nil, expected: false},
+		{name: "empty families", ipFamilies: []string{}, expected: false},
+		{name: "IPv4 only", ipFamilies: []string{"IPv4"}, expected: false},
+		{name: "dual-stack IPv4,IPv6", ipFamilies: []string{"IPv4", "IPv6"}, expected: true},
+		{name: "IPv6 only", ipFamilies: []string{"IPv6"}, expected: true},
+		{name: "case-insensitive ipv6", ipFamilies: []string{"ipv4", "ipv6"}, expected: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			g := NewWithT(t)
+			opts := &options.Options{NodeIPFamilies: c.ipFamilies}
+			g.Expect(opts.IsIPv6Enabled()).To(Equal(c.expected))
+		})
+	}
+}

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Options", func() {
 		"NETWORK_POLICY",
 		"DNS_SERVICE_IP",
 		"NODE_IDENTITIES",
+		"NODE_IP_FAMILIES",
 		"PROVISION_MODE",
 		"NODEBOOTSTRAPPING_SERVER_URL",
 		"VNET_GUID",
@@ -114,6 +115,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("NETWORK_POLICY", "env-network-policy")
 			os.Setenv("DNS_SERVICE_IP", "10.244.0.1")
 			os.Setenv("NODE_IDENTITIES", "/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/envid1,/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/envid2")
+			os.Setenv("NODE_IP_FAMILIES", "IPv4,IPv6")
 			os.Setenv("VNET_SUBNET_ID", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub")
 			os.Setenv("PROVISION_MODE", "bootstrappingclient")
 			os.Setenv("NODEBOOTSTRAPPING_SERVER_URL", "https://nodebootstrapping-server-url")
@@ -145,6 +147,7 @@ var _ = Describe("Options", func() {
 				NetworkPolicy:                  lo.ToPtr("env-network-policy"),
 				SubnetID:                       lo.ToPtr("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub"),
 				NodeIdentities:                 []string{"/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/envid1", "/subscriptions/1234/resourceGroups/mcrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/envid2"},
+				NodeIPFamilies:                 []string{"IPv4", "IPv6"},
 				ProvisionMode:                  lo.ToPtr("bootstrappingclient"),
 				NodeBootstrappingServerURL:     lo.ToPtr("https://nodebootstrapping-server-url"),
 				VnetGUID:                       lo.ToPtr("a519e60a-cac0-40b2-b883-084477fe6f5c"),

--- a/pkg/providers/imagefamily/azlinux.go
+++ b/pkg/providers/imagefamily/azlinux.go
@@ -153,6 +153,7 @@ func (u AzureLinux) ScriptlessCustomData(
 		NetworkPlugin:                  u.Options.NetworkPlugin,
 		NetworkPolicy:                  u.Options.NetworkPolicy,
 		KubernetesVersion:              u.Options.KubernetesVersion,
+		IsIPv6Enabled:                  u.Options.IsIPv6Enabled,
 	}
 }
 

--- a/pkg/providers/imagefamily/azlinux3.go
+++ b/pkg/providers/imagefamily/azlinux3.go
@@ -165,6 +165,7 @@ func (u AzureLinux3) ScriptlessCustomData(
 		NetworkPlugin:                  u.Options.NetworkPlugin,
 		NetworkPolicy:                  u.Options.NetworkPolicy,
 		KubernetesVersion:              u.Options.KubernetesVersion,
+		IsIPv6Enabled:                  u.Options.IsIPv6Enabled,
 	}
 }
 

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -47,6 +47,7 @@ type AKS struct {
 	NetworkPlugin                  string
 	NetworkPolicy                  string
 	KubernetesVersion              string
+	IsIPv6Enabled                  bool
 }
 
 var _ Bootstrapper = (*AKS)(nil) // assert AKS implements Bootstrapper
@@ -293,6 +294,7 @@ func (a AKS) applyOptions(nbv *NodeBootstrapVariables) {
 
 	nbv.NetworkPolicy = a.NetworkPolicy
 	nbv.KubernetesVersion = a.KubernetesVersion
+	nbv.IPv6DualStackEnabled = a.IsIPv6Enabled
 
 	nbv.KubeBinaryURL = kubeBinaryURL(a.KubernetesVersion, a.Arch)
 	nbv.VNETCNILinuxPluginsURL = fmt.Sprintf("%s/azure-cni/v1.4.32/binaries/azure-vnet-cni-linux-%s-v1.4.32.tgz", globalAKSMirror, a.Arch)

--- a/pkg/providers/imagefamily/ubuntu_2004.go
+++ b/pkg/providers/imagefamily/ubuntu_2004.go
@@ -116,6 +116,7 @@ func (u Ubuntu2004) ScriptlessCustomData(
 		NetworkPlugin:                  u.Options.NetworkPlugin,
 		NetworkPolicy:                  u.Options.NetworkPolicy,
 		KubernetesVersion:              u.Options.KubernetesVersion,
+		IsIPv6Enabled:                  u.Options.IsIPv6Enabled,
 	}
 }
 

--- a/pkg/providers/imagefamily/ubuntu_2204.go
+++ b/pkg/providers/imagefamily/ubuntu_2204.go
@@ -128,6 +128,7 @@ func (u Ubuntu2204) ScriptlessCustomData(
 		NetworkPlugin:                  u.Options.NetworkPlugin,
 		NetworkPolicy:                  u.Options.NetworkPolicy,
 		KubernetesVersion:              u.Options.KubernetesVersion,
+		IsIPv6Enabled:                  u.Options.IsIPv6Enabled,
 	}
 }
 

--- a/pkg/providers/imagefamily/ubuntu_2404.go
+++ b/pkg/providers/imagefamily/ubuntu_2404.go
@@ -128,6 +128,7 @@ func (u Ubuntu2404) ScriptlessCustomData(
 		NetworkPlugin:                  u.Options.NetworkPlugin,
 		NetworkPolicy:                  u.Options.NetworkPolicy,
 		KubernetesVersion:              u.Options.KubernetesVersion,
+		IsIPv6Enabled:                  u.Options.IsIPv6Enabled,
 	}
 }
 

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -524,6 +524,61 @@ var _ = Describe("VMInstanceProvider", func() {
 
 			Expect(len(nic.Properties.IPConfigurations)).To(Equal(11))
 		})
+		It("should add a non-primary IPv6 ip config on dual-stack Azure CNI Overlay", func() {
+			ctx = options.ToContext(
+				ctx,
+				test.Options(test.OptionsFields{
+					NetworkPlugin:     lo.ToPtr(consts.NetworkPluginAzure),
+					NetworkPluginMode: lo.ToPtr(consts.NetworkPluginModeOverlay),
+					NodeIPFamilies:    []string{"IPv4", "IPv6"},
+				}))
+
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+
+			pod := coretest.UnschedulablePod(coretest.PodOptions{})
+			ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
+			ExpectScheduled(ctx, env.Client, pod)
+
+			Expect(azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop().Interface
+			Expect(nic).ToNot(BeNil())
+
+			// Overlay = 1 primary IPv4 ipConfig + 1 non-primary IPv6 ipConfig.
+			Expect(len(nic.Properties.IPConfigurations)).To(Equal(2))
+			ipv6Config, found := lo.Find(nic.Properties.IPConfigurations, func(c *armnetwork.InterfaceIPConfiguration) bool {
+				return c.Properties != nil && c.Properties.PrivateIPAddressVersion != nil &&
+					*c.Properties.PrivateIPAddressVersion == armnetwork.IPVersionIPv6
+			})
+			Expect(found).To(BeTrue(), "expected an IPv6 ip configuration on the NIC")
+			Expect(lo.FromPtr(ipv6Config.Name)).To(Equal("ipv6config"))
+			Expect(lo.FromPtr(ipv6Config.Properties.Primary)).To(BeFalse())
+		})
+		It("should not add an IPv6 ip config on single-stack (IPv4-only) clusters", func() {
+			ctx = options.ToContext(
+				ctx,
+				test.Options(test.OptionsFields{
+					NetworkPlugin:     lo.ToPtr(consts.NetworkPluginAzure),
+					NetworkPluginMode: lo.ToPtr(consts.NetworkPluginModeOverlay),
+					NodeIPFamilies:    []string{"IPv4"},
+				}))
+
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+
+			pod := coretest.UnschedulablePod(coretest.PodOptions{})
+			ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
+			ExpectScheduled(ctx, env.Client, pod)
+
+			Expect(azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			nic := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop().Interface
+			Expect(nic).ToNot(BeNil())
+
+			Expect(len(nic.Properties.IPConfigurations)).To(Equal(1))
+			_, found := lo.Find(nic.Properties.IPConfigurations, func(c *armnetwork.InterfaceIPConfiguration) bool {
+				return c.Properties != nil && c.Properties.PrivateIPAddressVersion != nil &&
+					*c.Properties.PrivateIPAddressVersion == armnetwork.IPVersionIPv6
+			})
+			Expect(found).To(BeFalse(), "expected no IPv6 ip configuration on a single-stack cluster")
+		})
 	})
 
 	It("should create VM and NIC with valid ARM tags", func() {

--- a/pkg/providers/instance/vminstance.go
+++ b/pkg/providers/instance/vminstance.go
@@ -503,6 +503,32 @@ func (p *DefaultVMProvider) newNetworkInterfaceForVM(opts *createNICOptions) arm
 			)
 		}
 	}
+
+	// On dual-stack clusters, add a single non-primary IPv6 IP configuration. A NIC can only
+	// have one IPv6 ipConfig, so this is added once, outside the secondary-IP loop above.
+	// The IPv6 outbound LB backend pool (if any) is attached here, not on the primary IPv4
+	// config. Mirrors the AKS RP node NIC construction. The subnet is applied later by
+	// applyTemplateToNic to every ipConfig (IPv4 and IPv6 share the node subnet).
+	if opts.IsIPv6Enabled {
+		var ipv6BackendPools []*armnetwork.BackendAddressPool
+		for _, poolID := range opts.BackendPools.IPv6PoolIDs {
+			ipv6BackendPools = append(ipv6BackendPools, &armnetwork.BackendAddressPool{
+				ID: lo.ToPtr(poolID),
+			})
+		}
+		nic.Properties.IPConfigurations = append(
+			nic.Properties.IPConfigurations,
+			&armnetwork.InterfaceIPConfiguration{
+				Name: lo.ToPtr("ipv6config"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					Primary:                         lo.ToPtr(false),
+					PrivateIPAllocationMethod:       lo.ToPtr(armnetwork.IPAllocationMethodDynamic),
+					PrivateIPAddressVersion:         lo.ToPtr(armnetwork.IPVersionIPv6),
+					LoadBalancerBackendAddressPools: ipv6BackendPools,
+				},
+			},
+		)
+	}
 	return nic
 }
 
@@ -520,6 +546,7 @@ type createNICOptions struct {
 	NetworkPluginMode      string
 	MaxPods                int32
 	NetworkSecurityGroupID string
+	IsIPv6Enabled          bool
 }
 
 func (p *DefaultVMProvider) createNetworkInterface(ctx context.Context, opts *createNICOptions) (string, error) {
@@ -797,6 +824,7 @@ func (p *DefaultVMProvider) beginLaunchInstance(
 			BackendPools:           backendPools,
 			InstanceType:           instanceType,
 			NetworkSecurityGroupID: nsgID,
+			IsIPv6Enabled:          options.FromContext(ctx).IsIPv6Enabled(),
 		},
 	)
 	if err != nil {

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -198,6 +198,7 @@ func (p *Provider) getStaticParameters(
 		NetworkPolicy:                  options.FromContext(ctx).NetworkPolicy,
 		SubnetID:                       subnetID,
 		ClusterResourceGroup:           p.clusterResourceGroup,
+		IsIPv6Enabled:                  options.FromContext(ctx).IsIPv6Enabled(),
 	}, nil
 }
 

--- a/pkg/providers/launchtemplate/parameters/types.go
+++ b/pkg/providers/launchtemplate/parameters/types.go
@@ -49,6 +49,7 @@ type StaticParameters struct {
 	KubernetesVersion              string
 	SubnetID                       string
 	ClusterResourceGroup           string
+	IsIPv6Enabled                  bool
 
 	Labels map[string]string
 }

--- a/pkg/providers/loadbalancer/loadbalancer.go
+++ b/pkg/providers/loadbalancer/loadbalancer.go
@@ -65,7 +65,7 @@ type Provider struct {
 
 type BackendAddressPools struct {
 	IPv4PoolIDs []string
-	IPv6PoolIDs []string // TODO: This is always empty currently
+	IPv6PoolIDs []string // Populated only on dual-stack clusters; attached to a non-primary IPv6 NIC ipConfig.
 }
 
 // NewProvider creates a new LoadBalancer provider
@@ -87,22 +87,29 @@ func (p *Provider) LoadBalancerBackendPools(ctx context.Context) (*BackendAddres
 	}
 
 	backendAddressPools := lo.FlatMap(loadBalancers, extractBackendAddressPools)
-	ipv4PoolIDs := lo.FilterMap(backendAddressPools, func(backendPool *armnetwork.BackendAddressPool, idx int) (string, bool) {
+	var ipv4PoolIDs, ipv6PoolIDs []string
+	for idx, backendPool := range backendAddressPools {
 		if !isBackendAddressPoolApplicable(backendPool, idx) {
-			return "", false
+			continue
 		}
+		if isIPv6BackendPool(backendPool) {
+			ipv6PoolIDs = append(ipv6PoolIDs, lo.FromPtr(backendPool.ID))
+		} else {
+			ipv4PoolIDs = append(ipv4PoolIDs, lo.FromPtr(backendPool.ID))
+		}
+	}
 
-		return lo.FromPtr(backendPool.ID), true
-	})
-
-	log.FromContext(ctx).V(1).Info("returning IPv4 backend pools", "ipv4PoolCount", len(ipv4PoolIDs), "ipv4PoolIDs", ipv4PoolIDs)
+	log.FromContext(ctx).V(1).Info("returning backend pools",
+		"ipv4PoolCount", len(ipv4PoolIDs), "ipv4PoolIDs", ipv4PoolIDs,
+		"ipv6PoolCount", len(ipv6PoolIDs), "ipv6PoolIDs", ipv6PoolIDs)
 
 	// RP only actually assigns the LB backend pools to VMs if OutboundType is LoadBalancer,
 	// but that's also the only OutboundType which creates the LoadBalancer, so as long as we're not allowing
 	// OutboundType changes, we can just infer that if the LBs exist we should assign them.
+	// IPv6 pools are only present (and only assigned) on dual-stack clusters.
 	return &BackendAddressPools{
 		IPv4PoolIDs: ipv4PoolIDs,
-		// TODO: IPv6 deferred for now. When they're used they must be put onto a non-primary NIC.
+		IPv6PoolIDs: ipv6PoolIDs,
 	}, nil
 }
 
@@ -164,12 +171,6 @@ func isBackendAddressPoolApplicable(backendPool *armnetwork.BackendAddressPool, 
 		return false // shouldn't ever happen
 	}
 
-	name := *backendPool.Name
-	// Ignore well-known named ipv6 pools for now
-	if strings.EqualFold(name, SLBOutboundBackendPoolNameIPv6) || strings.EqualFold(name, SLBInboundBackendPoolNameIPv6) {
-		return false
-	}
-
 	// Ignore IP-based pools, which are a thing in NodeIP mode. We don't need to assign these pools.
 	// See isIPBasedBackendPool in RP.
 	for _, backendAddress := range backendPool.Properties.LoadBalancerBackendAddresses {
@@ -183,4 +184,11 @@ func isBackendAddressPoolApplicable(backendPool *armnetwork.BackendAddressPool, 
 	}
 
 	return true
+}
+
+// isIPv6BackendPool reports whether the backend pool is an IPv6 pool, based on its well-known
+// AKS name. IPv6 pools must be attached to the IPv6 (non-primary) NIC IP configuration.
+func isIPv6BackendPool(backendPool *armnetwork.BackendAddressPool) bool {
+	name := lo.FromPtr(backendPool.Name)
+	return strings.EqualFold(name, SLBOutboundBackendPoolNameIPv6) || strings.EqualFold(name, SLBInboundBackendPoolNameIPv6)
 }

--- a/pkg/providers/loadbalancer/suite_test.go
+++ b/pkg/providers/loadbalancer/suite_test.go
@@ -86,25 +86,26 @@ var _ = Describe("LoadBalancer Provider", func() {
 			Expect(pools.IPv4PoolIDs[2]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes-internal/backendAddressPools/kubernetes"))
 		})
 
-		It("should not return IPV6 pools", func() {
-			standardLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBName, true)
+		It("should classify IPv6 pools into IPv6PoolIDs on dual-stack clusters", func() {
+			// A dual-stack cluster's standard LB carries both IPv4 and IPv6 inbound/outbound pools.
+			standardLB := test.WithIPv6BackendPools(resourceGroup, test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBName, true))
 			internalLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.InternalSLBName, false)
-			otherLB := test.MakeStandardLoadBalancer(resourceGroup, "some-lb", true)
-			ipv6LB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBNameIPv6, true)
 
 			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
 			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(internalLB.ID), internalLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(otherLB.ID), otherLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(ipv6LB.ID), ipv6LB)
 
 			pools, err := loadBalancerProvider.LoadBalancerBackendPools(ctx)
 			Expect(err).ToNot(HaveOccurred())
 
+			// IPv4: standard inbound + standard outbound + internal inbound.
 			Expect(pools.IPv4PoolIDs).To(HaveLen(3))
-			Expect(pools.IPv6PoolIDs).To(HaveLen(0))
-			Expect(pools.IPv4PoolIDs[0]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"))
-			Expect(pools.IPv4PoolIDs[1]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/aksOutboundBackendPool"))
-			Expect(pools.IPv4PoolIDs[2]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes-internal/backendAddressPools/kubernetes"))
+			Expect(pools.IPv4PoolIDs).To(ContainElement("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"))
+			Expect(pools.IPv4PoolIDs).To(ContainElement("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/aksOutboundBackendPool"))
+
+			// IPv6: standard inbound-ipv6 + standard outbound-ipv6.
+			Expect(pools.IPv6PoolIDs).To(HaveLen(2))
+			Expect(pools.IPv6PoolIDs).To(ContainElement("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes-ipv6"))
+			Expect(pools.IPv6PoolIDs).To(ContainElement("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/aksOutboundBackendPool-ipv6"))
 		})
 
 		It("should not return IP-based pools", func() {

--- a/pkg/test/loadbalancer.go
+++ b/pkg/test/loadbalancer.go
@@ -50,3 +50,22 @@ func MakeStandardLoadBalancer(resourceGroup string, lbName string, includeOutbou
 
 	return result
 }
+
+// WithIPv6BackendPools appends the well-known IPv6 inbound and outbound backend pools to the
+// load balancer, simulating a dual-stack cluster's load balancer.
+func WithIPv6BackendPools(resourceGroup string, lb armnetwork.LoadBalancer) armnetwork.LoadBalancer {
+	lbName := lo.FromPtr(lb.Name)
+	lb.Properties.BackendAddressPools = append(lb.Properties.BackendAddressPools,
+		&armnetwork.BackendAddressPool{
+			ID:         lo.ToPtr(fake.MakeBackendAddressPoolID(resourceGroup, lbName, loadbalancer.SLBInboundBackendPoolNameIPv6)),
+			Name:       lo.ToPtr(loadbalancer.SLBInboundBackendPoolNameIPv6),
+			Properties: &armnetwork.BackendAddressPoolPropertiesFormat{},
+		},
+		&armnetwork.BackendAddressPool{
+			ID:         lo.ToPtr(fake.MakeBackendAddressPoolID(resourceGroup, lbName, loadbalancer.SLBOutboundBackendPoolNameIPv6)),
+			Name:       lo.ToPtr(loadbalancer.SLBOutboundBackendPoolNameIPv6),
+			Properties: &armnetwork.BackendAddressPoolPropertiesFormat{},
+		},
+	)
+	return lb
+}

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -37,6 +37,7 @@ type OptionsFields struct {
 	NetworkDataplane               *string
 	VMMemoryOverheadPercent        *float64
 	NodeIdentities                 []string
+	NodeIPFamilies                 []string
 	SubnetID                       *string
 	NodeResourceGroup              *string
 	ProvisionMode                  *string
@@ -80,6 +81,7 @@ func Options(overrides ...OptionsFields) *azoptions.Options {
 		NetworkDataplane:               lo.FromPtrOr(options.NetworkDataplane, "cilium"),
 		VMMemoryOverheadPercent:        lo.FromPtrOr(options.VMMemoryOverheadPercent, 0.075),
 		NodeIdentities:                 options.NodeIdentities,
+		NodeIPFamilies:                 lo.Ternary(options.NodeIPFamilies != nil, options.NodeIPFamilies, []string{"IPv4"}),
 		SubnetID:                       lo.FromPtrOr(options.SubnetID, "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-resourceGroup/providers/Microsoft.Network/virtualNetworks/aks-vnet-12345678/subnets/aks-subnet"),
 		NodeResourceGroup:              lo.FromPtrOr(options.NodeResourceGroup, "test-resourceGroup"),
 		ProvisionMode:                  lo.FromPtrOr(options.ProvisionMode, "aksscriptless"),


### PR DESCRIPTION
## Description

Provision **dual-stack (IPv4 + IPv6)** nodes on dual-stack Azure CNI clusters.

Previously, nodes launched by Karpenter on a dual-stack cluster were **IPv4-only**: the NIC had only a primary IPv4 IP configuration, IPv6 load-balancer backend pools were never attached, and the bootstrap contract's IPv6 dual-stack flag was never set. This effectively made dual-stack clusters unsupported for the self-hosted (VM-direct) provisioning path. This PR wires the cluster's IP families through to node provisioning so each node receives both an IPv4 and an IPv6 address, mirroring how AKS configures dual-stack VMSS nodes.

## What this PR does

- **Option:** add a `NodeIPFamilies` option (env `NODE_IP_FAMILIES`, default `IPv4`) and an `IsIPv6Enabled()` helper. The deploy script (`configure-values.sh`) populates it from the cluster's `networkProfile.ipFamilies`, threaded through the Helm values template.
- **LoadBalancer provider:** classify backend pools by IP version and populate `BackendAddressPools.IPv6PoolIDs` from the well-known IPv6 inbound/outbound pools (previously discarded).
- **VM NIC (VM-direct path):** on dual-stack clusters, append a single non-primary `ipv6config` IP configuration (dynamic, IPv6) with the IPv6 LB backend pools attached. A NIC may only have one IPv6 ip config, so it's added once, outside the secondary-IP loop. Mirrors the AKS RP node NIC construction.
- **Bootstrap:** set the existing (previously unused) `IPv6DualStackEnabled` node bootstrap variable from the cluster IP families.
- **Docs:** scope the README "IPv6 clusters" limitation to single-stack IPv6 only.

## Testing

- **Unit tests:** `IsIPv6Enabled`; LoadBalancer IPv6 pool classification; the IPv6 NIC ip configuration on dual-stack vs single-stack clusters.
- **Live validation** on a real dual-stack Azure CNI Overlay cluster (`ipFamilies: [ipv4, ipv6]`):
  - `configure-values.sh` correctly auto-extracted `NODE_IP_FAMILIES=ipv4,ipv6`.
  - A Karpenter-provisioned node's NIC came up with `ipconfig` (IPv4, primary, `10.224.0.6`) **and** `ipv6config` (IPv6, non-primary, `fdd2:…::6`) — matching the system VMSS reference NIC exactly.
  - The node registered both IPv4 and IPv6 `InternalIP` addresses, and workloads scheduled and ran.

## Scope & notes

- Covers the **self-hosted, VM-direct** provisioning path (`aksscriptless` / `bootstrappingclient`).
- The **AKS Machine API path (`aksmachineapi` / NAP) is unchanged**: the AKS RP owns NIC and LB construction there, and the Machine API has no per-machine IP-family field. Dual-stack for NAP is currently gated off at the AKS RP and is tracked as separate RP work.
- Single-stack **IPv6-only** clusters remain unsupported.
