### PR TITLE
fix: skip legacy kube binary URL for newer AKS versions

### DIFF
--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -245,6 +245,8 @@ func (a AKS) aksBootstrapScript() (string, error) {
 
 // Download URL for KUBE_BINARY_URL publishes each k8s version in the URL.
 func kubeBinaryURL(kubernetesVersion, cpuArch string) string {
+	// Versions 1.34+ use a different binary path for kubectl/kubelet. AgentBaker CSE has that path baked in to the image
+	// so we don't need to specify the URL.
 	if semver.MustParse(kubernetesVersion).Minor >= 34 {
 		return ""
 	}

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap.go
@@ -245,6 +245,9 @@ func (a AKS) aksBootstrapScript() (string, error) {
 
 // Download URL for KUBE_BINARY_URL publishes each k8s version in the URL.
 func kubeBinaryURL(kubernetesVersion, cpuArch string) string {
+	if semver.MustParse(kubernetesVersion).Minor >= 34 {
+		return ""
+	}
 	return fmt.Sprintf("%s/kubernetes/v%s/binaries/kubernetes-node-linux-%s.tar.gz", globalAKSMirror, kubernetesVersion, cpuArch)
 }
 

--- a/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
+++ b/pkg/providers/imagefamily/bootstrap/aksbootstrap_test.go
@@ -54,6 +54,21 @@ func TestKubeBinaryURL(t *testing.T) {
 			version:  "1.27.1",
 			expected: fmt.Sprintf("%s/kubernetes/v1.27.1/binaries/kubernetes-node-linux-amd64.tar.gz", globalAKSMirror),
 		},
+		{
+			name:     "Test version 1.33.x",
+			version:  "1.33.7",
+			expected: fmt.Sprintf("%s/kubernetes/v1.33.7/binaries/kubernetes-node-linux-amd64.tar.gz", globalAKSMirror),
+		},
+		{
+			name:     "Test version 1.34.x",
+			version:  "1.34.0",
+			expected: "",
+		},
+		{
+			name:     "Test version 1.35.x",
+			version:  "1.35.5",
+			expected: "",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- Stop emitting `KUBE_BINARY_URL` for Kubernetes 1.34+ AKS scriptless bootstrap
- Preserve legacy `kubernetes-node` archive URL generation for 1.33 and older
- Add unit coverage for 1.33, 1.34, and 1.35 behavior

- E2E test is: https://github.com/Azure/karpenter-provider-azure/actions/runs/28388666808

Fixes #1760

## Testing
- `go test -count=1 ./pkg/providers/imagefamily/bootstrap`

🤖 *Generated by GitHub Copilot*