### PR TITLE
feat: add and use quota provider

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -82,6 +82,7 @@ func main() {
 		WithControllers(ctx, controllers.NewControllers(
 			ctx,
 			op.Manager,
+			op.Clock,
 			op.GetClient(),
 			op.EventRecorder,
 			aksCloudProvider,

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -91,6 +91,7 @@ func main() {
 			op.KubernetesVersionProvider,
 			op.ImageProvider,
 			op.InstanceTypesProvider,
+			op.QuotaProvider,
 			op.InClusterKubernetesInterface,
 			op.KubernetesInterface,
 			op.ManagedDynamicInterface,

--- a/cmd/controller/main_ccp.go
+++ b/cmd/controller/main_ccp.go
@@ -82,6 +82,7 @@ func main() {
 		WithControllers(ctx, controllers.NewControllers(
 			ctx,
 			op.Manager,
+			op.Clock,
 			op.GetClient(),
 			op.EventRecorder,
 			aksCloudProvider,

--- a/cmd/controller/main_ccp.go
+++ b/cmd/controller/main_ccp.go
@@ -91,6 +91,7 @@ func main() {
 			op.KubernetesVersionProvider,
 			op.ImageProvider,
 			op.InstanceTypesProvider,
+			op.QuotaProvider,
 			op.InClusterKubernetesInterface,
 			op.KubernetesInterface,
 			op.ManagedDynamicInterface,

--- a/designs/0012-quota-fungibility-reactivity-improvements.md
+++ b/designs/0012-quota-fungibility-reactivity-improvements.md
@@ -99,16 +99,16 @@ At this stage, the ideal API would:
 
 #### API Comparison
 
-| Dimension                                  | On-Demand Placement Score          | Spot Placement Score               | Attribute-Based Recommendations   | Quota API     | Compute Fleet               | SKU Mix Placement                        | Capacity APIs (svc underlay) |
-| ------------------------------------------ | ---------------------------------- | ---------------------------------- | --------------------------------- | ------------- | --------------------------- | ---------------------------------------- | ---------------------------- |
-| **1. Recommendation-only?**                | ✅                                 | ✅                                 | ✅                                | ✅            | ❌ Changes VM creation path | ✅                                       | ❓                           |
-| **2. Traceability?**                       | ⚠️ High/Medium/Low per SKU+Zone    | ⚠️ High/Medium/Low per SKU+Zone    | ⚠️ Ordered list, but no reasoning | ✅            | ❌                          | ⚠️ Score 1-10 + partialFulfillmentReason | ❓                           |
-| **3. Zone control?**                       | ✅                                 | ✅                                 | ❌                                | N/A           | ✅                          | ✅ Explicit zone in skuSplit             | ❓                           |
-| **4. All regions/clouds?**                 | ✅                                 | ✅                                 | ✅                                | ✅            | ✅                          | ⚠️ Public cloud only for now             | ✅                           |
-| **5. One-stop-shop (quota+capacity+CRS)?** | ⚠️ Quota/capacity assume per-zone  | ⚠️ Quota/capacity assume per-zone  | ❓                                | ❌ Quota only | ✅                          | ✅                                       | ❓                           |
-| **6. Public API?**                         | ❌                                 | ✅                                 | ✅                                | ✅            | ✅                          | ⚠️ Preview, public cloud only            | ❌ AKS-internal only         |
-| **7. Cacheable / high throttle limit?**    | ⚠️ Score depends on `desiredCount` | ⚠️ Score depends on `desiredCount` | ❓                                | ✅            | N/A                         | ⚠️ Score depends on count/sizes          | ❓                           |
-| **8. Supports 1-N VMs + partial success?** | ⚠️ Scores based on full success    | ⚠️ Scores based on full success    | ❌                                | N/A           | ✅                          | ✅                                       | ❓                           |
+| Dimension                                  | On-Demand Placement Score          | Spot Placement Score               | Attribute-Based Recommendations   | Quota API     | Compute Locations Quota (legacy) | Compute Fleet               | SKU Mix Placement                        | Capacity APIs (svc underlay) |
+| ------------------------------------------ | ---------------------------------- | ---------------------------------- | --------------------------------- | ------------- | -------------------------------- | --------------------------- | ---------------------------------------- | ---------------------------- |
+| **1. Recommendation-only?**                | ✅                                 | ✅                                 | ✅                                | ✅            | ✅                               | ❌ Changes VM creation path | ✅                                       | ❓                           |
+| **2. Traceability?**                       | ⚠️ High/Medium/Low per SKU+Zone    | ⚠️ High/Medium/Low per SKU+Zone    | ⚠️ Ordered list, but no reasoning | ✅            | ✅                               | ❌                          | ⚠️ Score 1-10 + partialFulfillmentReason | ❓                           |
+| **3. Zone control?**                       | ✅                                 | ✅                                 | ❌                                | N/A           | N/A                              | ✅                          | ✅ Explicit zone in skuSplit             | ❓                           |
+| **4. All regions/clouds?**                 | ✅                                 | ✅                                 | ✅                                | ✅            | ✅                               | ✅                          | ⚠️ Public cloud only for now             | ✅                           |
+| **5. One-stop-shop (quota+capacity+CRS)?** | ⚠️ Quota/capacity assume per-zone  | ⚠️ Quota/capacity assume per-zone  | ❓                                | ❌ Quota only | ❌ Quota only                    | ✅                          | ✅                                       | ❓                           |
+| **6. Public API?**                         | ❌                                 | ✅                                 | ✅                                | ✅            | ✅                               | ✅                          | ⚠️ Preview, public cloud only            | ❌ AKS-internal only         |
+| **7. Cacheable / high throttle limit?**    | ⚠️ Score depends on `desiredCount` | ⚠️ Score depends on `desiredCount` | ❓                                | ✅            | ✅                               | N/A                         | ⚠️ Score depends on count/sizes          | ❓                           |
+| **8. Supports 1-N VMs + partial success?** | ⚠️ Scores based on full success    | ⚠️ Scores based on full success    | ❌                                | N/A           | N/A                              | ✅                          | ✅                                       | ❓                           |
 
 Legend: ✅ = good / yes, ⚠️ = partial / caveats, ❌ = no / not supported, ❓ = unknown
 
@@ -141,14 +141,14 @@ Phase 2: Start using the API as the main source of size picking.
 
 ### Decision 3: How can we improve our allocation success rate in the near term?
 
-#### Conclusion: New quota provider (short term), to be replaced by SKU Split provider in the medium term
+#### Conclusion: New quota provider using Microsoft.Compute/locations/usages (short term), to be replaced by SKU Split provider in the medium term
 
-Create a `quota` provider located at `pkg/providers/quota/quota.go`. This provider should call the [Azure Quota SDK](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/quota/armquota/v2) periodically (every 10m by default).
+Create a `quota` provider located at `pkg/providers/quota/quota.go`. This provider should call the [Compute locations usages API](https://learn.microsoft.com/en-us/rest/api/compute/usage/list?view=rest-compute-2024-07-01&tabs=HTTP) (`Microsoft.Compute/locations/usages`) periodically (every 10m by default).
 
 Reasons to do this now:
 
-- The quota and usage APIs are publicly available now in all regions/clouds.
-- The biggest cause of errors seems to be `SKUFamilyQuotaExceeded`, which can be checked with just the quota APIs.
+- The Compute locations usages API is publicly available now in all regions/clouds, requires no additional RBAC, and returns both usage and limit in a single call.
+- The biggest cause of errors seems to be `SKUFamilyQuotaExceeded`, which can be checked with just the usage/quota data from this API.
 
 Key design decisions for the quota provider:
 
@@ -160,18 +160,18 @@ We can use this data either as a **hard filter**, or as a **ranking signal**.
 
 ##### Hard filter
 
-* ✅ Easier to understand.
-* ✅ Preserves price-first with filters approach we've had historically.
-* ✅ Avoids wasting a VM creation attempt (and its latency/throttling cost) on a family we already know will fail.
-* ❌ Quota data is polled every 10m and stale between polls. If quota is freed (node deleted, external change), we won't know until next poll and will incorrectly exclude the family. This is very similar to the existing unavailableofferings cache, so users are (likely) already experiencing this latency today.
-* ❌ Quota is per-family, not per-size. A family with 8 remaining cores can't fit a D64 but can fit a D4. We will need to be core-aware which adds some complexity.
+- ✅ Easier to understand.
+- ✅ Preserves price-first with filters approach we've had historically.
+- ✅ Avoids wasting a VM creation attempt (and its latency/throttling cost) on a family we already know will fail.
+- ❌ Quota data is polled every 10m and stale between polls. If quota is freed (node deleted, external change), we won't know until next poll and will incorrectly exclude the family. This is very similar to the existing unavailableofferings cache, so users are (likely) already experiencing this latency today.
+- ❌ Quota is per-family, not per-size. A family with 8 remaining cores can't fit a D64 but can fit a D4. We will need to be core-aware which adds some complexity.
 
 ##### Ranking signal
 
-* ✅ More resilient to stale data — families with freed quota still get attempted, just later in the order.
-* ❌ Still wastes one attempt if the top-ranked candidate ends up being quota-exhausted (though less likely since de-prioritized).
-* ❌ More complex ranking logic — need to define interaction between quota score and price (is a $0.30/hr family with plenty of quota better than the $0.20/hr family with almost none?).
-* ❌ Harder for users to reason about: "why did it pick a more expensive size?" vs the simpler "excluded due to quota."
+- ✅ More resilient to stale data — families with freed quota still get attempted, just later in the order.
+- ❌ Still wastes one attempt if the top-ranked candidate ends up being quota-exhausted (though less likely since de-prioritized).
+- ❌ More complex ranking logic — need to define interaction between quota score and price (is a $0.30/hr family with plenty of quota better than the $0.20/hr family with almost none?).
+- ❌ Harder for users to reason about: "why did it pick a more expensive size?" vs the simpler "excluded due to quota."
 
 Given our objective is as a stopgap measure while we wait for the SKU Split API, going for the simpler hard filter seems the correct approach.
 
@@ -336,6 +336,49 @@ Publicly callable
 
 - Quota data is already taken care of by other APIs such as Placement Score and SKU Mix Placement, so this may be redundant if using those.
 -
+
+### Compute locations quota API (legacy)
+
+| Dimension                                  |               |
+| ------------------------------------------ | ------------- |
+| **1. Recommendation-only?**                | ✅            |
+| **2. Traceability?**                       | ✅            |
+| **3. Zone control?**                       | N/A           |
+| **4. All regions/clouds?**                 | ✅            |
+| **5. One-stop-shop (quota+capacity+CRS)?** | ❌ Quota only |
+| **6. Public API?**                         | ✅            |
+| **7. Cacheable / high throttle limit?**    | ✅            |
+| **8. Supports 1-N VMs + partial success?** | N/A           |
+
+#### API reference
+
+**URL:** `GET https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/usages?api-version=2024-07-01`
+
+**Docs:**
+
+- [List usage](https://learn.microsoft.com/en-us/rest/api/compute/usage/list?view=rest-compute-2024-07-01&tabs=HTTP)
+
+These two APIs expose **identical data** for all practical purposes. A live comparison of all 626 counters for `eastus2` showed:
+
+| Check                            | Result                                                         |
+| -------------------------------- | -------------------------------------------------------------- |
+| Counter set (families/resources) | Identical — same 626 keys, none exclusive to either API        |
+| Limits (quota values)            | 100% match — 0 mismatches                                      |
+| Actual usage (currentValue)      | Match on every counter with usage > 0                          |
+| Difference                       | 203 counters where legacy Compute = 0 but Microsoft.Quota = -1 |
+
+The 203 discrepancies are all the same pattern: the legacy Compute API reports `currentValue: 0` while Microsoft.Quota reports `usages.value: -1` for families with `isQuotaApplicable: false` (VM families not offered/tracked in that region). For anything actually deployable and in use, the two agree exactly.
+
+#### Gotchas
+
+- Schema differences (same data, different shape):
+  - Legacy Compute returns usage and limit in one call: `{ name:{value,localizedValue}, currentValue, limit, unit }`.
+  - Microsoft.Quota splits them: `/usages` gives consumption, `/quotas` gives limits — two calls to get the full picture.
+  - Microsoft.Quota adds richer metadata (`isQuotaApplicable`, `limitType: Independent/Shared`, ARM resource `id`/`type`), and its `/quotas` endpoint additionally supports writing quota-increase requests.
+- Flattens "not tracked" families to `currentValue: 0` instead of providing an explicit sentinel or `isQuotaApplicable` flag.
+- Read-only — does not support writing quota-increase requests (use Microsoft.Quota for that).
+- This is the legacy API; Microsoft.Quota is the newer replacement with richer semantics.
+- No additional RBAC required, unlike Microsoft.Quota APIs.
 
 ### Compute fleet
 

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -39,11 +39,13 @@ import (
 
 	instancetypecontroller "github.com/Azure/karpenter-provider-azure/pkg/controllers/instancetype"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclaim/inplaceupdate"
+	quotacontroller "github.com/Azure/karpenter-provider-azure/pkg/controllers/quota"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient/azapi"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 	instancetypeprovider "github.com/Azure/karpenter-provider-azure/pkg/providers/instancetype"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/kubernetesversion"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/quota"
 )
 
 func NewControllers(
@@ -57,6 +59,7 @@ func NewControllers(
 	kubernetesVersionProvider kubernetesversion.KubernetesVersionProvider,
 	nodeImageProvider imagefamily.NodeImageProvider,
 	instanceTypesProvider instancetypeprovider.Provider,
+	quotaProvider quota.Provider,
 	inClusterKubernetesInterface kubernetes.Interface,
 	managedKubernetesInterface kubernetes.Interface,
 	managedDynamicInterface dynamic.Interface,
@@ -79,6 +82,7 @@ func NewControllers(
 		status.NewController[*v1beta1.AKSNodeClass](kubeClient, mgr.GetEventRecorderFor("karpenter")), //nolint:staticcheck // SA1019: will be replaced by mgr.GetEventRecorder once operatorpkg is updated
 
 		instancetypecontroller.NewController(instanceTypesProvider),
+		quotacontroller.NewController(quotaProvider),
 	}
 	return controllers
 }

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/awslabs/operatorpkg/status"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/clock"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/events"
@@ -51,6 +52,7 @@ import (
 func NewControllers(
 	ctx context.Context,
 	mgr manager.Manager,
+	clk clock.Clock,
 	kubeClient client.Client,
 	recorder events.Recorder,
 	cloudProvider cloudprovider.CloudProvider,
@@ -82,7 +84,7 @@ func NewControllers(
 		status.NewController[*v1beta1.AKSNodeClass](kubeClient, mgr.GetEventRecorderFor("karpenter")), //nolint:staticcheck // SA1019: will be replaced by mgr.GetEventRecorder once operatorpkg is updated
 
 		instancetypecontroller.NewController(instanceTypesProvider),
-		quotacontroller.NewController(quotaProvider),
+		quotacontroller.NewController(quotaProvider, clk),
 	}
 	return controllers
 }

--- a/pkg/controllers/quota/controller.go
+++ b/pkg/controllers/quota/controller.go
@@ -1,0 +1,63 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"context"
+	"time"
+
+	"github.com/awslabs/operatorpkg/reconciler"
+	"github.com/awslabs/operatorpkg/singleton"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/quota"
+)
+
+const (
+	RefreshInterval = 10 * time.Minute
+)
+
+type Controller struct {
+	quotaProvider quota.Provider
+}
+
+func NewController(quotaProvider quota.Provider) *Controller {
+	return &Controller{
+		quotaProvider: quotaProvider,
+	}
+}
+
+func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
+	ctx = injection.WithControllerName(ctx, "quota")
+
+	if err := c.quotaProvider.Update(ctx); err != nil {
+		log.FromContext(ctx).Error(err, "updating quota usages")
+		return reconciler.Result{}, err
+	}
+	log.FromContext(ctx).V(1).Info("updated quota usages")
+	return reconciler.Result{RequeueAfter: RefreshInterval}, nil
+}
+
+func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named("quota").
+		WatchesRawSource(singleton.Source()).
+		Complete(singleton.AsReconciler(c))
+}

--- a/pkg/controllers/quota/controller.go
+++ b/pkg/controllers/quota/controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/awslabs/operatorpkg/reconciler"
 	"github.com/awslabs/operatorpkg/singleton"
+	"k8s.io/utils/clock"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -32,15 +33,22 @@ import (
 
 const (
 	RefreshInterval = 10 * time.Minute
+	// MaxStaleness is how long we keep using cached quota data after the last successful refresh.
+	// If the quota API fails for longer than this, we clear the cache so HasQuotaFor fails open
+	// for all sizes rather than filtering based on outdated information.
+	MaxStaleness = RefreshInterval + 5*time.Minute
 )
 
 type Controller struct {
-	quotaProvider quota.Provider
+	quotaProvider        quota.Provider
+	clock                clock.PassiveClock
+	lastSuccessfulUpdate time.Time
 }
 
-func NewController(quotaProvider quota.Provider) *Controller {
+func NewController(quotaProvider quota.Provider, clk clock.PassiveClock) *Controller {
 	return &Controller{
 		quotaProvider: quotaProvider,
+		clock:         clk,
 	}
 }
 
@@ -49,8 +57,16 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 
 	if err := c.quotaProvider.Update(ctx); err != nil {
 		log.FromContext(ctx).Error(err, "updating quota usages")
+		// If data is too stale, clear it so HasQuotaFor fails open for all sizes
+		if !c.lastSuccessfulUpdate.IsZero() && c.clock.Since(c.lastSuccessfulUpdate) > MaxStaleness {
+			log.FromContext(ctx).Info("quota data is stale beyond max staleness, resetting to fail open",
+				"lastSuccessfulUpdate", c.lastSuccessfulUpdate,
+				"maxStaleness", MaxStaleness)
+			c.quotaProvider.Reset()
+		}
 		return reconciler.Result{}, err
 	}
+	c.lastSuccessfulUpdate = c.clock.Now()
 	return reconciler.Result{RequeueAfter: RefreshInterval}, nil
 }
 

--- a/pkg/controllers/quota/controller.go
+++ b/pkg/controllers/quota/controller.go
@@ -51,7 +51,6 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 		log.FromContext(ctx).Error(err, "updating quota usages")
 		return reconciler.Result{}, err
 	}
-	log.FromContext(ctx).V(1).Info("updated quota usages")
 	return reconciler.Result{RequeueAfter: RefreshInterval}, nil
 }
 

--- a/pkg/controllers/quota/suite_test.go
+++ b/pkg/controllers/quota/suite_test.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
+	clock "k8s.io/utils/clock/testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis"
@@ -41,6 +43,7 @@ var ctx context.Context
 var env *coretest.Environment
 var azureEnv *test.Environment
 var controller *quotacontroller.Controller
+var fakeClock *clock.FakeClock
 
 func TestController(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -53,7 +56,8 @@ var _ = BeforeSuite(func() {
 	ctx = options.ToContext(ctx, test.Options())
 	env = coretest.NewEnvironment(coretest.WithCRDs(apis.CRDs...), coretest.WithCRDs(v1alpha1.CRDs...))
 	azureEnv = test.NewEnvironment(ctx, env)
-	controller = quotacontroller.NewController(azureEnv.QuotaProvider)
+	fakeClock = clock.NewFakeClock(time.Now())
+	controller = quotacontroller.NewController(azureEnv.QuotaProvider, fakeClock)
 })
 
 var _ = AfterSuite(func() {
@@ -108,5 +112,39 @@ var _ = Describe("Quota Controller", func() {
 		err := ExpectSingletonReconcileFailed(ctx, controller)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("simulated usage API failure"))
+	})
+
+	It("should clear stale quota data after MaxStaleness of consecutive failures", func() {
+		// First, populate quota data with a successful reconciliation
+		azureEnv.UsageAPI.Usages.Append(
+			&armcompute.Usage{
+				Name:         &armcompute.UsageName{Value: lo.ToPtr("standardDSv3Family")},
+				CurrentValue: lo.ToPtr[int32](90),
+				Limit:        lo.ToPtr[int64](100),
+				Unit:         lo.ToPtr("Count"),
+			},
+		)
+		ExpectSingletonReconciled(ctx, controller)
+
+		found, _ := azureEnv.QuotaProvider.GetUsage("standardDSv3Family")
+		Expect(found).To(BeTrue(), "data should be present after successful reconciliation")
+
+		// Simulate the API failing
+		azureEnv.UsageAPI.Error = fmt.Errorf("simulated prolonged API failure")
+
+		// Immediate failure should preserve data
+		err := ExpectSingletonReconcileFailed(ctx, controller)
+		Expect(err).To(HaveOccurred())
+		found, _ = azureEnv.QuotaProvider.GetUsage("standardDSv3Family")
+		Expect(found).To(BeTrue(), "data should be preserved on immediate failure")
+
+		// Advance time past MaxStaleness
+		fakeClock.Step(quotacontroller.MaxStaleness + 1*time.Minute)
+
+		// Next failure should trigger cache clearing
+		err = ExpectSingletonReconcileFailed(ctx, controller)
+		Expect(err).To(HaveOccurred())
+		found, _ = azureEnv.QuotaProvider.GetUsage("standardDSv3Family")
+		Expect(found).To(BeFalse(), "stale data should be cleared after MaxStaleness")
 	})
 })

--- a/pkg/controllers/quota/suite_test.go
+++ b/pkg/controllers/quota/suite_test.go
@@ -1,0 +1,112 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+	"github.com/Azure/karpenter-provider-azure/pkg/apis"
+	quotacontroller "github.com/Azure/karpenter-provider-azure/pkg/controllers/quota"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
+	"github.com/Azure/karpenter-provider-azure/pkg/test"
+	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
+	coretest "sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+)
+
+var ctx context.Context
+var env *coretest.Environment
+var azureEnv *test.Environment
+var controller *quotacontroller.Controller
+
+func TestController(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "QuotaController")
+}
+
+var _ = BeforeSuite(func() {
+	ctx = coreoptions.ToContext(ctx, coretest.Options())
+	ctx = options.ToContext(ctx, test.Options())
+	env = coretest.NewEnvironment(coretest.WithCRDs(apis.CRDs...), coretest.WithCRDs(v1alpha1.CRDs...))
+	azureEnv = test.NewEnvironment(ctx, env)
+	controller = quotacontroller.NewController(azureEnv.QuotaProvider)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = BeforeEach(func() {
+	azureEnv.Reset(ctx)
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+})
+
+var _ = Describe("Quota Controller", func() {
+	It("should return a requeue interval of 10 minutes", func() {
+		result := ExpectSingletonReconciled(ctx, controller)
+		Expect(result.RequeueAfter).To(Equal(quotacontroller.RefreshInterval))
+	})
+
+	It("should update quota data after reconciliation", func() {
+		azureEnv.UsageAPI.Usages.Append(
+			&armcompute.Usage{
+				Name:         &armcompute.UsageName{Value: lo.ToPtr("standardBSFamily"), LocalizedValue: lo.ToPtr("Standard BS Family vCPUs")},
+				CurrentValue: lo.ToPtr[int32](10),
+				Limit:        lo.ToPtr[int64](100),
+				Unit:         lo.ToPtr("Count"),
+			},
+			&armcompute.Usage{
+				Name:         &armcompute.UsageName{Value: lo.ToPtr("cores"), LocalizedValue: lo.ToPtr("Total Regional vCPUs")},
+				CurrentValue: lo.ToPtr[int32](50),
+				Limit:        lo.ToPtr[int64](500),
+				Unit:         lo.ToPtr("Count"),
+			},
+		)
+
+		ExpectSingletonReconciled(ctx, controller)
+
+		found, usage := azureEnv.QuotaProvider.GetUsage("standardBSFamily")
+		Expect(found).To(BeTrue())
+		Expect(*usage.CurrentValue).To(Equal(int32(10)))
+		Expect(*usage.Limit).To(Equal(int64(100)))
+
+		found, usage = azureEnv.QuotaProvider.GetTotalRegionalUsage()
+		Expect(found).To(BeTrue())
+		Expect(*usage.CurrentValue).To(Equal(int32(50)))
+	})
+
+	It("should fail reconciliation when the usage API returns an error", func() {
+		azureEnv.UsageAPI.Error = fmt.Errorf("simulated usage API failure")
+
+		err := ExpectSingletonReconcileFailed(ctx, controller)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("simulated usage API failure"))
+	})
+})

--- a/pkg/fake/usageapi.go
+++ b/pkg/fake/usageapi.go
@@ -1,0 +1,63 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/quota"
+)
+
+type UsageAPI struct {
+	Usages AtomicPtrSlice[armcompute.Usage]
+	Error  error
+}
+
+// assert that the fake implements the interface
+var _ quota.UsageAPI = &UsageAPI{}
+
+func (u *UsageAPI) NewListPager(_ string, _ *armcompute.UsageClientListOptions) *runtime.Pager[armcompute.UsageClientListResponse] {
+	pagingHandler := runtime.PagingHandler[armcompute.UsageClientListResponse]{
+		More: func(page armcompute.UsageClientListResponse) bool {
+			return false
+		},
+		Fetcher: func(ctx context.Context, _ *armcompute.UsageClientListResponse) (armcompute.UsageClientListResponse, error) {
+			if u.Error != nil {
+				return armcompute.UsageClientListResponse{}, u.Error
+			}
+			output := armcompute.ListUsagesResult{
+				Value: []*armcompute.Usage{},
+			}
+			output.Value = append(output.Value, u.Usages.values...)
+			return armcompute.UsageClientListResponse{
+				ListUsagesResult: output,
+			}, nil
+		},
+	}
+	return runtime.NewPager(pagingHandler)
+}
+
+func (u *UsageAPI) Reset() {
+	if u == nil {
+		return
+	}
+	u.Usages.Reset()
+	u.Error = nil
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -69,6 +69,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/networksecuritygroup"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/quota"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 	armopts "github.com/Azure/karpenter-provider-azure/pkg/utils/clientopts"
 )
@@ -101,6 +102,7 @@ type Operator struct {
 	VMInstanceProvider        *instance.DefaultVMProvider
 	AKSMachineProvider        *instance.DefaultAKSMachineProvider
 	LoadBalancerProvider      *loadbalancer.Provider
+	QuotaProvider             *quota.DefaultProvider
 	AZClient                  *azclient.AZClient
 }
 
@@ -274,6 +276,8 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		aksMachineCache,
 	)
 
+	quotaProvider := quota.NewProvider(azClient.UsageClient, azConfig.Location)
+
 	return ctx, &Operator{
 		Operator:                     operator,
 		InClusterKubernetesInterface: inClusterClient,
@@ -288,6 +292,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		VMInstanceProvider:           vmInstanceProvider,
 		AKSMachineProvider:           aksMachineInstanceProvider,
 		LoadBalancerProvider:         loadBalancerProvider,
+		QuotaProvider:                quotaProvider,
 		AZClient:                     azClient,
 	}
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -193,12 +193,14 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		cache.New(imagefamily.ImageExpirationInterval,
 			imagefamily.ImageCacheCleaningInterval),
 	)
+	quotaProvider := quota.NewProvider(azClient.UsageClient, azConfig.Location)
 	instanceTypeProvider := instancetype.NewDefaultProvider(
 		azConfig.Location,
 		cache.New(instancetype.InstanceTypesCacheTTL, azurecache.DefaultCleanupInterval),
 		azClient.SKUClient,
 		pricingProvider,
 		unavailableOfferingsCache,
+		quotaProvider,
 	)
 
 	// Ensure we're able to hydrate instance types before starting any controllers
@@ -275,8 +277,6 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		options.FromContext(ctx).ProvisionMode == consts.ProvisionModeAKSMachineAPIHeaderBatch,
 		aksMachineCache,
 	)
-
-	quotaProvider := quota.NewProvider(azClient.UsageClient, azConfig.Location)
 
 	return ctx, &Operator{
 		Operator:                     operator,

--- a/pkg/providers/azclient/azclient.go
+++ b/pkg/providers/azclient/azclient.go
@@ -211,6 +211,12 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *auth.Environment, c
 		return nil, err
 	}
 
+	// Note that this is the Microsoft.Compute/locations/usages API,
+	// which is different than the Microsoft.Quota API. We use it here because:
+	//   * It is what the portal uses.
+	//   * It doesn't require additional RBAC over and above VM contributor which we already require.
+	//   * It is functionally identical to the Microsoft.Quota API.
+	// See designs/0012-quota-fungibility-reactivity-improvements.md for more details.
 	usageClient, err := armcompute.NewUsageClient(cfg.SubscriptionID, cred, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/providers/azclient/azclient.go
+++ b/pkg/providers/azclient/azclient.go
@@ -37,6 +37,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance/skuclient"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/networksecuritygroup"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/quota"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/zone"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils/batcher"
 	"github.com/Azure/skewer"
@@ -63,6 +64,7 @@ type AZClient struct {
 	LoadBalancersClient         loadbalancer.LoadBalancersAPI
 	NetworkSecurityGroupsClient networksecuritygroup.API
 	SubscriptionsClient         zone.SubscriptionsAPI
+	UsageClient                 quota.UsageAPI
 }
 
 func (c *AZClient) SubnetsClient() azapi.SubnetsAPI {
@@ -118,6 +120,7 @@ func NewAZClientFromAPI(
 	nodeBootstrappingClient imagefamilytypes.NodeBootstrappingAPI,
 	skuClient skewer.ResourceClient,
 	subscriptionsClient zone.SubscriptionsAPI,
+	usageClient quota.UsageAPI,
 ) *AZClient {
 	return &AZClient{
 		virtualMachinesClient:          virtualMachinesClient,
@@ -136,6 +139,7 @@ func NewAZClientFromAPI(
 		LoadBalancersClient:            loadBalancersClient,
 		NetworkSecurityGroupsClient:    networkSecurityGroupsClient,
 		SubscriptionsClient:            subscriptionsClient,
+		UsageClient:                    usageClient,
 	}
 }
 
@@ -203,6 +207,11 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *auth.Environment, c
 	}
 
 	diskEncryptionSetsClient, err := armcompute.NewDiskEncryptionSetsClient(cfg.SubscriptionID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	usageClient, err := armcompute.NewUsageClient(cfg.SubscriptionID, cred, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -292,5 +301,6 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *auth.Environment, c
 		nodeBootstrappingClient,
 		skuClient,
 		subscriptionsClient,
+		usageClient,
 	), nil
 }

--- a/pkg/providers/instance/aksmachineinstancetimestamputils_test.go
+++ b/pkg/providers/instance/aksmachineinstancetimestamputils_test.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// nolint: gocyclo
 func TestCreationTimestampUtilities(t *testing.T) {
 	t.Run("ZeroAKSMachineTimestamp", func(t *testing.T) {
 		result := ZeroAKSMachineTimestamp()

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -44,6 +44,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/utils/zones"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/quota"
 
 	"github.com/Azure/skewer"
 	"github.com/alecthomas/units"
@@ -91,6 +92,7 @@ type DefaultProvider struct {
 	skuClient            skewer.ResourceClient
 	pricingProvider      *pricing.Provider
 	unavailableOfferings *kcache.UnavailableOfferings
+	quotaProvider        quota.Provider
 
 	// Values cached *before* considering insufficient capacity errors from the unavailableOfferings cache.
 	// Fully initialized Instance Types are also cached based on the set of all instance types,
@@ -111,6 +113,7 @@ func NewDefaultProvider(
 	skuClient skewer.ResourceClient,
 	pricingProvider *pricing.Provider,
 	offeringsCache *kcache.UnavailableOfferings,
+	quotaProvider quota.Provider,
 ) *DefaultProvider {
 	return &DefaultProvider{
 		// TODO: skewer api, subnetprovider, pricing provider, unavailable offerings, ...
@@ -118,6 +121,7 @@ func NewDefaultProvider(
 		skuClient:            skuClient,
 		pricingProvider:      pricingProvider,
 		unavailableOfferings: offeringsCache,
+		quotaProvider:        quotaProvider,
 		instanceTypesCache:   cache,
 		cm:                   pretty.NewChangeMonitor(),
 		instanceTypesSeqNum:  0,
@@ -148,9 +152,10 @@ func (p *DefaultProvider) List(
 		LocalDNSEnabled:          nodeClass.IsLocalDNSEnabled(),
 	}
 	paramsHash, _ := hashstructure.Hash(instanceTypeParams, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
-	key := fmt.Sprintf("%d-%d-%016x",
+	key := fmt.Sprintf("%d-%d-%d-%016x",
 		p.instanceTypesSeqNum,
 		p.unavailableOfferings.SeqNum,
+		p.quotaProvider.SeqNum(),
 		paramsHash,
 	)
 	if item, ok := p.instanceTypesCache.Get(key); ok {
@@ -174,7 +179,7 @@ func (p *DefaultProvider) List(
 			continue
 		}
 		instanceTypeZones := p.instanceTypeZones(sku)
-		instanceType := newInstanceType(ctx, sku, vmsize, p.region, p.createOfferings(sku, instanceTypeZones), instanceTypeParams, architecture)
+		instanceType := newInstanceType(ctx, sku, vmsize, p.region, p.createOfferings(ctx, sku, instanceTypeZones), instanceTypeParams, architecture)
 		if len(instanceType.Offerings) == 0 {
 			continue
 		}
@@ -238,7 +243,7 @@ func (p *DefaultProvider) instanceTypeZones(sku *skewer.SKU) sets.Set[string] {
 // offering, you can do the following thanks to this invariant:
 //
 //	offering.Requirements.Get(v1.TopologyLabelZone).Any()
-func (p *DefaultProvider) createOfferings(sku *skewer.SKU, offeringZones sets.Set[string]) cloudprovider.Offerings {
+func (p *DefaultProvider) createOfferings(ctx context.Context, sku *skewer.SKU, offeringZones sets.Set[string]) cloudprovider.Offerings {
 	offerings := []*cloudprovider.Offering{}
 
 	for zone := range offeringZones {
@@ -249,9 +254,15 @@ func (p *DefaultProvider) createOfferings(sku *skewer.SKU, offeringZones sets.Se
 		spotPrice, _ := p.pricingProvider.SpotPrice(*sku.Name)
 
 		// Determine allocatability from SKU capabilities.
-		// On-demand is always allocatable if the SKU passed UpdateInstanceTypes filters, we just need to check the unavailableOfferings cache.
-		availableOnDemand := !p.unavailableOfferings.IsUnavailable(sku, zone, karpv1.CapacityTypeOnDemand)
+		// On-demand is always allocatable if the SKU passed UpdateInstanceTypes filters, we just need to check the
+		// unavailableOfferings cache and per-family quota.
+		availableOnDemand := !p.unavailableOfferings.IsUnavailable(sku, zone, karpv1.CapacityTypeOnDemand) &&
+			p.quotaProvider.HasQuotaFor(ctx, sku)
 		// Spot is only allocatable if the SKU reports LowPriorityCapable=True and the offering is not in the unavailableOfferings cache.
+		// NOTE:  Quota check applies to on-demand only. Spot VMs do not consume per-family vCPU quota;
+		// they use a single regional "Total Regional Spot vCPUs" (lowPriorityCores) pool shared
+		// across all families, which is not useful as a size-selection signal.
+		// See: https://learn.microsoft.com/en-us/azure/quotas/spot-quota
 		// IMPORTANT: Spot can be capacity restricted separately from dedicated. Unlike dedicated, spot capacity restrictions are not returned
 		// in the "restrictions" section of the SKU API, instead the LowPriorityCapable capability is set to False. This means that the VM SKU API cannot differentiate
 		// between restricted at a regional level and for all zones, or just restricted for some zones. Both are LowPriorityCapable=False. It would be

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -3231,8 +3231,6 @@ var _ = Describe("InstanceType Provider", func() {
 		})
 
 		It("should fail open when quota data is unavailable", func() {
-			// No quota data set up — provider has no data
-
 			instanceTypes, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
 			Expect(err).To(BeNil())
 			Expect(instanceTypes).ToNot(BeEmpty())

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -3098,6 +3098,213 @@ var _ = Describe("InstanceType Provider", func() {
 			})
 		})
 	})
+
+	Context("Quota Filtering", func() {
+		It("should exclude on-demand offering when family quota is exhausted", func() {
+			targetFamily := defaultTestSKU.GetFamilyName()
+			Expect(targetFamily).ToNot(BeEmpty())
+
+			azureEnv.UsageAPI.Usages.Append(
+				&armcompute.Usage{
+					Name:         &armcompute.UsageName{Value: lo.ToPtr(targetFamily)},
+					CurrentValue: lo.ToPtr[int32](100),
+					Limit:        lo.ToPtr[int64](100),
+				},
+			)
+			lo.Must0(azureEnv.QuotaProvider.Update(ctx))
+
+			instanceTypes, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
+			Expect(err).To(BeNil())
+
+			foundFamily := false
+			for _, it := range instanceTypes {
+				sku := fake.MakeSKU(it.Name)
+				if sku.GetFamilyName() == targetFamily {
+					foundFamily = true
+					// All on-demand offerings for this family should be unavailable
+					for _, offering := range it.Offerings {
+						if offering.Requirements.Get(karpv1.CapacityTypeLabelKey).Has(karpv1.CapacityTypeOnDemand) {
+							Expect(offering.Available).To(BeFalse(), fmt.Sprintf("on-demand offering for %s should be unavailable due to quota", it.Name))
+						}
+					}
+				}
+			}
+			Expect(foundFamily).To(BeTrue(), "expected to find instance types in the target family")
+		})
+
+		It("should allow on-demand offering when family has enough quota", func() {
+			targetFamily := defaultTestSKU.GetFamilyName()
+			Expect(targetFamily).ToNot(BeEmpty())
+
+			azureEnv.UsageAPI.Usages.Append(
+				&armcompute.Usage{
+					Name:         &armcompute.UsageName{Value: lo.ToPtr(targetFamily)},
+					CurrentValue: lo.ToPtr[int32](0),
+					Limit:        lo.ToPtr[int64](1000),
+				},
+			)
+			lo.Must0(azureEnv.QuotaProvider.Update(ctx))
+
+			instanceTypes, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
+			Expect(err).To(BeNil())
+
+			foundFamily := false
+			for _, it := range instanceTypes {
+				sku := fake.MakeSKU(it.Name)
+				if sku.GetFamilyName() == targetFamily {
+					foundFamily = true
+					for _, offering := range it.Offerings {
+						if offering.Requirements.Get(karpv1.CapacityTypeLabelKey).Has(karpv1.CapacityTypeOnDemand) {
+							Expect(offering.Available).To(BeTrue(), fmt.Sprintf("on-demand offering for %s should be available with sufficient quota", it.Name))
+						}
+					}
+				}
+			}
+			Expect(foundFamily).To(BeTrue(), "expected to find instance types in the target family")
+		})
+
+		It("should block large sizes but allow small sizes in the same family", func() {
+			targetFamily := defaultTestSKU.GetFamilyName()
+			Expect(targetFamily).ToNot(BeEmpty())
+
+			// Leave only 4 cores of quota remaining
+			azureEnv.UsageAPI.Usages.Append(
+				&armcompute.Usage{
+					Name:         &armcompute.UsageName{Value: lo.ToPtr(targetFamily)},
+					CurrentValue: lo.ToPtr[int32](96),
+					Limit:        lo.ToPtr[int64](100),
+				},
+			)
+			lo.Must0(azureEnv.QuotaProvider.Update(ctx))
+
+			instanceTypes, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
+			Expect(err).To(BeNil())
+
+			foundFamily := false
+			for _, it := range instanceTypes {
+				sku := fake.MakeSKU(it.Name)
+				if sku.GetFamilyName() == targetFamily {
+					foundFamily = true
+					vcpus := lo.Must(sku.VCPU())
+					for _, offering := range it.Offerings {
+						if offering.Requirements.Get(karpv1.CapacityTypeLabelKey).Has(karpv1.CapacityTypeOnDemand) {
+							if vcpus <= 4 {
+								Expect(offering.Available).To(BeTrue(), fmt.Sprintf("on-demand offering for %s (%d vCPUs) should be available with 4 remaining cores", it.Name, vcpus))
+							} else {
+								Expect(offering.Available).To(BeFalse(), fmt.Sprintf("on-demand offering for %s (%d vCPUs) should be unavailable with only 4 remaining cores", it.Name, vcpus))
+							}
+						}
+					}
+				}
+			}
+			Expect(foundFamily).To(BeTrue(), "expected to find instance types in the target family")
+		})
+
+		It("should not affect spot offerings when on-demand quota is exhausted", func() {
+			targetFamily := defaultTestSKU.GetFamilyName()
+			Expect(targetFamily).ToNot(BeEmpty())
+
+			azureEnv.UsageAPI.Usages.Append(
+				&armcompute.Usage{
+					Name:         &armcompute.UsageName{Value: lo.ToPtr(targetFamily)},
+					CurrentValue: lo.ToPtr[int32](100),
+					Limit:        lo.ToPtr[int64](100),
+				},
+			)
+			lo.Must0(azureEnv.QuotaProvider.Update(ctx))
+
+			instanceTypes, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
+			Expect(err).To(BeNil())
+
+			foundSpot := false
+			for _, it := range instanceTypes {
+				sku := fake.MakeSKU(it.Name)
+				if sku.GetFamilyName() == targetFamily {
+					for _, offering := range it.Offerings {
+						if offering.Requirements.Get(karpv1.CapacityTypeLabelKey).Has(karpv1.CapacityTypeSpot) && offering.Available {
+							foundSpot = true
+						}
+					}
+				}
+			}
+			Expect(foundSpot).To(BeTrue(), "spot offerings should still be available when on-demand quota is exhausted")
+		})
+
+		It("should fail open when quota data is unavailable", func() {
+			// No quota data set up — provider has no data
+
+			instanceTypes, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
+			Expect(err).To(BeNil())
+			Expect(instanceTypes).ToNot(BeEmpty())
+
+			for _, it := range instanceTypes {
+				for _, offering := range it.Offerings {
+					if offering.Requirements.Get(karpv1.CapacityTypeLabelKey).Has(karpv1.CapacityTypeOnDemand) {
+						Expect(offering.Available).To(BeTrue(), fmt.Sprintf("on-demand offering for %s should be available when quota data is empty (fail-open)", it.Name))
+					}
+				}
+			}
+		})
+
+		It("should invalidate instance type cache when quota data changes", func() {
+			targetFamily := defaultTestSKU.GetFamilyName()
+			Expect(targetFamily).ToNot(BeEmpty())
+
+			// First call with plenty of quota
+			azureEnv.UsageAPI.Usages.Append(
+				&armcompute.Usage{
+					Name:         &armcompute.UsageName{Value: lo.ToPtr(targetFamily)},
+					CurrentValue: lo.ToPtr[int32](0),
+					Limit:        lo.ToPtr[int64](1000),
+				},
+			)
+			lo.Must0(azureEnv.QuotaProvider.Update(ctx))
+
+			instanceTypes, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
+			Expect(err).To(BeNil())
+			foundFamily := false
+			for _, it := range instanceTypes {
+				sku := fake.MakeSKU(it.Name)
+				if sku.GetFamilyName() == targetFamily {
+					foundFamily = true
+					for _, offering := range it.Offerings {
+						if offering.Requirements.Get(karpv1.CapacityTypeLabelKey).Has(karpv1.CapacityTypeOnDemand) {
+							Expect(offering.Available).To(BeTrue())
+						}
+					}
+				}
+			}
+			Expect(foundFamily).To(BeTrue(), "expected to find instance types in the target family")
+
+			// Now exhaust the quota and update
+			azureEnv.UsageAPI.Usages.Reset()
+			azureEnv.UsageAPI.Usages.Append(
+				&armcompute.Usage{
+					Name:         &armcompute.UsageName{Value: lo.ToPtr(targetFamily)},
+					CurrentValue: lo.ToPtr[int32](100),
+					Limit:        lo.ToPtr[int64](100),
+				},
+			)
+			lo.Must0(azureEnv.QuotaProvider.Update(ctx))
+
+			// Second call should reflect the new quota (cache invalidated by SeqNum change)
+			instanceTypes, err = azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
+			Expect(err).To(BeNil())
+			foundFamily = false
+			for _, it := range instanceTypes {
+				sku := fake.MakeSKU(it.Name)
+				if sku.GetFamilyName() == targetFamily {
+					foundFamily = true
+					for _, offering := range it.Offerings {
+						if offering.Requirements.Get(karpv1.CapacityTypeLabelKey).Has(karpv1.CapacityTypeOnDemand) {
+							Expect(offering.Available).To(BeFalse(), fmt.Sprintf("on-demand offering for %s should be unavailable after quota exhaustion", it.Name))
+						}
+					}
+				}
+			}
+			Expect(foundFamily).To(BeTrue(), "expected to find instance types in the target family")
+		})
+	})
 })
 
 var _ = Describe("Tax Calculator", func() {

--- a/pkg/providers/quota/quota.go
+++ b/pkg/providers/quota/quota.go
@@ -1,0 +1,107 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"context"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/karpenter/pkg/utils/pretty"
+)
+
+type UsageAPI interface {
+	NewListPager(location string, options *armcompute.UsageClientListOptions) *runtime.Pager[armcompute.UsageClientListResponse]
+}
+
+// Provider exposes Azure compute quota/usage data for a given region.
+type Provider interface {
+	// Update fetches the latest quota usage data from the Azure Compute Usage API.
+	Update(ctx context.Context) error
+	// GetUsage returns the usage entry for the given VM family name (e.g. "standardBSFamily").
+	// The bool indicates whether the family was found.
+	GetUsage(familyName string) (bool, *armcompute.Usage)
+	// GetTotalRegionalUsage returns the total regional vCPU usage (the "cores" entry).
+	// The bool indicates whether the entry was found.
+	GetTotalRegionalUsage() (bool, *armcompute.Usage)
+}
+
+var _ Provider = &DefaultProvider{}
+
+type DefaultProvider struct {
+	usageClient UsageAPI
+	location    string
+	mu          sync.RWMutex
+	usages      map[string]*armcompute.Usage
+	cm          *pretty.ChangeMonitor
+}
+
+func NewProvider(usageClient UsageAPI, location string) *DefaultProvider {
+	return &DefaultProvider{
+		usageClient: usageClient,
+		location:    location,
+		usages:      map[string]*armcompute.Usage{},
+		cm:          pretty.NewChangeMonitor(),
+	}
+}
+
+func (p *DefaultProvider) Update(ctx context.Context) error {
+	freshUsages := map[string]*armcompute.Usage{}
+
+	pager := p.usageClient.NewListPager(p.location, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return err
+		}
+		for _, usage := range page.Value {
+			// Note that the usages API also returns entries for non-family categories, such as
+			// "cores" (total regional vCPU usage), "PremiumDiskCount", etc.
+			// We currently include these in our map as it doesn't harm anything, although they are not used currently.
+			if usage != nil && usage.Name != nil && usage.Name.Value != nil {
+				freshUsages[*usage.Name.Value] = usage
+			}
+		}
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.usages = freshUsages
+	if p.cm.HasChanged("quota-usages", freshUsages) {
+		log.FromContext(ctx).V(1).Info("updated quota usages", "usages", len(freshUsages))
+	}
+	return nil
+}
+
+func (p *DefaultProvider) GetUsage(familyName string) (bool, *armcompute.Usage) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	usage, ok := p.usages[familyName]
+	return ok, usage
+}
+
+func (p *DefaultProvider) GetTotalRegionalUsage() (bool, *armcompute.Usage) {
+	return p.GetUsage("cores")
+}
+
+func (p *DefaultProvider) Reset() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.usages = map[string]*armcompute.Usage{}
+}

--- a/pkg/providers/quota/quota.go
+++ b/pkg/providers/quota/quota.go
@@ -55,6 +55,8 @@ type Provider interface {
 	// each time quota data is successfully refreshed. Consumers can use this
 	// to invalidate caches that depend on quota state.
 	SeqNum() uint64
+	// Reset clears all cached quota data, causing HasQuotaFor to fail open for all SKUs.
+	Reset()
 }
 
 var _ Provider = &DefaultProvider{}
@@ -99,8 +101,8 @@ func (p *DefaultProvider) Update(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.usages = freshUsages
-	atomic.AddUint64(&p.seqNum, 1)
 	if p.cm.HasChanged("quota-usages", freshUsages) {
+		atomic.AddUint64(&p.seqNum, 1)
 		log.FromContext(ctx).V(1).Info("updated quota usages", "familyQuotas", formatFamilyQuotas(freshUsages))
 	}
 	return nil

--- a/pkg/providers/quota/quota.go
+++ b/pkg/providers/quota/quota.go
@@ -18,10 +18,16 @@ package quota
 
 import (
 	"context"
+	"fmt"
+	"sort"
+	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+	"github.com/Azure/skewer"
+	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 )
@@ -40,6 +46,15 @@ type Provider interface {
 	// GetTotalRegionalUsage returns the total regional vCPU usage (the "cores" entry).
 	// The bool indicates whether the entry was found.
 	GetTotalRegionalUsage() (bool, *armcompute.Usage)
+	// HasQuotaFor returns true if the SKU's family has enough remaining quota
+	// to accommodate the SKU's vCPU count. Returns true (fail-open) if quota
+	// data is unavailable, the family is not found in the cached data, or
+	// the SKU's family name or vCPU count cannot be determined.
+	HasQuotaFor(ctx context.Context, sku *skewer.SKU) bool
+	// SeqNum returns a monotonically increasing counter that is incremented
+	// each time quota data is successfully refreshed. Consumers can use this
+	// to invalidate caches that depend on quota state.
+	SeqNum() uint64
 }
 
 var _ Provider = &DefaultProvider{}
@@ -50,6 +65,7 @@ type DefaultProvider struct {
 	mu          sync.RWMutex
 	usages      map[string]*armcompute.Usage
 	cm          *pretty.ChangeMonitor
+	seqNum      uint64
 }
 
 func NewProvider(usageClient UsageAPI, location string) *DefaultProvider {
@@ -83,8 +99,9 @@ func (p *DefaultProvider) Update(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.usages = freshUsages
+	atomic.AddUint64(&p.seqNum, 1)
 	if p.cm.HasChanged("quota-usages", freshUsages) {
-		log.FromContext(ctx).V(1).Info("updated quota usages", "usages", len(freshUsages))
+		log.FromContext(ctx).V(1).Info("updated quota usages", "familyQuotas", formatFamilyQuotas(freshUsages))
 	}
 	return nil
 }
@@ -100,8 +117,49 @@ func (p *DefaultProvider) GetTotalRegionalUsage() (bool, *armcompute.Usage) {
 	return p.GetUsage("cores")
 }
 
+func (p *DefaultProvider) HasQuotaFor(ctx context.Context, sku *skewer.SKU) bool {
+	familyName := sku.GetFamilyName()
+	if familyName == "" {
+		log.FromContext(ctx).V(1).Info("WARNING: cannot check quota for SKU, family name is missing; assuming quota available", "sku", sku.GetName())
+		return true // fail open
+	}
+	vcpus, err := sku.VCPU()
+	if err != nil {
+		log.FromContext(ctx).V(1).Info("WARNING: cannot check quota for SKU, vCPU count unavailable; assuming quota available", "sku", sku.GetName(), "error", err)
+		return true // fail open
+	}
+	found, usage := p.GetUsage(familyName)
+	if !found {
+		return true // fail open
+	}
+	if usage.Limit == nil || usage.CurrentValue == nil {
+		log.FromContext(ctx).V(1).Info("WARNING: quota entry has nil Limit or CurrentValue; assuming quota available", "family", familyName)
+		return true // fail open
+	}
+	remaining := *usage.Limit - int64(*usage.CurrentValue)
+	return vcpus <= remaining
+}
+
+func (p *DefaultProvider) SeqNum() uint64 {
+	return atomic.LoadUint64(&p.seqNum)
+}
+
 func (p *DefaultProvider) Reset() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.usages = map[string]*armcompute.Usage{}
+}
+
+// formatFamilyQuotas returns a compact summary of family quotas like "standardDSv3Family: 78/500, standardDv5Family: 20/100".
+// Only entries containing "Family" or "family" in the name are included.
+func formatFamilyQuotas(usages map[string]*armcompute.Usage) string {
+	var parts []string
+	for name, usage := range usages {
+		if !strings.Contains(strings.ToLower(name), "family") {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s: %d/%d", name, lo.FromPtr(usage.CurrentValue), lo.FromPtr(usage.Limit)))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
 }

--- a/pkg/providers/quota/quota_test.go
+++ b/pkg/providers/quota/quota_test.go
@@ -1,0 +1,152 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+	"github.com/Azure/karpenter-provider-azure/pkg/fake"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/quota"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+)
+
+func Test_Update_PopulatesUsageData(t *testing.T) {
+	t.Parallel()
+	ctx := TestContextWithLogger(t)
+	g := NewWithT(t)
+	usageAPI, quotaProvider := newTestProvider(t)
+
+	usageAPI.Usages.Append(
+		&armcompute.Usage{
+			Name:         &armcompute.UsageName{Value: lo.ToPtr("standardBSFamily"), LocalizedValue: lo.ToPtr("Standard BS Family vCPUs")},
+			CurrentValue: lo.ToPtr[int32](10),
+			Limit:        lo.ToPtr[int64](100),
+			Unit:         lo.ToPtr("Count"),
+		},
+		&armcompute.Usage{
+			Name:         &armcompute.UsageName{Value: lo.ToPtr("cores"), LocalizedValue: lo.ToPtr("Total Regional vCPUs")},
+			CurrentValue: lo.ToPtr[int32](50),
+			Limit:        lo.ToPtr[int64](500),
+			Unit:         lo.ToPtr("Count"),
+		},
+	)
+
+	err := quotaProvider.Update(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	found, usage := quotaProvider.GetUsage("standardBSFamily")
+	g.Expect(found).To(BeTrue())
+	g.Expect(*usage.CurrentValue).To(Equal(int32(10)))
+	g.Expect(*usage.Limit).To(Equal(int64(100)))
+}
+
+func Test_GetTotalRegionalUsage_ReturnsCoresUsage(t *testing.T) {
+	t.Parallel()
+	ctx := TestContextWithLogger(t)
+	g := NewWithT(t)
+	usageAPI, quotaProvider := newTestProvider(t)
+
+	usageAPI.Usages.Append(
+		&armcompute.Usage{
+			Name:         &armcompute.UsageName{Value: lo.ToPtr("cores"), LocalizedValue: lo.ToPtr("Total Regional vCPUs")},
+			CurrentValue: lo.ToPtr[int32](50),
+			Limit:        lo.ToPtr[int64](500),
+			Unit:         lo.ToPtr("Count"),
+		},
+	)
+
+	err := quotaProvider.Update(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	found, usage := quotaProvider.GetTotalRegionalUsage()
+	g.Expect(found).To(BeTrue())
+	g.Expect(*usage.CurrentValue).To(Equal(int32(50)))
+	g.Expect(*usage.Limit).To(Equal(int64(500)))
+}
+
+func Test_GetUsage_ReturnsFalseForUnknownFamily(t *testing.T) {
+	t.Parallel()
+	ctx := TestContextWithLogger(t)
+	g := NewWithT(t)
+	_, quotaProvider := newTestProvider(t)
+
+	err := quotaProvider.Update(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	found, _ := quotaProvider.GetUsage("nonExistentFamily")
+	g.Expect(found).To(BeFalse())
+}
+
+func Test_GetTotalRegionalUsage_ReturnsFalseWhenEmpty(t *testing.T) {
+	t.Parallel()
+	ctx := TestContextWithLogger(t)
+	g := NewWithT(t)
+	_, quotaProvider := newTestProvider(t)
+
+	err := quotaProvider.Update(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	found, _ := quotaProvider.GetTotalRegionalUsage()
+	g.Expect(found).To(BeFalse())
+}
+
+func Test_Update_PreservesCachedDataOnFailure(t *testing.T) {
+	t.Parallel()
+	ctx := TestContextWithLogger(t)
+	g := NewWithT(t)
+	usageAPI, quotaProvider := newTestProvider(t)
+
+	usageAPI.Usages.Append(
+		&armcompute.Usage{
+			Name:         &armcompute.UsageName{Value: lo.ToPtr("cores"), LocalizedValue: lo.ToPtr("Total Regional vCPUs")},
+			CurrentValue: lo.ToPtr[int32](50),
+			Limit:        lo.ToPtr[int64](500),
+			Unit:         lo.ToPtr("Count"),
+		},
+	)
+
+	// First update succeeds
+	err := quotaProvider.Update(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	found, usage := quotaProvider.GetTotalRegionalUsage()
+	g.Expect(found).To(BeTrue())
+	g.Expect(*usage.CurrentValue).To(Equal(int32(50)))
+
+	// Configure a failure
+	usageAPI.Error = fmt.Errorf("simulated API failure")
+
+	// Second update fails
+	err = quotaProvider.Update(ctx)
+	g.Expect(err).To(HaveOccurred())
+
+	// Previous data should still be available
+	found, usage = quotaProvider.GetTotalRegionalUsage()
+	g.Expect(found).To(BeTrue())
+	g.Expect(*usage.CurrentValue).To(Equal(int32(50)))
+}
+
+func newTestProvider(t *testing.T) (*fake.UsageAPI, *quota.DefaultProvider) {
+	t.Helper()
+	usageAPI := &fake.UsageAPI{}
+	return usageAPI, quota.NewProvider(usageAPI, fake.Region)
+}

--- a/pkg/providers/quota/quota_test.go
+++ b/pkg/providers/quota/quota_test.go
@@ -150,3 +150,115 @@ func newTestProvider(t *testing.T) (*fake.UsageAPI, *quota.DefaultProvider) {
 	usageAPI := &fake.UsageAPI{}
 	return usageAPI, quota.NewProvider(usageAPI, fake.Region)
 }
+
+func Test_HasQuotaFor(t *testing.T) {
+	t.Parallel()
+	sku := fake.MakeSKU("Standard_D4s_v3") // 4 vCPUs, standardDSv3Family
+
+	tests := []struct {
+		name     string
+		usages   []*armcompute.Usage
+		update   bool // whether to call Update before checking
+		expected bool
+	}{
+		{
+			name: "allows when enough quota",
+			usages: []*armcompute.Usage{{
+				Name:         &armcompute.UsageName{Value: lo.ToPtr(sku.GetFamilyName())},
+				CurrentValue: lo.ToPtr[int32](10),
+				Limit:        lo.ToPtr[int64](100),
+			}},
+			update:   true,
+			expected: true,
+		},
+		{
+			name: "blocks when insufficient quota",
+			usages: []*armcompute.Usage{{
+				Name:         &armcompute.UsageName{Value: lo.ToPtr(sku.GetFamilyName())},
+				CurrentValue: lo.ToPtr[int32](98),
+				Limit:        lo.ToPtr[int64](100),
+			}},
+			update:   true,
+			expected: false, // 100-98=2 remaining, SKU needs 4
+		},
+		{
+			name: "allows exact fit",
+			usages: []*armcompute.Usage{{
+				Name:         &armcompute.UsageName{Value: lo.ToPtr(sku.GetFamilyName())},
+				CurrentValue: lo.ToPtr[int32](96),
+				Limit:        lo.ToPtr[int64](100),
+			}},
+			update:   true,
+			expected: true, // 100-96=4 remaining, SKU needs exactly 4
+		},
+		{
+			name: "fails open when family not found",
+			usages: []*armcompute.Usage{{
+				Name:         &armcompute.UsageName{Value: lo.ToPtr("standardBSFamily")},
+				CurrentValue: lo.ToPtr[int32](100),
+				Limit:        lo.ToPtr[int64](100),
+			}},
+			update:   true,
+			expected: true,
+		},
+		{
+			name: "fails open when no data",
+			// No usages, no Update call
+			update:   false,
+			expected: true,
+		},
+		{
+			name: "fails open when Limit is nil",
+			usages: []*armcompute.Usage{{
+				Name:         &armcompute.UsageName{Value: lo.ToPtr(sku.GetFamilyName())},
+				CurrentValue: lo.ToPtr[int32](50),
+				Limit:        nil,
+			}},
+			update:   true,
+			expected: true,
+		},
+		{
+			name: "fails open when CurrentValue is nil",
+			usages: []*armcompute.Usage{{
+				Name:         &armcompute.UsageName{Value: lo.ToPtr(sku.GetFamilyName())},
+				CurrentValue: nil,
+				Limit:        lo.ToPtr[int64](100),
+			}},
+			update:   true,
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := TestContextWithLogger(t)
+			g := NewWithT(t)
+			usageAPI, quotaProvider := newTestProvider(t)
+
+			if len(tc.usages) > 0 {
+				usageAPI.Usages.Append(tc.usages...)
+			}
+			if tc.update {
+				lo.Must0(quotaProvider.Update(ctx))
+			}
+
+			g.Expect(quotaProvider.HasQuotaFor(ctx, sku)).To(Equal(tc.expected))
+		})
+	}
+}
+
+func Test_SeqNum_IncrementsOnUpdate(t *testing.T) {
+	t.Parallel()
+	ctx := TestContextWithLogger(t)
+	g := NewWithT(t)
+	_, quotaProvider := newTestProvider(t)
+
+	g.Expect(quotaProvider.SeqNum()).To(Equal(uint64(0)))
+
+	lo.Must0(quotaProvider.Update(ctx))
+	g.Expect(quotaProvider.SeqNum()).To(Equal(uint64(1)))
+
+	lo.Must0(quotaProvider.Update(ctx))
+	g.Expect(quotaProvider.SeqNum()).To(Equal(uint64(2)))
+}

--- a/pkg/providers/quota/quota_test.go
+++ b/pkg/providers/quota/quota_test.go
@@ -248,17 +248,32 @@ func Test_HasQuotaFor(t *testing.T) {
 	}
 }
 
-func Test_SeqNum_IncrementsOnUpdate(t *testing.T) {
+func Test_SeqNum_IncrementsOnlyWhenDataChanges(t *testing.T) {
 	t.Parallel()
 	ctx := TestContextWithLogger(t)
 	g := NewWithT(t)
-	_, quotaProvider := newTestProvider(t)
+	usageAPI, quotaProvider := newTestProvider(t)
 
 	g.Expect(quotaProvider.SeqNum()).To(Equal(uint64(0)))
 
+	// First update with empty data → changes from initial state
 	lo.Must0(quotaProvider.Update(ctx))
 	g.Expect(quotaProvider.SeqNum()).To(Equal(uint64(1)))
 
+	// Second update with same empty data → no change, seqNum stays
+	lo.Must0(quotaProvider.Update(ctx))
+	g.Expect(quotaProvider.SeqNum()).To(Equal(uint64(1)))
+
+	// Third update with new data → changes, seqNum increments
+	usageAPI.Usages.Append(&armcompute.Usage{
+		Name:         &armcompute.UsageName{Value: lo.ToPtr("standardDSv3Family")},
+		CurrentValue: lo.ToPtr[int32](10),
+		Limit:        lo.ToPtr[int64](100),
+	})
+	lo.Must0(quotaProvider.Update(ctx))
+	g.Expect(quotaProvider.SeqNum()).To(Equal(uint64(2)))
+
+	// Fourth update with same data → no change, seqNum stays
 	lo.Must0(quotaProvider.Update(ctx))
 	g.Expect(quotaProvider.SeqNum()).To(Equal(uint64(2)))
 }

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -50,9 +50,9 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/networksecuritygroup"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/quota"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils/batcher"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils/zones"
-	"github.com/Azure/karpenter-provider-azure/pkg/providers/quota"
 )
 
 func init() {
@@ -386,6 +386,8 @@ func (env *Environment) Reset(ctx context.Context) {
 	env.UnavailableOfferingsCache.Flush()
 	env.AKSMachineCache.InvalidateAll()
 	env.LoadBalancerCache.Flush()
+
+	lo.Must0(env.InstanceTypesProvider.UpdateInstanceTypes(ctx))
 
 	// Re-seed the managed NSG so launchtemplate provider can resolve it
 	nodeResourceGroup := options.FromContext(ctx).NodeResourceGroup

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -174,12 +174,14 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 	pricingProvider := pricing.NewProvider(ctx, azureEnv, pricingAPI, region, make(chan struct{}))
 	kubernetesVersionProvider := kubernetesversion.NewKubernetesVersionProvider(env.KubernetesInterface, kubernetesVersionCache)
 	imageFamilyProvider := imagefamily.NewProvider(communityImageVersionsAPI, region, subscription, nodeImageVersionsAPI, nodeImagesCache)
+	quotaProvider := quota.NewProvider(usageAPI, region)
 	instanceTypesProvider := instancetype.NewDefaultProvider(
 		region,
 		instanceTypeCache,
 		skusAPI,
 		pricingProvider,
-		unavailableOfferingsCache)
+		unavailableOfferingsCache,
+		quotaProvider)
 	imageFamilyResolver := imagefamily.NewDefaultResolver(env.Client, imageFamilyProvider, instanceTypesProvider, nodeBootstrappingAPI)
 	networkSecurityGroupProvider := networksecuritygroup.NewProvider(
 		networkSecurityGroupAPI,
@@ -295,7 +297,6 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 	)
 
 	store := nodeoverlay.NewInstanceTypeStore()
-	quotaProvider := quota.NewProvider(usageAPI, region)
 
 	// Populate the instance type cache before returning the environment, as many tests assume it's populated and it simplifies test setup.
 	// We can update it in individual tests as needed.

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -52,6 +52,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils/batcher"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils/zones"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/quota"
 )
 
 func init() {
@@ -86,6 +87,7 @@ type Environment struct {
 	NodeBootstrappingAPI        *fake.NodeBootstrappingAPI
 	AKSMachinesAPI              *fake.AKSMachinesAPI
 	AKSAgentPoolsAPI            *fake.AKSAgentPoolsAPI
+	UsageAPI                    *fake.UsageAPI
 	DynamicInterface            dynamic.Interface
 
 	// Fake data stores for the APIs
@@ -111,6 +113,7 @@ type Environment struct {
 	LoadBalancerProvider         *loadbalancer.Provider
 	NetworkSecurityGroupProvider *networksecuritygroup.Provider
 	AllocationStrategyProvider   allocationstrategy.Provider
+	QuotaProvider                *quota.DefaultProvider
 
 	InstanceTypeStore *nodeoverlay.InstanceTypeStore
 
@@ -153,6 +156,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 	nodeImageVersionsAPI := &fake.NodeImageVersionsAPI{}
 	nodeBootstrappingAPI := &fake.NodeBootstrappingAPI{}
 	subscriptionAPI := &fake.SubscriptionsAPI{}
+	usageAPI := &fake.UsageAPI{}
 
 	aksDataStorage := fake.NewAKSDataStorage()
 	aksAgentPoolsAPI := fake.NewAKSAgentPoolsAPI(aksDataStorage)
@@ -231,6 +235,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		nodeBootstrappingAPI,
 		skusAPI,
 		subscriptionAPI,
+		usageAPI,
 	)
 	allocationStrategyProvider := allocationstrategy.NewProvider()
 	vmInstanceProvider := instance.NewDefaultVMProvider(
@@ -290,6 +295,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 	)
 
 	store := nodeoverlay.NewInstanceTypeStore()
+	quotaProvider := quota.NewProvider(usageAPI, region)
 
 	// Populate the instance type cache before returning the environment, as many tests assume it's populated and it simplifies test setup.
 	// We can update it in individual tests as needed.
@@ -317,6 +323,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		NodeBootstrappingAPI:        nodeBootstrappingAPI,
 		AKSMachinesAPI:              aksMachinesAPI,
 		AKSAgentPoolsAPI:            aksAgentPoolsAPI,
+		UsageAPI:                    usageAPI,
 		DynamicInterface:            dynamic.NewForConfigOrDie(env.Config),
 
 		AKSDataStorage: aksDataStorage,
@@ -339,6 +346,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		LoadBalancerProvider:         loadBalancerProvider,
 		NetworkSecurityGroupProvider: networkSecurityGroupProvider,
 		AllocationStrategyProvider:   allocationStrategyProvider,
+		QuotaProvider:                quotaProvider,
 
 		InstanceTypeStore: store,
 
@@ -368,6 +376,8 @@ func (env *Environment) Reset(ctx context.Context) {
 	env.PricingProvider.Reset()
 	env.AKSMachinesAPI.Reset()
 	env.AKSAgentPoolsAPI.Reset()
+	env.UsageAPI.Reset()
+	env.QuotaProvider.Reset()
 
 	env.KubernetesVersionCache.Flush()
 	env.NodeImagesCache.Flush()


### PR DESCRIPTION
* Adds a new quota provider and controller.
* Refreshes quota every 10m (logs quota when it does).
* Considers quota as a hard blocker to instance allocation, similar to when a size is in unavailableofferings.

Fixes #1323
Fixes #1733

There is more we could do here (see [the design](https://github.com/Azure/karpenter-provider-azure/blob/main/designs/0012-quota-fungibility-reactivity-improvements.md)), but this is a stopgap in the meantime that should significantly improve behavior.

**How was this change tested?**

* Unit tests
* E2E tests (regression: Hard to have a dedicated quota e2e)
  * Machine: https://github.com/Azure/karpenter-provider-azure/actions/runs/29128641557
  * Standard selfhosted OSS: https://github.com/Azure/karpenter-provider-azure/actions/runs/29128627538

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
