### PR TITLE
test(e2e): make scheduling label coverage filter-aware

### DIFF
--- a/test/suites/scheduling/suite_test.go
+++ b/test/suites/scheduling/suite_test.go
@@ -88,20 +88,18 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 			// Can't test FIPS if not using SIG
 			selectors.Insert(v1beta1.AKSLabelFIPSEnabled)
 		}
-
-		// If no spec with Label("GPU") ran (e.g., `-label-filter='!GPU'`),
-		// ignore GPU labels in the coverage assertion.
-		if !Label("GPU").MatchesLabelFilter(GinkgoLabelFilter()) {
-			selectors.Insert(
-				v1beta1.LabelSKUGPUCount,
-				v1beta1.LabelSKUGPUManufacturer,
-			)
-		}
-
 	})
 	AfterAll(func() {
-		// Ensure that we're exercising all well known labels (with the above exceptions)
-		Expect(lo.Keys(selectors)).To(ContainElements(append(karpv1.WellKnownLabels.UnsortedList(), lo.Keys(karpv1.NormalizedLabels)...)))
+		// All selector tests are unlabeled except the GPU test, so only require coverage from tests selected by the label filter.
+		expectedSelectors := sets.New(append(karpv1.WellKnownLabels.UnsortedList(), lo.Keys(karpv1.NormalizedLabels)...)...)
+		gpuSelectors := sets.New(v1beta1.LabelSKUGPUCount, v1beta1.LabelSKUGPUManufacturer)
+		if !Label().MatchesLabelFilter(GinkgoLabelFilter()) { // unlabeled tests did not run (were filtered out)
+			expectedSelectors = gpuSelectors // only require GPU selector coverage
+		}
+		if !Label("GPU").MatchesLabelFilter(GinkgoLabelFilter()) { // GPU tests did not run (were filtered out)
+			expectedSelectors = expectedSelectors.Difference(gpuSelectors) // don't require GPU selectors coverage
+		}
+		Expect(selectors.UnsortedList()).To(ContainElements(expectedSelectors.UnsortedList()))
 	})
 
 	It("should apply annotations to the node", func() {

--- a/test/suites/scheduling/suite_test.go
+++ b/test/suites/scheduling/suite_test.go
@@ -133,6 +133,7 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 				v1beta1.LabelSKUAcceleratedNetworking:     "true",
 				v1beta1.LabelSKUStoragePremiumCapable:     "true",
 				v1beta1.LabelSKUStorageEphemeralOSMaxSize: "53",
+				v1beta1.LabelUltraSSD:                     "false",
 				v1beta1.AKSLabelCluster:                   env.NodeResourceGroup,
 				v1beta1.AKSLabelMode:                      "system",
 				v1beta1.AKSLabelScaleSetPriority:          "regular",


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

**Description**

Ensure the scheduling suite's well-known-label coverage assertion reflects the specs selected by the active Ginkgo label filter, both GPU and !GPU.

- Require only GPU selector coverage during `GPU`-only runs.
- Exclude GPU selectors during `!GPU` runs.
- Preserve full coverage validation when both test groups run.
- Add coverage for the recently introduced Ultra SSD label (follow-up to https://github.com/Azure/karpenter-provider-azure/pull/1797)

**How was this change tested?**

* E2E: https://github.com/Azure/karpenter-provider-azure/actions/runs/29795716128

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
