### PR TITLE
chore: use the same clock interface everywhere

### DIFF
--- a/pkg/providers/zone/zone.go
+++ b/pkg/providers/zone/zone.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 	"github.com/samber/lo"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -35,10 +36,6 @@ const (
 	maxFailuresPerWindow = 10
 	windowBackoff        = 60 * time.Minute
 )
-
-type Clock interface {
-	Now() time.Time
-}
 
 // SubscriptionsAPI defines the interface for Azure Subscriptions client operations
 type SubscriptionsAPI interface {
@@ -54,7 +51,7 @@ type SubscriptionsAPI interface {
 type Provider struct {
 	subscriptionsAPI SubscriptionsAPI
 	subscriptionID   string
-	clock            Clock
+	clock            clock.PassiveClock
 
 	// Cached zone list data - maps region name to list of available zones
 	zoneList  map[string][]string
@@ -68,7 +65,7 @@ type Provider struct {
 // NewProvider creates a new zone provider
 func NewProvider(
 	subscriptionsAPI SubscriptionsAPI,
-	clock Clock,
+	clock clock.PassiveClock,
 	subscriptionID string,
 ) *Provider {
 	result := &Provider{

--- a/test/pkg/environment/azure/environment.go
+++ b/test/pkg/environment/azure/environment.go
@@ -195,8 +195,6 @@ func NewEnvironment(t *testing.T) *Environment {
 	return azureEnv
 }
 
-
-
 func (env *Environment) GetDefaultCredential() azcore.TokenCredential {
 	return env.defaultCredential
 }

--- a/test/pkg/environment/azure/environment.go
+++ b/test/pkg/environment/azure/environment.go
@@ -46,6 +46,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
 	"github.com/Azure/karpenter-provider-azure/pkg/test/azure"
 	"github.com/Azure/karpenter-provider-azure/test/pkg/environment/common"
+	clock "k8s.io/utils/clock"
 )
 
 func init() {
@@ -174,7 +175,7 @@ func NewEnvironment(t *testing.T) *Environment {
 	azureEnv.DiskEncryptionSetClient = lo.Must(armcompute.NewDiskEncryptionSetsClient(azureEnv.SubscriptionID, cred, byokRetryOptions))
 	azureEnv.RBACManager = lo.Must(NewRBACManager(azureEnv.SubscriptionID, cred))
 	subscriptionsClient := lo.Must(armsubscriptions.NewClient(cred, nil))
-	azureEnv.zoneProvider = zone.NewProvider(subscriptionsClient, realClock{}, azureEnv.SubscriptionID)
+	azureEnv.zoneProvider = zone.NewProvider(subscriptionsClient, clock.RealClock{}, azureEnv.SubscriptionID)
 	// If ProvisionMode wasn't set, default to scriptless, though note that this is
 	// actually defaulted dynamically based on the value of a toggle in AKS which means
 	// assuming we're always in ProvisionMode Scriptless here is incorrect at times, though OK
@@ -194,9 +195,7 @@ func NewEnvironment(t *testing.T) *Environment {
 	return azureEnv
 }
 
-type realClock struct{}
 
-func (realClock) Now() time.Time { return time.Now() }
 
 func (env *Environment) GetDefaultCredential() azcore.TokenCredential {
 	return env.defaultCredential


### PR DESCRIPTION
Prefer the k8s clock interface rather than our own custom defined one

**How was this change tested?**

* Unit tests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
