### PR TITLE
chore(ci): add memory diagnostics to ci-test (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -49,7 +49,59 @@ jobs:
     - uses: ./.github/actions/install-deps
       with:
         k8sVersion: ${{ matrix.k8sVersion }}
-    - run: K8S_VERSION=${{ matrix.k8sVersion }} make ci-test
+    # ---------------------------------------------------------------------------
+    # TEMPORARY: OOM/memory-pressure diagnostics for the recurring
+    # "The runner has received a shutdown signal ... Interrupted by User"
+    # cancellations that hit this workflow across many PRs at ~11-14 minutes
+    # into `make ci-test`. This branch (chore/ci-oom-diagnostics) is intended
+    # only to test the hypothesis that the tests are being OOM-killed.
+    # If the theory is confirmed we should revert this and address the root
+    # cause; if disproved we should revert this and investigate a different
+    # angle. Do not merge to main.
+    # ---------------------------------------------------------------------------
+    - name: Run ci-test with VM diagnostics
+      env:
+        # Emit a GC trace line to stderr on every Go GC. Format:
+        #   gc N @Ts s: PCT%: ns+ns+ns ms clock, ns+ns+ns/ns+ns/ns+ns+ns ns cpu,
+        #   XX->YY->ZZ MB, WW MB goal, VV MB stacks, UU MB globals, P P
+        # This gives us the heap-size trajectory of every test binary the
+        # ginkgo runner spawns, so we can see whether they are approaching
+        # the ~15 GB limit of a standard GitHub-hosted `ubuntu-latest` VM.
+        GODEBUG: gctrace=1
+      run: |
+        set -o pipefail
+
+        # Background VM-level memory sampler. Emits one line every 15s to
+        # stdout tagged `[mem-sampler]` so it can be grep'd out of the log
+        # stream. Stdout is written to the Actions log in real time, which
+        # is essential here because when the runner receives its shutdown
+        # signal every `if: always()` post-step is `skipped`, so we cannot
+        # rely on artifact uploads to capture pre-death state.
+        (
+          while :; do
+            ts=$(date -u +%FT%TZ)
+            mem=$(awk '/^MemTotal:|^MemAvailable:|^SwapFree:|^Buffers:|^Cached:/{printf "%s=%dMB ", $1, $2/1024}' /proc/meminfo)
+            top=$(ps -eo comm,rss --no-headers --sort=-rss | head -5 | awk '{printf "%s=%dMB ", $1, $2/1024}')
+            printf '[mem-sampler] %s %stop: %s\n' "$ts" "$mem" "$top"
+            sleep 15
+          done
+        ) &
+        SAMPLER_PID=$!
+        trap 'kill "${SAMPLER_PID}" 2>/dev/null || true' EXIT
+
+        K8S_VERSION=${{ matrix.k8sVersion }} make ci-test
+
+    # Only runs when the step above finishes normally; when the runner is
+    # shut down mid-job this step is `skipped` (confirmed in prior failures).
+    # Still worth capturing for successful runs that come close to the limit.
+    - name: Capture kernel OOM messages
+      if: always()
+      run: |
+        echo "=== dmesg tail (last 200 lines) ==="
+        sudo dmesg -T 2>/dev/null | tail -200 || true
+        echo "=== OOM / kill lines in kernel ring buffer ==="
+        sudo dmesg -T 2>/dev/null | grep -iE 'killed process|out of memory|oom-killer|invoked oom-killer' \
+          || echo "(no OOM lines found in kernel ring buffer)"
     - name: Send coverage
       # should only send coverage once https://docs.coveralls.io/parallel-builds
       if: matrix.k8sVersion == '1.32.x'


### PR DESCRIPTION
## Purpose (do not merge)

Diagnostic-only PR to test the hypothesis that the recurring `ci-test` cancellations are caused by memory pressure / OOM-kill of the GitHub-hosted runner VM.

## Background

`ci-test` fails on many PRs with this exact log signature:

```
##[error]The runner has received a shutdown signal. This can happen when
the runner service is stopped, or a manually started runner is canceled.
[INTERRUPTED] Interrupted by User
...
##[error]The operation was canceled.
```

Evidence collected from prior failing runs (28761648509, 28816762235, 28735540448, 28840214466):

- Failures cluster tightly at **11 m 36 s – 13 m 38 s** elapsed into `make ci-test`.
- Kill always lands during the ~130 s `pkg/providers/instance` suite (right after `Ran 142 of 142 Specs`).
- Each matrix job runs on its **own dedicated GitHub-hosted VM** (`is_github_hosted:true`, unique `RUNNER_NAME` / IP in `westus`); siblings cannot signal each other.
- No `timeout-minutes` in `.github/`.
- No `concurrency:` group in any workflow.
- No signal-sending code in the repo (`syscall.Kill`, `signal.Notify`, `exec.Command`, `os.Interrupt`, etc. — zero matches).

That narrows the cause to (a) the runner VM being reaped by the host / OS, or (b) the Actions service issuing a cancel. Memory pressure / OOM-kill is a candidate for (a) worth ruling out.

## What this PR adds (temporary)

To the `ci-test` step in [.github/workflows/ci-test.yml](../blob/chore/ci-oom-diagnostics/.github/workflows/ci-test.yml):

1. **`GODEBUG=gctrace=1`** on the test invocation — Go runtime emits a GC-trace line to stderr on every GC of every `*.test` binary that ginkgo spawns. Shows heap trajectory over the whole run.
2. **Background memory sampler** — bash loop prints one line every 15 s to stdout with `/proc/meminfo` (`MemTotal`, `MemAvailable`, `SwapFree`, `Buffers`, `Cached`) plus the RSS of the top-5 processes. Streaming to stdout is essential: when the runner is shut down, all post-steps are `skipped`, so artifact upload is not a reliable channel — but the log stream is captured in real time.
3. **`Capture kernel OOM messages`** post-step (`if: always()`, `sudo dmesg -T` + OOM grep) — only produces output on runs that survive that far, but is useful for successful-but-close-to-limit cases.

Local sanity-check of sampler line:
```
[mem-sampler] 2026-07-07T05:14:12Z MemTotal:=31926MB MemAvailable:=21756MB Buffers:=4456MB Cached:=9969MB SwapFree:=16271MB top: kube-apiserver=3153MB gopls=1849MB ...
```

## How we'll read the result

- Re-run this workflow a few times (7 matrix jobs per run, so we get several samples per re-run).
- On any job that fails with the interrupt signature, grep the log for `[mem-sampler]` to see the memory trajectory in the ~2 min before the kill.
- If `MemAvailable` was collapsing toward zero right before the kill, OR if a `gctrace` line shows heap approaching 15 GB, OR if the runner survives long enough to run `Capture kernel OOM messages` and it prints an OOM line — that confirms the OOM theory.
- If `MemAvailable` stays healthy and no OOM lines appear, we've ruled it out and should investigate a different angle (Actions-service cancel, harden-runner watchdog, hosted-pool reliability).

## What happens next

**Do not merge.** Once we've captured enough data to conclude, this branch should be reverted and either the real root cause fixed or a different diagnostic tried.