### PR TITLE
fix: use aks-gpu-cuda-lts for compute GPU SKUs to match AgentBaker VHD prebake

### DIFF
--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1640,9 +1640,9 @@ var _ = Describe("InstanceType Provider", func() {
 					ContainSubstring("MIG_NODE=false"),
 					ContainSubstring("CONFIG_GPU_DRIVER_IF_NEEDED=true"),
 					ContainSubstring("ENABLE_GPU_DEVICE_PLUGIN_IF_NEEDED=false"),
-					ContainSubstring("GPU_DRIVER_TYPE=\"cuda\""),
-					ContainSubstring(fmt.Sprintf("GPU_DRIVER_VERSION=\"%s\"", utils.NvidiaCudaDriverVersion)),
-					ContainSubstring(fmt.Sprintf("GPU_IMAGE_SHA=\"%s\"", utils.AKSGPUCudaVersionSuffix)),
+					ContainSubstring("GPU_DRIVER_TYPE=\"cuda-lts\""),
+					ContainSubstring(fmt.Sprintf("GPU_DRIVER_VERSION=\"%s\"", utils.NvidiaCudaLTSDriverVersion)),
+					ContainSubstring(fmt.Sprintf("GPU_IMAGE_SHA=\"%s\"", utils.AKSGPUCudaLTSVersionSuffix)),
 					ContainSubstring("GPU_NEEDS_FABRIC_MANAGER=\"false\""),
 					ContainSubstring("GPU_INSTANCE_PROFILE=\"\""),
 				))

--- a/pkg/utils/gpu.go
+++ b/pkg/utils/gpu.go
@@ -28,9 +28,20 @@ import (
 const (
 	Nvidia470CudaDriverVersion = "470.82.01"
 
-	// https://github.com/Azure/AgentBaker/blob/12d432b5fea64a6cda718df6e1ab851211b49c74/parts/common/components.json#L740-L752
+	// Default managed CUDA path. AgentBaker migrated modern compute SKUs (T4, V100, A100, H100, ...)
+	// from aks-gpu-cuda to the R580 LTS image aks-gpu-cuda-lts (AgentBaker #8811/#8822; see
+	// baker.go GetGPUDriverType/GetGPUDriverVersion and parts/common/components.json aks-gpu-cuda-lts).
+	// These MUST match the driver prebaked into the shared Ubuntu VHDs; otherwise the kernel module
+	// installed at bootstrap diverges from the VHD's userspace libnvidia-ml and NVML fails with
+	// "Driver/library version mismatch" (nvidia.com/gpu never advertised).
+	// https://github.com/Azure/AgentBaker/blob/main/parts/common/components.json (aks-gpu-cuda-lts)
+	NvidiaCudaLTSDriverVersion = "580.159.04"
+	AKSGPUCudaLTSVersionSuffix = "20260629214430"
+
+	// Pre-LTS CUDA image (aks-gpu-cuda). No longer the default compute driver; retained for legacy
+	// reference / parity with AgentBaker's components.json.
 	NvidiaCudaDriverVersion = "580.126.09"
-	AKSGPUCudaVersionSuffix = "20260126030251"
+	AKSGPUCudaVersionSuffix = "20260430040408"
 
 	NvidiaGridDriverVersion = "570.211.01"
 	AKSGPUGridVersionSuffix = "20260522192315"
@@ -97,7 +108,7 @@ func GetAKSGPUImageSHA(size string) string {
 	if UseGridDrivers(size) {
 		return AKSGPUGridVersionSuffix
 	}
-	return AKSGPUCudaVersionSuffix
+	return AKSGPUCudaLTSVersionSuffix
 }
 
 // IsNvidiaEnabledSKU determines if an VM SKU has nvidia driver support
@@ -130,10 +141,13 @@ func GetGPUDriverVersion(size string) string {
 	if isStandardNCv1(size) {
 		return Nvidia470CudaDriverVersion
 	}
-	return NvidiaCudaDriverVersion
+	return NvidiaCudaLTSDriverVersion
 }
 
-// GetGPUDriverType returns the type of GPU driver for given VM SKU ("grid-v20", "grid", or "cuda")
+// GetGPUDriverType returns the type of GPU driver for given VM SKU ("grid-v20", "grid", "cuda-lts", or "cuda").
+// Mirrors AgentBaker's GetGPUDriverType: modern CUDA compute SKUs use the R580 LTS image (cuda-lts);
+// legacy NCv1 (K80) keeps "cuda". The type selects the aks-gpu-<type> container image installed at
+// bootstrap and must match the driver prebaked into the shared Ubuntu VHD.
 func GetGPUDriverType(size string) string {
 	if UseGridV20Drivers(size) {
 		return "grid-v20"
@@ -141,7 +155,10 @@ func GetGPUDriverType(size string) string {
 	if UseGridDrivers(size) {
 		return "grid"
 	}
-	return "cuda"
+	if isStandardNCv1(size) {
+		return "cuda"
+	}
+	return "cuda-lts"
 }
 
 func isStandardNCv1(size string) bool {

--- a/pkg/utils/gpu_test.go
+++ b/pkg/utils/gpu_test.go
@@ -33,12 +33,12 @@ func TestGetAKSGPUImageSHA(t *testing.T) {
 		{"GRID v20 Driver - RTX PRO 6000 BSE ds", "standard_nc144ds_xl_rtxpro6000bse_v6", AKSGPUGridV20VersionSuffix, "grid-v20"},
 		{"GRID v20 Driver - RTX PRO 6000 BSE lds", "standard_nc144lds_xl_rtxpro6000bse_v6", AKSGPUGridV20VersionSuffix, "grid-v20"},
 		{"GRID v20 Driver - RTX PRO 6000 BSE mixed case", "Standard_NC24lds_xl_RTXPRO6000BSE_v6", AKSGPUGridV20VersionSuffix, "grid-v20"},
-		{"Cuda Driver - NV Series", "standard_nv6", AKSGPUCudaVersionSuffix, "cuda"},
-		{"CUDA Driver - NC Series", "standard_nc6s_v3", AKSGPUCudaVersionSuffix, "cuda"},
+		{"CUDA-LTS Driver - NV Series", "standard_nv6", AKSGPUCudaLTSVersionSuffix, "cuda-lts"},
+		{"CUDA-LTS Driver - NC Series", "standard_nc6s_v3", AKSGPUCudaLTSVersionSuffix, "cuda-lts"},
 		{"GRID Driver - NV Series v5", "standard_nv6ads_a10_v5", AKSGPUGridVersionSuffix, "grid"},
-		{"Unknown SKU", "unknown_sku", AKSGPUCudaVersionSuffix, "cuda"},
-		{"CUDA Driver - NC Series v2", "standard_nc6s_v2", AKSGPUCudaVersionSuffix, "cuda"},
-		{"CUDA Driver - NV Series v3", "standard_nv12s_v3", AKSGPUCudaVersionSuffix, "cuda"},
+		{"CUDA-LTS Driver - Unknown SKU", "unknown_sku", AKSGPUCudaLTSVersionSuffix, "cuda-lts"},
+		{"CUDA-LTS Driver - NC Series v2", "standard_nc6s_v2", AKSGPUCudaLTSVersionSuffix, "cuda-lts"},
+		{"CUDA-LTS Driver - NV Series v3", "standard_nv12s_v3", AKSGPUCudaLTSVersionSuffix, "cuda-lts"},
 	}
 
 	for _, test := range tests {
@@ -61,9 +61,9 @@ func TestGetGPUDriverVersion(t *testing.T) {
 		{"GRID v20 Driver - RTX PRO 6000 BSE lds", "standard_nc144lds_xl_rtxpro6000bse_v6", NvidiaGridV20DriverVersion},
 		{"GRID v20 Driver - RTX PRO 6000 BSE mixed case", "Standard_NC24lds_xl_RTXPRO6000BSE_v6", NvidiaGridV20DriverVersion},
 		{"CUDA Driver - NC Series v1", "standard_nc6s", Nvidia470CudaDriverVersion},
-		{"CUDA Driver - NC Series v2", "standard_nc6s_v2", NvidiaCudaDriverVersion},
-		{"Unknown SKU", "unknown_sku", NvidiaCudaDriverVersion},
-		{"CUDA Driver - NC Series v3", "standard_nc6s_v3", NvidiaCudaDriverVersion},
+		{"CUDA-LTS Driver - NC Series v2", "standard_nc6s_v2", NvidiaCudaLTSDriverVersion},
+		{"CUDA-LTS Driver - Unknown SKU", "unknown_sku", NvidiaCudaLTSDriverVersion},
+		{"CUDA-LTS Driver - NC Series v3", "standard_nc6s_v3", NvidiaCudaLTSDriverVersion},
 		{"GRID Driver - A10", "standard_nc8ads_a10_v4", NvidiaGridDriverVersion},
 	}
 


### PR DESCRIPTION
## Problem

karpenter installs `aks-gpu-cuda` (580.126.09) on CUDA compute SKUs (NCv2/NCv3/T4/A100/H100 — everything except NCv1 K80 and the GRID NV-series). AgentBaker moved these SKUs to `aks-gpu-cuda-lts` (580.159.04) in Azure/AgentBaker#8811 and #8822, and the shared Ubuntu VHDs now prebake cuda-lts.

The driver karpenter installs at bootstrap therefore no longer matches the userspace `libnvidia-ml` prebaked in the VHD. NVML fails to initialize (`Driver/library version mismatch`), the device plugin never registers, and `nvidia.com/gpu` is not advertised — GPU pods stay Pending.

Grid, grid-v20, and NCv1 driver selection are already correct; only the default CUDA path is stale.

## Change

Align `pkg/utils/gpu.go` with AgentBaker's `GetGPUDriverType` / `GetGPUDriverVersion`:

- Add `NvidiaCudaLTSDriverVersion` / `AKSGPUCudaLTSVersionSuffix` and return them from `GetGPUDriverVersion` and `GetAKSGPUImageSHA` for the default CUDA path.
- `GetGPUDriverType` returns `cuda-lts` for the CUDA path; NCv1 (K80) still returns `cuda` (R470).
- Refresh the retained `aks-gpu-cuda` suffix to AgentBaker's current value for parity (it is no longer selected at runtime).

Values are taken verbatim from AgentBaker `parts/common/components.json`.

## Scope / safety

Only the self-contained CSE bootstrap path (`Options` → `cse_cmd.sh.gtpl`) consumes these functions; it now emits `GPU_DRIVER_TYPE="cuda-lts"`, which AgentBaker's CSE resolves to `mcr.microsoft.com/aks/aks-gpu-cuda-lts` with the matching version/SHA. The RP-API bootstrap path (`ProvisionClientBootstrap`, `GPUProfile.DriverType`) does not use these functions and is unchanged — it already resolves the driver server-side. Both paths stay consistent.

No change to which SKUs are GPU-enabled, to grid/grid-v20/NCv1 selection, or to `InstallGPUDriver` behavior.

## Risk

Medium. This changes the driver installed on every CUDA compute GPU node karpenter provisions — but that is the fix: it aligns the installed driver with the VHD prebake, replacing a mismatch that already breaks GPU advertisement. The blast radius is bounded to the CUDA compute path; grid/grid-v20/NCv1 and the RP-API path are untouched, and the values are copied verbatim from AgentBaker. The main residual risk is future drift: these constants are still manually mirrored (see the existing `// TODO: Get these from agentbaker`), so the next AgentBaker driver bump reintroduces the same skew until that sync is automated.

## Testing

- `pkg/utils` unit tests updated and passing (compute SKUs → cuda-lts type + LTS version/SHA; NCv1 → cuda/R470).
- Updated the T4 (`Standard_NC16as_T4_v3`) bootstrap-payload assertion in `pkg/providers/instancetype/suite_test.go` to expect `GPU_DRIVER_TYPE="cuda-lts"` and the LTS version/SHA.
- `go build ./...` and `go vet ./pkg/utils/...` clean. The instancetype Ginkgo suite requires envtest binaries not present locally (panics at `test.NewEnvironment` on unmodified `main` too); it runs in CI.

Refs: Azure/AgentBaker#8811, Azure/AgentBaker#8822.