### PR TITLE
fix: bug where loadbalancer deletion could block node provisioning

### DIFF
--- a/pkg/fake/loadbalancerapi.go
+++ b/pkg/fake/loadbalancerapi.go
@@ -28,8 +28,14 @@ import (
 	"github.com/samber/lo"
 )
 
+type LoadBalancerListInput struct {
+	ResourceGroupName string
+	Options           *armnetwork.LoadBalancersClientListOptions
+}
+
 type LoadBalancersBehavior struct {
-	LoadBalancers fakesync.Map[string, armnetwork.LoadBalancer]
+	LoadBalancers        fakesync.Map[string, armnetwork.LoadBalancer]
+	NewListPagerBehavior MockedFunction[LoadBalancerListInput, *runtime.Pager[armnetwork.LoadBalancersClientListResponse]]
 }
 
 // assert that the fake implements the interface
@@ -42,6 +48,7 @@ type LoadBalancersAPI struct {
 // Reset must be called between tests otherwise tests will pollute each other.
 func (api *LoadBalancersAPI) Reset() {
 	api.LoadBalancers.Clear()
+	api.NewListPagerBehavior.Reset()
 }
 
 func (api *LoadBalancersAPI) Get(_ context.Context, resourceGroupName string, loadBalancerName string, _ *armnetwork.LoadBalancersClientGetOptions) (armnetwork.LoadBalancersClientGetResponse, error) {
@@ -55,35 +62,40 @@ func (api *LoadBalancersAPI) Get(_ context.Context, resourceGroupName string, lo
 	}, nil
 }
 
-func (api *LoadBalancersAPI) NewListPager(_ string, _ *armnetwork.LoadBalancersClientListOptions) *runtime.Pager[armnetwork.LoadBalancersClientListResponse] {
-	pagingHandler := runtime.PagingHandler[armnetwork.LoadBalancersClientListResponse]{
-		More: func(page armnetwork.LoadBalancersClientListResponse) bool {
-			return false // TODO: It might be ideal if we had a MockPager which sometimes simulated multiple pages of results to ensure we handle that correctly
-		},
-		Fetcher: func(ctx context.Context, _ *armnetwork.LoadBalancersClientListResponse) (armnetwork.LoadBalancersClientListResponse, error) {
-			output := armnetwork.LoadBalancerListResult{
-				Value: []*armnetwork.LoadBalancer{},
-			}
-			api.LoadBalancers.Range(func(key string, value armnetwork.LoadBalancer) bool {
-				output.Value = append(output.Value, &value)
-
-				return true
-			})
-
-			// Sort the result according to ID so that we have a stable base to write asserts upon
-			sort.Slice(output.Value, func(i, j int) bool {
-				l := output.Value[i]
-				r := output.Value[j]
-
-				return lo.FromPtr(l.ID) < lo.FromPtr(r.ID)
-			})
-
-			return armnetwork.LoadBalancersClientListResponse{
-				LoadBalancerListResult: output,
-			}, nil
-		},
+func (api *LoadBalancersAPI) NewListPager(resourceGroupName string, options *armnetwork.LoadBalancersClientListOptions) *runtime.Pager[armnetwork.LoadBalancersClientListResponse] {
+	input := &LoadBalancerListInput{
+		ResourceGroupName: resourceGroupName,
+		Options:           options,
 	}
-	return runtime.NewPager(pagingHandler)
+	pager, _ := api.NewListPagerBehavior.Invoke(input, func(_ *LoadBalancerListInput) (*runtime.Pager[armnetwork.LoadBalancersClientListResponse], error) {
+		p := runtime.NewPager(runtime.PagingHandler[armnetwork.LoadBalancersClientListResponse]{
+			More: func(page armnetwork.LoadBalancersClientListResponse) bool {
+				return false // TODO: It might be ideal if we had a MockPager which sometimes simulated multiple pages of results to ensure we handle that correctly
+			},
+			Fetcher: func(ctx context.Context, _ *armnetwork.LoadBalancersClientListResponse) (armnetwork.LoadBalancersClientListResponse, error) {
+				output := armnetwork.LoadBalancerListResult{
+					Value: []*armnetwork.LoadBalancer{},
+				}
+				api.LoadBalancers.Range(func(key string, value armnetwork.LoadBalancer) bool {
+					output.Value = append(output.Value, &value)
+					return true
+				})
+
+				// Sort the result according to ID so that we have a stable base to write asserts upon
+				sort.Slice(output.Value, func(i, j int) bool {
+					l := output.Value[i]
+					r := output.Value[j]
+					return lo.FromPtr(l.ID) < lo.FromPtr(r.ID)
+				})
+
+				return armnetwork.LoadBalancersClientListResponse{
+					LoadBalancerListResult: output,
+				}, nil
+			},
+		})
+		return p, nil
+	})
+	return pager
 }
 
 func MakeLoadBalancerID(resourceGroupName, loadBalancerName string) string {

--- a/pkg/providers/instance/lberrors.go
+++ b/pkg/providers/instance/lberrors.go
@@ -1,0 +1,53 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instance
+
+import (
+	"strings"
+
+	sdkerrors "github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
+)
+
+const invalidResourceReferenceCode = "InvalidResourceReference"
+
+// isMissingSubmittedBackendPool returns true if err is an Azure InvalidResourceReference
+// whose message identifies one of the backend-pool IDs that were submitted in the NIC request.
+// This avoids retrying errors about missing subnets, NSGs, or other unrelated resources.
+func isMissingSubmittedBackendPool(err error, pools *loadbalancer.BackendAddressPools) bool {
+	azErr := sdkerrors.IsResponseError(err)
+	if azErr == nil {
+		return false
+	}
+	if !strings.EqualFold(azErr.ErrorCode, invalidResourceReferenceCode) {
+		return false
+	}
+
+	// Check whether any submitted pool ID appears in the error message.
+	errMsg := strings.ToLower(err.Error())
+	for _, poolID := range pools.IPv4PoolIDs {
+		if strings.Contains(errMsg, strings.ToLower(poolID)) {
+			return true
+		}
+	}
+	for _, poolID := range pools.IPv6PoolIDs {
+		if strings.Contains(errMsg, strings.ToLower(poolID)) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/providers/instance/lberrors_test.go
+++ b/pkg/providers/instance/lberrors_test.go
@@ -1,0 +1,119 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instance
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
+	. "github.com/onsi/gomega"
+)
+
+// makeInvalidResourceReferenceError constructs an error that looks like what Azure Network RP
+// returns when a NIC references a deleted load balancer backend pool. The error wraps an
+// *azcore.ResponseError (so sdkerrors.IsResponseError finds it) and includes the referenced
+// resource ID in the message (so isMissingSubmittedBackendPool can match it).
+func makeInvalidResourceReferenceError(referencedResourceID string) error {
+	inner := &azcore.ResponseError{
+		ErrorCode:  "InvalidResourceReference",
+		StatusCode: 400,
+	}
+	return fmt.Errorf(
+		"Resource %s referenced by resource /subscriptions/sub1/resourceGroups/MC_rg/providers/Microsoft.Network/networkInterfaces/aks-test-node-abc12 was not found. "+
+			"Please make sure that the referenced resource exists, and that both resources are in the same region.: %w",
+		referencedResourceID,
+		inner,
+	)
+}
+
+func TestIsMissingSubmittedBackendPool(t *testing.T) {
+	pools := &loadbalancer.BackendAddressPools{
+		IPv4PoolIDs: []string{
+			"/subscriptions/sub1/resourceGroups/mc_rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes",
+			"/subscriptions/sub1/resourceGroups/mc_rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/aksOutboundBackendPool",
+		},
+	}
+	tests := []struct {
+		name   string
+		err    error
+		pools  *loadbalancer.BackendAddressPools
+		expect bool
+	}{
+		{
+			name:   "matching InvalidResourceReference with pool ID in message",
+			err:    makeInvalidResourceReferenceError(pools.IPv4PoolIDs[0]),
+			pools:  pools,
+			expect: true,
+		},
+		{
+			name:   "matching InvalidResourceReference with second pool ID",
+			err:    makeInvalidResourceReferenceError(pools.IPv4PoolIDs[1]),
+			pools:  pools,
+			expect: true,
+		},
+		{
+			name: "matching InvalidResourceReference with case-insensitive pool ID",
+			err: makeInvalidResourceReferenceError(
+				"/subscriptions/sub1/resourceGroups/MC_RG/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/KUBERNETES",
+			),
+			pools:  pools,
+			expect: true,
+		},
+		{
+			name: "InvalidResourceReference about a subnet does not match",
+			err: makeInvalidResourceReferenceError(
+				"/subscriptions/sub1/resourceGroups/mc_rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/default",
+			),
+			pools:  pools,
+			expect: false,
+		},
+		{
+			name:   "different error code does not match",
+			err:    fmt.Errorf("subnet issue: %w", &azcore.ResponseError{ErrorCode: "SubnetNotFound", StatusCode: 400}),
+			pools:  pools,
+			expect: false,
+		},
+		{
+			name:   "non-Azure error does not match",
+			err:    errors.New("connection refused"),
+			pools:  pools,
+			expect: false,
+		},
+		{
+			name:   "nil error does not match",
+			err:    nil,
+			pools:  pools,
+			expect: false,
+		},
+		{
+			name:   "empty pool list does not match",
+			err:    makeInvalidResourceReferenceError(pools.IPv4PoolIDs[0]),
+			pools:  &loadbalancer.BackendAddressPools{},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(isMissingSubmittedBackendPool(tt.err, tt.pools)).To(Equal(tt.expect))
+		})
+	}
+}

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -1267,4 +1267,67 @@ var _ = Describe("VMInstanceProvider", func() {
 			}))
 		})
 	})
+
+	Context("stale load balancer cache recovery", func() {
+		It("should retry NIC creation after refreshing a stale backend pool reference", func() {
+			// Seed the fake with a standard and internal LB
+			nodeResourceGroup := options.FromContext(ctx).NodeResourceGroup
+			standardLB := test.MakeStandardLoadBalancer(nodeResourceGroup, "kubernetes", true)
+			internalLB := test.MakeStandardLoadBalancer(nodeResourceGroup, "kubernetes-internal", false)
+			azureEnv.LoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
+			azureEnv.LoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(internalLB.ID), internalLB)
+
+			// Warm the LB cache so the provider has a generation-1 snapshot
+			_, err := azureEnv.LoadBalancerProvider.LoadBalancerBackendPools(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Delete the internal LB from the fake (simulates Azure-side deletion while cache is warm)
+			azureEnv.LoadBalancersAPI.LoadBalancers.Delete(lo.FromPtr(internalLB.ID))
+
+			// Make the first NIC creation fail with InvalidResourceReference for the now-deleted pool,
+			// then succeed on retry (after the LB cache is refreshed).
+			deletedPoolID := fake.MakeBackendAddressPoolID(nodeResourceGroup, "kubernetes-internal", "kubernetes")
+			nicCreateCalls := 0
+			azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.SetCustomTransformer(
+				func(input *fake.NetworkInterfaceCreateOrUpdateInput) error {
+					nicCreateCalls++
+					if nicCreateCalls == 1 {
+						return fmt.Errorf(
+							"Resource %s referenced by resource /subscriptions/test/resourceGroups/%s/providers/Microsoft.Network/networkInterfaces/%s was not found. "+
+								"Please make sure that the referenced resource exists, and that both resources are in the same region.: %w",
+							deletedPoolID,
+							nodeResourceGroup,
+							input.InterfaceName,
+							&azcore.ResponseError{ErrorCode: "InvalidResourceReference", StatusCode: 400},
+						)
+					}
+					return nil
+				},
+			)
+
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+			pod := coretest.UnschedulablePod(coretest.PodOptions{})
+			ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
+			ExpectScheduled(ctx, env.Client, pod)
+
+			// NIC creation should have been called twice: first fails, refresh, second succeeds
+			Expect(nicCreateCalls).To(Equal(2))
+
+			// The second NIC request should NOT include the deleted pool
+			Expect(azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(2))
+			// Pop returns most recent first (stack order)
+			secondNIC := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop()
+			firstNIC := azureEnv.NetworkInterfacesAPI.NetworkInterfacesCreateOrUpdateBehavior.CalledWithInput.Pop()
+
+			// First attempt included the deleted pool
+			firstPools := firstNIC.Interface.Properties.IPConfigurations[0].Properties.LoadBalancerBackendAddressPools
+			firstPoolIDs := lo.Map(firstPools, func(p *armnetwork.BackendAddressPool, _ int) string { return lo.FromPtr(p.ID) })
+			Expect(firstPoolIDs).To(ContainElement(deletedPoolID))
+
+			// Second attempt should not include the deleted pool
+			secondPools := secondNIC.Interface.Properties.IPConfigurations[0].Properties.LoadBalancerBackendAddressPools
+			secondPoolIDs := lo.Map(secondPools, func(p *armnetwork.BackendAddressPool, _ int) string { return lo.FromPtr(p.ID) })
+			Expect(secondPoolIDs).ToNot(ContainElement(deletedPoolID))
+		})
+	})
 })

--- a/pkg/providers/instance/vminstance.go
+++ b/pkg/providers/instance/vminstance.go
@@ -786,19 +786,30 @@ func (p *DefaultVMProvider) beginLaunchInstance(
 	// TODO: doing so would bypass the capacity and other errors that are currently handled by
 	// TODO: core pkg/controllers/nodeclaim/lifecycle/controller.go - in particular, there are metrics/events
 	// TODO: emitted in capacity failure cases that we probably want.
-	nicReference, err := p.createNetworkInterface(
-		ctx,
-		&createNICOptions{
-			NICName:                resourceName,
-			NetworkPlugin:          networkPlugin,
-			NetworkPluginMode:      networkPluginMode,
-			MaxPods:                utils.GetMaxPods(nodeClass, networkPlugin, networkPluginMode),
-			LaunchTemplate:         launchTemplate,
-			BackendPools:           backendPools,
-			InstanceType:           instanceType,
-			NetworkSecurityGroupID: nsgID,
-		},
-	)
+	nicOpts := &createNICOptions{
+		NICName:                resourceName,
+		NetworkPlugin:          networkPlugin,
+		NetworkPluginMode:      networkPluginMode,
+		MaxPods:                utils.GetMaxPods(nodeClass, networkPlugin, networkPluginMode),
+		LaunchTemplate:         launchTemplate,
+		BackendPools:           backendPools,
+		InstanceType:           instanceType,
+		NetworkSecurityGroupID: nsgID,
+	}
+
+	nicReference, err := p.createNetworkInterface(ctx, nicOpts)
+	if err != nil && isMissingSubmittedBackendPool(err, backendPools) {
+		log.FromContext(ctx).Info("network interface creation failed due to stale load balancer backend pool reference, refreshing",
+			"nicName", resourceName,
+			"error", err)
+		refreshedPools, refreshErr := p.loadBalancerProvider.RefreshBackendPools(ctx, backendPools)
+		if refreshErr != nil {
+			return nil, fmt.Errorf("refreshing backend pools after network interface failure: %w", refreshErr)
+		}
+		nicOpts.BackendPools = refreshedPools
+		// Try again
+		nicReference, err = p.createNetworkInterface(ctx, nicOpts)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/loadbalancer/loadbalancer.go
+++ b/pkg/providers/loadbalancer/loadbalancer.go
@@ -61,11 +61,18 @@ type Provider struct {
 	resourceGroup    string
 	cache            *cache.Cache
 	mu               sync.Mutex
+
+	// generation is incremented each time we refresh the LB list from Azure.
+	// It is used to prevent multiple callers from refreshing the LB list at the same time
+	generation uint64
 }
 
 type BackendAddressPools struct {
 	IPv4PoolIDs []string
 	IPv6PoolIDs []string // TODO: This is always empty currently
+
+	// generation is the generation of the LB list that was used to build this pool collection.
+	generation uint64
 }
 
 // NewProvider creates a new LoadBalancer provider
@@ -81,18 +88,67 @@ func NewProvider(loadBalancersAPI LoadBalancersAPI, cache *cache.Cache, resource
 // This collection is collected from Azure periodically but usually served from a cache to reduce
 // Azure request load.
 func (p *Provider) LoadBalancerBackendPools(ctx context.Context) (*BackendAddressPools, error) {
-	loadBalancers, err := p.getLoadBalancers(ctx)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.loadBalancerBackendPoolsLocked(ctx)
+}
+
+// RefreshBackendPools refreshes the LB cache if the provided pools came from
+// the same generation that is currently cached (meaning no other caller has refreshed
+// since). If a newer generation already exists, it returns pools from that generation
+// without calling Azure.
+func (p *Provider) RefreshBackendPools(ctx context.Context, observedPools *BackendAddressPools) (*BackendAddressPools, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if observedPools.generation == p.generation {
+		// Cache holds stale data. Delete so getLoadBalancersLocked re-fetches from Azure.
+		p.cache.Delete(loadBalancersCacheKey)
+	}
+
+	return p.loadBalancerBackendPoolsLocked(ctx)
+}
+
+// loadBalancerBackendPoolsLocked must be called with p.mu held.
+func (p *Provider) loadBalancerBackendPoolsLocked(ctx context.Context) (*BackendAddressPools, error) {
+	lbs, err := p.getLoadBalancersLocked(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return p.newPoolsLocked(ctx, lbs), nil
+}
+
+// getLoadBalancersLocked returns cached LBs or fetches from Azure. Must be called with p.mu held.
+func (p *Provider) getLoadBalancersLocked(ctx context.Context) ([]*armnetwork.LoadBalancer, error) {
+	if cached, ok := p.cache.Get(loadBalancersCacheKey); ok {
+		return cached.([]*armnetwork.LoadBalancer), nil
+	}
+
+	lbs, err := p.loadFromAzure(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	p.generation++
+	p.cache.SetDefault(loadBalancersCacheKey, lbs)
+
+	return lbs, nil
+}
+
+// newPoolsLocked extracts pool IDs from LBs and tags the result with the current generation.
+// Must be called with p.mu held (reads p.generation).
+func (p *Provider) newPoolsLocked(ctx context.Context, loadBalancers []*armnetwork.LoadBalancer) *BackendAddressPools {
 	backendAddressPools := lo.FlatMap(loadBalancers, extractBackendAddressPools)
 	ipv4PoolIDs := lo.FilterMap(backendAddressPools, func(backendPool *armnetwork.BackendAddressPool, idx int) (string, bool) {
 		if !isBackendAddressPoolApplicable(backendPool, idx) {
 			return "", false
 		}
-
-		return lo.FromPtr(backendPool.ID), true
+		id := lo.FromPtr(backendPool.ID)
+		if id == "" {
+			return "", false
+		}
+		return id, true
 	})
 
 	log.FromContext(ctx).V(1).Info("returning IPv4 backend pools", "ipv4PoolCount", len(ipv4PoolIDs), "ipv4PoolIDs", ipv4PoolIDs)
@@ -103,27 +159,8 @@ func (p *Provider) LoadBalancerBackendPools(ctx context.Context) (*BackendAddres
 	return &BackendAddressPools{
 		IPv4PoolIDs: ipv4PoolIDs,
 		// TODO: IPv6 deferred for now. When they're used they must be put onto a non-primary NIC.
-	}, nil
-}
-
-func (p *Provider) getLoadBalancers(ctx context.Context) ([]*armnetwork.LoadBalancer, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if cached, ok := p.cache.Get(loadBalancersCacheKey); ok {
-		return cached.([]*armnetwork.LoadBalancer), nil
+		generation: p.generation,
 	}
-
-	lbs, err := p.loadFromAzure(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// If we wanted to hyper-optimize, we could set a much longer timeout once we find the -internal LB, as at that point we're "done" and
-	// aren't particularly interested in LB changes anymore.
-	p.cache.SetDefault(loadBalancersCacheKey, lbs)
-
-	return lbs, nil
 }
 
 func (p *Provider) loadFromAzure(ctx context.Context) ([]*armnetwork.LoadBalancer, error) {

--- a/pkg/providers/loadbalancer/suite_test.go
+++ b/pkg/providers/loadbalancer/suite_test.go
@@ -21,11 +21,9 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
-	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/karpenter-provider-azure/pkg/fake"
@@ -33,101 +31,144 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
 )
 
-var ctx context.Context
-var stop context.CancelFunc
+const resourceGroup = "test-rg"
 
-var resourceGroup string
-var fakeLoadBalancersAPI *fake.LoadBalancersAPI
-var loadBalancerProvider *loadbalancer.Provider
-var loadBalancerCache *cache.Cache
-
-func TestAKS(t *testing.T) {
-	ctx = TestContextWithLogger(t)
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Providers/LoadBalancer/AKS")
+type testFixture struct {
+	ctx      context.Context
+	api      *fake.LoadBalancersAPI
+	cache    *cache.Cache
+	provider *loadbalancer.Provider
 }
 
-var _ = BeforeSuite(func() {
-	ctx, stop = context.WithCancel(ctx)
+func newTestFixture(t *testing.T) *testFixture {
+	t.Helper()
+	ctx := context.Background()
+	api := &fake.LoadBalancersAPI{}
+	c := cache.New(time.Second, time.Second)
+	provider := loadbalancer.NewProvider(api, c, resourceGroup)
+	return &testFixture{ctx: ctx, api: api, cache: c, provider: provider}
+}
 
-	fakeLoadBalancersAPI = &fake.LoadBalancersAPI{}
-	resourceGroup = "test-rg"
-	loadBalancerCache = cache.New(time.Second, time.Second)
-	loadBalancerProvider = loadbalancer.NewProvider(fakeLoadBalancersAPI, loadBalancerCache, resourceGroup)
-})
+func TestLoadBalancerBackendPools_ReturnsOnlyWellKnownPools(t *testing.T) {
+	g := NewWithT(t)
+	f := newTestFixture(t)
 
-var _ = AfterSuite(func() {
-	stop()
-})
+	standardLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBName, true)
+	internalLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.InternalSLBName, false)
+	otherLB := test.MakeStandardLoadBalancer(resourceGroup, "some-lb", true)
 
-var _ = BeforeEach(func() {
-	fakeLoadBalancersAPI.Reset()
-	loadBalancerCache.Flush()
-})
+	f.api.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
+	f.api.LoadBalancers.Store(lo.FromPtr(internalLB.ID), internalLB)
+	f.api.LoadBalancers.Store(lo.FromPtr(otherLB.ID), otherLB)
 
-var _ = Describe("LoadBalancer Provider", func() {
-	Context("Backend pools", func() {
-		It("should return only well-known loadbalancer pools", func() {
-			standardLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBName, true)
-			internalLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.InternalSLBName, false)
-			otherLB := test.MakeStandardLoadBalancer(resourceGroup, "some-lb", true)
+	pools, err := f.provider.LoadBalancerBackendPools(f.ctx)
+	g.Expect(err).ToNot(HaveOccurred())
 
-			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(internalLB.ID), internalLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(otherLB.ID), otherLB)
+	g.Expect(pools.IPv4PoolIDs).To(HaveLen(3))
+	g.Expect(pools.IPv6PoolIDs).To(HaveLen(0))
+	g.Expect(pools.IPv4PoolIDs[0]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"))
+	g.Expect(pools.IPv4PoolIDs[1]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/aksOutboundBackendPool"))
+	g.Expect(pools.IPv4PoolIDs[2]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes-internal/backendAddressPools/kubernetes"))
+}
 
-			pools, err := loadBalancerProvider.LoadBalancerBackendPools(ctx)
-			Expect(err).ToNot(HaveOccurred())
+func TestLoadBalancerBackendPools_DoesNotReturnIPv6Pools(t *testing.T) {
+	g := NewWithT(t)
+	f := newTestFixture(t)
 
-			Expect(pools.IPv4PoolIDs).To(HaveLen(3))
-			Expect(pools.IPv6PoolIDs).To(HaveLen(0))
-			Expect(pools.IPv4PoolIDs[0]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"))
-			Expect(pools.IPv4PoolIDs[1]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/aksOutboundBackendPool"))
-			Expect(pools.IPv4PoolIDs[2]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes-internal/backendAddressPools/kubernetes"))
-		})
+	standardLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBName, true)
+	internalLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.InternalSLBName, false)
+	otherLB := test.MakeStandardLoadBalancer(resourceGroup, "some-lb", true)
+	ipv6LB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBNameIPv6, true)
 
-		It("should not return IPV6 pools", func() {
-			standardLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBName, true)
-			internalLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.InternalSLBName, false)
-			otherLB := test.MakeStandardLoadBalancer(resourceGroup, "some-lb", true)
-			ipv6LB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBNameIPv6, true)
+	f.api.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
+	f.api.LoadBalancers.Store(lo.FromPtr(internalLB.ID), internalLB)
+	f.api.LoadBalancers.Store(lo.FromPtr(otherLB.ID), otherLB)
+	f.api.LoadBalancers.Store(lo.FromPtr(ipv6LB.ID), ipv6LB)
 
-			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(internalLB.ID), internalLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(otherLB.ID), otherLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(ipv6LB.ID), ipv6LB)
+	pools, err := f.provider.LoadBalancerBackendPools(f.ctx)
+	g.Expect(err).ToNot(HaveOccurred())
 
-			pools, err := loadBalancerProvider.LoadBalancerBackendPools(ctx)
-			Expect(err).ToNot(HaveOccurred())
+	g.Expect(pools.IPv4PoolIDs).To(HaveLen(3))
+	g.Expect(pools.IPv6PoolIDs).To(HaveLen(0))
+	g.Expect(pools.IPv4PoolIDs[0]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"))
+	g.Expect(pools.IPv4PoolIDs[1]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/aksOutboundBackendPool"))
+	g.Expect(pools.IPv4PoolIDs[2]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes-internal/backendAddressPools/kubernetes"))
+}
 
-			Expect(pools.IPv4PoolIDs).To(HaveLen(3))
-			Expect(pools.IPv6PoolIDs).To(HaveLen(0))
-			Expect(pools.IPv4PoolIDs[0]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"))
-			Expect(pools.IPv4PoolIDs[1]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/aksOutboundBackendPool"))
-			Expect(pools.IPv4PoolIDs[2]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes-internal/backendAddressPools/kubernetes"))
-		})
+func TestLoadBalancerBackendPools_DoesNotReturnIPBasedPools(t *testing.T) {
+	g := NewWithT(t)
+	f := newTestFixture(t)
 
-		It("should not return IP-based pools", func() {
-			standardLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBName, true)
-			standardLB.Properties.BackendAddressPools[1].Properties.LoadBalancerBackendAddresses = []*armnetwork.LoadBalancerBackendAddress{
-				{
-					Properties: &armnetwork.LoadBalancerBackendAddressPropertiesFormat{
-						IPAddress: lo.ToPtr("1.2.3.4"),
-					},
-				},
-			}
-			internalLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.InternalSLBName, false)
+	standardLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBName, true)
+	standardLB.Properties.BackendAddressPools[1].Properties.LoadBalancerBackendAddresses = []*armnetwork.LoadBalancerBackendAddress{
+		{
+			Properties: &armnetwork.LoadBalancerBackendAddressPropertiesFormat{
+				IPAddress: lo.ToPtr("1.2.3.4"),
+			},
+		},
+	}
+	internalLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.InternalSLBName, false)
 
-			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
-			fakeLoadBalancersAPI.LoadBalancers.Store(lo.FromPtr(internalLB.ID), internalLB)
+	f.api.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
+	f.api.LoadBalancers.Store(lo.FromPtr(internalLB.ID), internalLB)
 
-			pools, err := loadBalancerProvider.LoadBalancerBackendPools(ctx)
-			Expect(err).ToNot(HaveOccurred())
+	pools, err := f.provider.LoadBalancerBackendPools(f.ctx)
+	g.Expect(err).ToNot(HaveOccurred())
 
-			Expect(pools.IPv4PoolIDs).To(HaveLen(2))
-			Expect(pools.IPv6PoolIDs).To(HaveLen(0))
-			Expect(pools.IPv4PoolIDs[0]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"))
-			Expect(pools.IPv4PoolIDs[1]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes-internal/backendAddressPools/kubernetes"))
-		})
-	})
-})
+	g.Expect(pools.IPv4PoolIDs).To(HaveLen(2))
+	g.Expect(pools.IPv6PoolIDs).To(HaveLen(0))
+	g.Expect(pools.IPv4PoolIDs[0]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"))
+	g.Expect(pools.IPv4PoolIDs[1]).To(Equal("/subscriptions/subscriptionID/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes-internal/backendAddressPools/kubernetes"))
+}
+
+func TestRefreshBackendPools_RefreshesWhenGenerationMatchesCurrentCache(t *testing.T) {
+	g := NewWithT(t)
+	f := newTestFixture(t)
+
+	standardLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBName, true)
+	f.api.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
+
+	pools, err := f.provider.LoadBalancerBackendPools(f.ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(pools.IPv4PoolIDs).To(HaveLen(2))
+	g.Expect(f.api.NewListPagerBehavior.Calls()).To(Equal(1))
+
+	// Simulate LB deletion
+	f.api.LoadBalancers.Clear()
+
+	refreshed, err := f.provider.RefreshBackendPools(f.ctx, pools)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(refreshed.IPv4PoolIDs).To(HaveLen(0))
+	g.Expect(f.api.NewListPagerBehavior.Calls()).To(Equal(2))
+
+	// Subsequent LoadBalancerBackendPools should serve from the refreshed cache
+	pools2, err := f.provider.LoadBalancerBackendPools(f.ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(pools2.IPv4PoolIDs).To(HaveLen(0))
+	g.Expect(f.api.NewListPagerBehavior.Calls()).To(Equal(2)) // no additional call
+}
+
+func TestRefreshBackendPools_ReusesNewerGenerationWithoutCallingAzure(t *testing.T) {
+	g := NewWithT(t)
+	f := newTestFixture(t)
+
+	standardLB := test.MakeStandardLoadBalancer(resourceGroup, loadbalancer.SLBName, true)
+	f.api.LoadBalancers.Store(lo.FromPtr(standardLB.ID), standardLB)
+
+	// Get gen 1
+	pools1, err := f.provider.LoadBalancerBackendPools(f.ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(f.api.NewListPagerBehavior.Calls()).To(Equal(1))
+
+	// Force a refresh to gen 2
+	f.cache.Flush()
+	pools2, err := f.provider.LoadBalancerBackendPools(f.ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(f.api.NewListPagerBehavior.Calls()).To(Equal(2))
+
+	// Now try to refresh with stale gen-1 pools — should NOT call Azure again
+	refreshed, err := f.provider.RefreshBackendPools(f.ctx, pools1)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(f.api.NewListPagerBehavior.Calls()).To(Equal(2)) // no new call
+	g.Expect(refreshed.IPv4PoolIDs).To(HaveLen(len(pools2.IPv4PoolIDs)))
+}


### PR DESCRIPTION
* When CloudProvider deletes a managed loadbalancer it can take Karpenter up to 2 hours to pick up on that deletion. In the meantime, NIC creation fails due to InvalidResourceReference. This change fixes this behavior so that Karpenter detects the deletion immedaitely and reacts to unblock VM/NIC creation.

**How was this change tested?**

* Unit tests
* E2E: https://github.com/Azure/karpenter-provider-azure/actions/runs/29440679302

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
