### PR TITLE
chore: restore FIPS-compliant build

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -12,6 +12,12 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-test.[a-z0-9]+'
+  workflow_dispatch:
+    inputs:
+      skip_trivy_scan:
+        description: 'Bypass the blocking Trivy scan (emergency release only). Scans still run in report-only mode. Select the release tag as the ref when running.'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -38,6 +44,7 @@ jobs:
     - name: Build and publish image
       env:
         RELEASE_ACR: ${{ secrets.AZURE_REGISTRY }}
+        SKIP_TRIVY_SCAN: ${{ inputs.skip_trivy_scan }}
       run: |
         az login --identity
         ko version

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: mcr.microsoft.com/cbl-mariner/distroless/base:2.0@sha256:7f7b46882d43593b14567a60934529de9a64ceb203ba0fa42d2f08802d392073
+defaultBaseImage: mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:f8f5a9bb739ad1ec347853144c9ed4ca2260e587082277bc6066fcd5cc9973e8
 defaultPlatforms:
   - linux/arm64
   - linux/amd64

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,6 +1,6 @@
-defaultBaseImage: mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:138fe2905465e384b232ffe8ba3147de04c633a83f29d8df00d6817e3eacb0d2
+defaultBaseImage: mcr.microsoft.com/cbl-mariner/distroless/base:2.0@sha256:7f7b46882d43593b14567a60934529de9a64ceb203ba0fa42d2f08802d392073
 defaultPlatforms:
   - linux/arm64
   - linux/amd64
 defaultEnv:
-  - MS_GO_NOSYSTEMCRYPTO=1
+  - CGO_ENABLED=1

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -32,9 +32,9 @@ CUSTOM_SUBNET_NAME ?= nodesubnet
 PROVISION_MODE ?= aksscriptless
 AKS_MACHINES_POOL_NAME ?= testmpool
 # pre-pull base images for skaffold/ko build, as a workaround for https://github.com/GoogleContainerTools/skaffold/issues/10106
-KO_BASE_IMAGE ?= mcr.microsoft.com/cbl-mariner/distroless/base:2.0@sha256:7f7b46882d43593b14567a60934529de9a64ceb203ba0fa42d2f08802d392073
-KO_BASE_IMAGE_AMD64 ?= mcr.microsoft.com/cbl-mariner/distroless/base@sha256:0ccfe048216561864a6838568f19afee9665031b65030bbd455bb2b6332fd5c5
-KO_BASE_IMAGE_ARM64 ?= mcr.microsoft.com/cbl-mariner/distroless/base@sha256:b7b3b726d4921a133185313378942e425c745d6eee0e9d746cecb487a7a36d33
+KO_BASE_IMAGE ?= mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:f8f5a9bb739ad1ec347853144c9ed4ca2260e587082277bc6066fcd5cc9973e8
+KO_BASE_IMAGE_AMD64 ?= mcr.microsoft.com/azurelinux/distroless/base@sha256:301f049bc6e5986a0227b17d57c22f8b46f6594952813a14db814b5a6159190f
+KO_BASE_IMAGE_ARM64 ?= mcr.microsoft.com/azurelinux/distroless/base@sha256:ef54cbe5a632f71090688f45901d073f19f414eb38516a60891ce3dff33c2029
 export KOCACHE ?= $(or $(RUNNER_TEMP),/tmp)/ko-cache
 
 .DEFAULT_GOAL := help	# make without arguments will show help

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -32,9 +32,9 @@ CUSTOM_SUBNET_NAME ?= nodesubnet
 PROVISION_MODE ?= aksscriptless
 AKS_MACHINES_POOL_NAME ?= testmpool
 # pre-pull base images for skaffold/ko build, as a workaround for https://github.com/GoogleContainerTools/skaffold/issues/10106
-KO_BASE_IMAGE ?= mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:138fe2905465e384b232ffe8ba3147de04c633a83f29d8df00d6817e3eacb0d2
-KO_BASE_IMAGE_AMD64 ?= mcr.microsoft.com/azurelinux/distroless/minimal@sha256:fbe9982049f312a0ae6421599b0a33629369c919abe3564893a5405776fc6266
-KO_BASE_IMAGE_ARM64 ?= mcr.microsoft.com/azurelinux/distroless/minimal@sha256:ffcf415e6a14221e4d91b29445e33650062650095569407ea29a4315983721df
+KO_BASE_IMAGE ?= mcr.microsoft.com/cbl-mariner/distroless/base:2.0@sha256:7f7b46882d43593b14567a60934529de9a64ceb203ba0fa42d2f08802d392073
+KO_BASE_IMAGE_AMD64 ?= mcr.microsoft.com/cbl-mariner/distroless/base@sha256:0ccfe048216561864a6838568f19afee9665031b65030bbd455bb2b6332fd5c5
+KO_BASE_IMAGE_ARM64 ?= mcr.microsoft.com/cbl-mariner/distroless/base@sha256:b7b3b726d4921a133185313378942e425c745d6eee0e9d746cecb487a7a36d33
 export KOCACHE ?= $(or $(RUNNER_TEMP),/tmp)/ko-cache
 
 .DEFAULT_GOAL := help	# make without arguments will show help

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -88,16 +88,24 @@ buildAndPublish() {
     SOURCE_DATE_EPOCH="${date_epoch}" KO_DATA_DATE_EPOCH="${date_epoch}" KO_DOCKER_REPO="${oci_repo}" \
     ko build -B --sbom none --tarball="${tarball_nap}" --platform=linux/amd64 --push=false ./cmd/controller
 
-  # Run trivy scans on local tarballs BEFORE pushing
-  if ! trivy image --input "${tarball}" --ignore-unfixed --exit-code 1; then
-    echo "Trivy scan failed for controller image. Aborting."
-    rm -f "${tarball}" "${tarball_nap}"
-    exit 1
-  fi
-  if ! trivy image --input "${tarball_nap}" --ignore-unfixed --exit-code 1; then
-    echo "Trivy scan failed for controller-aks image. Aborting."
-    rm -f "${tarball}" "${tarball_nap}"
-    exit 1
+  # Run trivy scans on local tarballs BEFORE pushing.
+  # Set SKIP_TRIVY_SCAN=true to bypass the blocking gate (e.g. an emergency release). The scans
+  # still run in report-only mode so findings remain in the logs, but they no longer abort the publish.
+  if [[ "${SKIP_TRIVY_SCAN:-false}" == "true" ]]; then
+    echo "::warning::Trivy scan BYPASSED via SKIP_TRIVY_SCAN=true; running in report-only mode (findings will not block the release)."
+    trivy image --input "${tarball}"     --ignore-unfixed --exit-code 0 || true
+    trivy image --input "${tarball_nap}" --ignore-unfixed --exit-code 0 || true
+  else
+    if ! trivy image --input "${tarball}" --ignore-unfixed --exit-code 1; then
+      echo "Trivy scan failed for controller image. Aborting."
+      rm -f "${tarball}" "${tarball_nap}"
+      exit 1
+    fi
+    if ! trivy image --input "${tarball_nap}" --ignore-unfixed --exit-code 1; then
+      echo "Trivy scan failed for controller-aks image. Aborting."
+      rm -f "${tarball}" "${tarball_nap}"
+      exit 1
+    fi
   fi
   rm -f "${tarball}" "${tarball_nap}"
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Restore FIPS-compliant build (revert https://github.com/Azure/karpenter-provider-azure/pull/1408). Allow bypass of blocking Trivy scan on manual release.

**How was this change tested?**

* local build
* [E2EMatrixTrigger · Azure/karpenter-provider-azure@f055f0d](https://github.com/Azure/karpenter-provider-azure/actions/runs/28072829459)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
