### PR TITLE
feat: request security-patch node images on the SecurityPatch channel

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -50,8 +50,8 @@ const (
 	// autoUpgradeProfile.nodeOSUpgradeChannel and are surfaced to Karpenter so it
 	// can select the appropriate node image lineage. An empty value means the
 	// channel is unset/unknown and standard node images are used.
-	NodeOSUpgradeChannelNone          = "None"
-	NodeOSUpgradeChannelUnmanaged     = "Unmanaged"
+	// Only the AKS-managed channels are represented here: the None and Unmanaged
+	// channels have no meaning for NAP node image selection and are never surfaced.
 	NodeOSUpgradeChannelSecurityPatch = "SecurityPatch"
 	NodeOSUpgradeChannelNodeImage     = "NodeImage"
 

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -46,6 +46,15 @@ const (
 	ProvisionModeAKSMachineAPI            = "aksmachineapi"
 	ProvisionModeAKSMachineAPIHeaderBatch = "aksmachineapiheaderbatch"
 
+	// Node OS upgrade channel values. These mirror the managed cluster's
+	// autoUpgradeProfile.nodeOSUpgradeChannel and are surfaced to Karpenter so it
+	// can select the appropriate node image lineage. An empty value means the
+	// channel is unset/unknown and standard node images are used.
+	NodeOSUpgradeChannelNone          = "None"
+	NodeOSUpgradeChannelUnmanaged     = "Unmanaged"
+	NodeOSUpgradeChannelSecurityPatch = "SecurityPatch"
+	NodeOSUpgradeChannelNodeImage     = "NodeImage"
+
 	AKSMachineAPIHeaderBatchMaxSize = 50
 
 	// Provisioning states for AKS Machine objects.

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -82,8 +82,13 @@ type Options struct {
 	SubnetID                string   `json:"subnetId,omitempty"`                // => VnetSubnetID to use (for nodes in Azure CNI Overlay and Azure CNI + pod subnet; for for nodes and pods in Azure CNI), unless overridden via AKSNodeClass
 	setFlags                map[string]bool
 
-	ProvisionMode              string            `json:"provisionMode,omitempty"`
-	NodeOSUpgradeChannel       string            `json:"nodeOSUpgradeChannel,omitempty"` // => Mirrors the managed cluster's autoUpgradeProfile.nodeOSUpgradeChannel; drives node image lineage selection (e.g. SecurityPatch)
+	ProvisionMode string `json:"provisionMode,omitempty"`
+	// NodeOSUpgradeChannel mirrors the managed cluster's autoUpgradeProfile.nodeOSUpgradeChannel.
+	// Only the AKS-managed channels are surfaced: "SecurityPatch" (currently acted on: Karpenter
+	// requests security-patch node images) and "NodeImage" (reserved for future use). The None and
+	// Unmanaged channels are intentionally not surfaced as they have no meaning for NAP node image
+	// selection; an empty value means standard node images are used.
+	NodeOSUpgradeChannel       string            `json:"nodeOSUpgradeChannel,omitempty"`
 	NodeBootstrappingServerURL string            `json:"-"`
 	UseSIG                     bool              `json:"useSIG,omitempty"` // => UseSIG is true if Karpenter is managed by AKS, false if it is a self-hosted karpenter installation
 	SIGAccessTokenServerURL    string            `json:"-"`                // => SIGAccessTokenServerURL used to access SIG, not set if it is a self-hosted karpenter installation

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -83,6 +83,7 @@ type Options struct {
 	setFlags                map[string]bool
 
 	ProvisionMode              string            `json:"provisionMode,omitempty"`
+	NodeOSUpgradeChannel       string            `json:"nodeOSUpgradeChannel,omitempty"` // => Mirrors the managed cluster's autoUpgradeProfile.nodeOSUpgradeChannel; drives node image lineage selection (e.g. SecurityPatch)
 	NodeBootstrappingServerURL string            `json:"-"`
 	UseSIG                     bool              `json:"useSIG,omitempty"` // => UseSIG is true if Karpenter is managed by AKS, false if it is a self-hosted karpenter installation
 	SIGAccessTokenServerURL    string            `json:"-"`                // => SIGAccessTokenServerURL used to access SIG, not set if it is a self-hosted karpenter installation
@@ -120,6 +121,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.SubnetID, "vnet-subnet-id", env.WithDefaultString("VNET_SUBNET_ID", ""), "[REQUIRED] The default subnet ID to use for new nodes. This must be a valid ARM resource ID for subnet that does not overlap with the service CIDR or the pod CIDR.")
 	fs.Var(newNodeIdentitiesValue(env.WithDefaultString("NODE_IDENTITIES", ""), &o.NodeIdentities), "node-identities", "User assigned identities for nodes.")
 	fs.StringVar(&o.ProvisionMode, "provision-mode", env.WithDefaultString("PROVISION_MODE", consts.ProvisionModeAKSScriptless), "[UNSUPPORTED] The provision mode for the cluster.")
+	fs.StringVar(&o.NodeOSUpgradeChannel, "node-os-upgrade-channel", env.WithDefaultString("NODE_OS_UPGRADE_CHANNEL", ""), "The managed cluster node OS upgrade channel (e.g. 'SecurityPatch', 'NodeImage', 'None', 'Unmanaged'). When 'SecurityPatch' and use-sig is true, Karpenter requests security-patch node images. Only takes effect for AKS managed karpenter (use-sig=true).")
 	fs.StringVar(&o.NodeBootstrappingServerURL, "nodebootstrapping-server-url", env.WithDefaultString("NODEBOOTSTRAPPING_SERVER_URL", ""), "[UNSUPPORTED] The url for the node bootstrapping provider server.")
 	fs.StringVar(&o.NodeResourceGroup, "node-resource-group", env.WithDefaultString("AZURE_NODE_RESOURCE_GROUP", ""), "[REQUIRED] the resource group created and managed by AKS where the nodes live")
 	fs.StringVar(&o.KubeletIdentityClientID, "kubelet-identity-client-id", env.WithDefaultString("KUBELET_IDENTITY_CLIENT_ID", ""), "The client ID of the kubelet identity.")
@@ -145,6 +147,12 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 // IsAKSMachineAPIMode returns true if the current provision mode creates instances via the AKS Machine API.
 func (o *Options) IsAKSMachineAPIMode() bool {
 	return o.ProvisionMode == consts.ProvisionModeAKSMachineAPI || o.ProvisionMode == consts.ProvisionModeAKSMachineAPIHeaderBatch
+}
+
+// IsSecurityPatchChannel returns true if the cluster's node OS upgrade channel is SecurityPatch.
+// In this mode Karpenter should source node images from the security-patch lineage.
+func (o *Options) IsSecurityPatchChannel() bool {
+	return o.NodeOSUpgradeChannel == consts.NodeOSUpgradeChannelSecurityPatch
 }
 
 func (o *Options) GetAPIServerName() string {

--- a/pkg/operator/options/options_validation.go
+++ b/pkg/operator/options/options_validation.go
@@ -43,6 +43,7 @@ func (o *Options) Validate() error {
 		o.validateVMMemoryOverheadPercent(),
 		o.validateVnetSubnetID(),
 		o.validateProvisionMode(),
+		o.validateNodeOSUpgradeChannel(),
 		o.validateUseSIG(),
 		o.validateAdminUsername(),
 		o.validateAdditionalTags(),
@@ -140,6 +141,19 @@ func (o *Options) validateProvisionMode() error {
 		}
 	}
 	return nil
+}
+
+func (o *Options) validateNodeOSUpgradeChannel() error {
+	switch o.NodeOSUpgradeChannel {
+	case "",
+		consts.NodeOSUpgradeChannelNone,
+		consts.NodeOSUpgradeChannelUnmanaged,
+		consts.NodeOSUpgradeChannelSecurityPatch,
+		consts.NodeOSUpgradeChannelNodeImage:
+		return nil
+	default:
+		return fmt.Errorf("node-os-upgrade-channel is invalid: %s", o.NodeOSUpgradeChannel)
+	}
 }
 
 func (o *Options) validateBatchOptions() error {

--- a/pkg/operator/options/options_validation.go
+++ b/pkg/operator/options/options_validation.go
@@ -146,8 +146,6 @@ func (o *Options) validateProvisionMode() error {
 func (o *Options) validateNodeOSUpgradeChannel() error {
 	switch o.NodeOSUpgradeChannel {
 	case "",
-		consts.NodeOSUpgradeChannelNone,
-		consts.NodeOSUpgradeChannelUnmanaged,
 		consts.NodeOSUpgradeChannelSecurityPatch,
 		consts.NodeOSUpgradeChannelNodeImage:
 		return nil

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -447,6 +447,33 @@ var _ = Describe("Options", func() {
 			)
 			Expect(err).To(MatchError(ContainSubstring("invalid")))
 		})
+		It("should fail validation when NodeOSUpgradeChannel is not valid", func() {
+			err := opts.Parse(
+				fs,
+				"--cluster-name", "my-name",
+				"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+				"--kubelet-bootstrap-token", "flag-bootstrap-token",
+				"--ssh-public-key", "flag-ssh-public-key",
+				"--vnet-subnet-id", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub",
+				"--node-resource-group", "my-node-rg",
+				"--node-os-upgrade-channel", "NotAChannel",
+			)
+			Expect(err).To(MatchError(ContainSubstring("node-os-upgrade-channel is invalid")))
+		})
+		It("should pass validation when NodeOSUpgradeChannel is SecurityPatch", func() {
+			err := opts.Parse(
+				fs,
+				"--cluster-name", "my-name",
+				"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+				"--kubelet-bootstrap-token", "flag-bootstrap-token",
+				"--ssh-public-key", "flag-ssh-public-key",
+				"--vnet-subnet-id", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub",
+				"--node-resource-group", "my-node-rg",
+				"--node-os-upgrade-channel", "SecurityPatch",
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(opts.IsSecurityPatchChannel()).To(BeTrue())
+		})
 		It("should fail validation when ProvisionMode is bootstrappingclient but NodebootstrappingServerURL is not provided", func() {
 			err := opts.Parse(
 				fs,

--- a/pkg/providers/azclient/azclient.go
+++ b/pkg/providers/azclient/azclient.go
@@ -186,7 +186,14 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *auth.Environment, c
 		return nil, err
 	}
 
-	nodeImageVersionsClient, err := imagefamily.NewNodeImageVersionsClient(cfg.SubscriptionID, cred, opts)
+	// copy the options to avoid modifying the original, so we can optionally
+	// attach the SecurityPatchOnly header policy without affecting other clients.
+	var nodeImageVersionsClientOptions = *opts
+	if o.UseSIG && o.IsSecurityPatchChannel() {
+		log.FromContext(ctx).Info("cluster is on the SecurityPatch node OS upgrade channel; requesting security-patch node images")
+		nodeImageVersionsClientOptions.PerCallPolicies = append(nodeImageVersionsClientOptions.PerCallPolicies, &securityPatchOnlyPolicy{})
+	}
+	nodeImageVersionsClient, err := imagefamily.NewNodeImageVersionsClient(cfg.SubscriptionID, cred, &nodeImageVersionsClientOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/azclient/securitypatchheader.go
+++ b/pkg/providers/azclient/securitypatchheader.go
@@ -1,0 +1,42 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azclient
+
+import (
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+const securityPatchOnlyHeader = "SecurityPatchOnly"
+
+var _ policy.Policy = &securityPatchOnlyPolicy{}
+
+// securityPatchOnlyPolicy is an Azure SDK per-call policy that sets the
+// SecurityPatchOnly header on ListNodeImageVersions requests. When set, the
+// service returns node image versions from the security-patch lineage instead
+// of the standard node images, so clusters on the SecurityPatch node OS upgrade
+// channel receive security-patched images.
+//
+// The policy is only attached when the cluster is on the SecurityPatch channel,
+// so it can set the header unconditionally on every request the client makes.
+type securityPatchOnlyPolicy struct{}
+
+func (p *securityPatchOnlyPolicy) Do(req *policy.Request) (*http.Response, error) {
+	req.Raw().Header.Set(securityPatchOnlyHeader, "true")
+	return req.Next()
+}

--- a/pkg/providers/azclient/securitypatchheader_test.go
+++ b/pkg/providers/azclient/securitypatchheader_test.go
@@ -1,0 +1,56 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azclient
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureHeaderPolicy is a terminal test policy that records a header value and
+// short-circuits the pipeline with a synthetic response.
+type captureHeaderPolicy struct {
+	header string
+	out    *string
+}
+
+func (c *captureHeaderPolicy) Do(req *policy.Request) (*http.Response, error) {
+	*c.out = req.Raw().Header.Get(c.header)
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req.Raw()}, nil
+}
+
+func TestSecurityPatchOnlyPolicy_SetsHeader(t *testing.T) {
+	req, err := runtime.NewRequest(t.Context(), http.MethodGet, "https://management.azure.com/nodeImageVersions")
+	require.NoError(t, err)
+
+	var seen string
+	pipeline := runtime.NewPipeline("test", "v1.0.0", runtime.PipelineOptions{
+		PerCall: []policy.Policy{
+			&securityPatchOnlyPolicy{},
+			&captureHeaderPolicy{header: securityPatchOnlyHeader, out: &seen},
+		},
+	}, nil)
+
+	_, err = pipeline.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, "true", seen)
+}

--- a/pkg/providers/imagefamily/nodeimageversionsclient.go
+++ b/pkg/providers/imagefamily/nodeimageversionsclient.go
@@ -92,10 +92,16 @@ func FilteredNodeImages(nodeImageVersions []*armcontainerservice.NodeImageVersio
 }
 
 // isNewerVersion will return if version1 is greater than version2, note the new versioning scheme is yearmm.dd.build, previously it was yy.mm.dd without the build id.
+//
+// Security-patch node images (returned when the SecurityPatchOnly header is set) use a different
+// scheme: "<baseVersion>-<securityPatchDate>", e.g. "202605.14.0-2026.06.13". We tokenize on both
+// "." and "-" so these are compared correctly (base version first, then security-patch date).
+// Standard versions contain no "-", so their comparison is unchanged. The two schemes are never
+// compared against each other since security-patch and standard images come from separate calls.
 func isNewerVersion(version1, version2 string) bool {
-	// Split by dots and compare each segment as an integer getting the largest vhd version
-	v1Segments := strings.Split(version1, ".")
-	v2Segments := strings.Split(version2, ".")
+	// Split by dots and hyphens and compare each segment as an integer getting the largest vhd version
+	v1Segments := splitVersion(version1)
+	v2Segments := splitVersion(version2)
 
 	for i := 0; i < len(v1Segments) && i < len(v2Segments); i++ {
 		v1Segment, err1 := strconv.Atoi(v1Segments[i])
@@ -116,4 +122,13 @@ func isNewerVersion(version1, version2 string) bool {
 	// the longer version is considered newer if it has additional segments
 	// the legacy linux versions use "yy.mm.dd" whereas new linux versions use "yymm.dd.build"
 	return len(v1Segments) > len(v2Segments)
+}
+
+// splitVersion tokenizes a node image version into its numeric segments, splitting on both "." and
+// "-". Standard versions like "202607.09.0" yield ["202607","09","0"]; security-patch versions like
+// "202605.14.0-2026.06.13" yield ["202605","14","0","2026","06","13"].
+func splitVersion(version string) []string {
+	return strings.FieldsFunc(version, func(r rune) bool {
+		return r == '.' || r == '-'
+	})
 }

--- a/pkg/providers/imagefamily/nodeimageversionsclient_test.go
+++ b/pkg/providers/imagefamily/nodeimageversionsclient_test.go
@@ -18,6 +18,9 @@ package imagefamily
 
 import (
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
+	"github.com/samber/lo"
 )
 
 func TestIsNewerVersion(t *testing.T) {
@@ -36,6 +39,15 @@ func TestIsNewerVersion(t *testing.T) {
 		{"2022.12.15", "2022.10.03", true},
 		{"202411.12.0", "202411.12.0", false},
 		{"2o2411.12.0", "202411.12.0", false}, // invalid version strings should be ignored and return false
+
+		// Security-patch versions use the "<baseVersion>-<securityPatchDate>" scheme and must
+		// compare correctly (real data from the SecurityPatchOnly nodeImageVersions response).
+		{"202606.08.1-2026.06.13", "202604.24.0-2026.05.24", true},  // newer base + newer patch date
+		{"202604.24.0-2026.05.24", "202606.08.1-2026.06.13", false}, // older
+		{"202605.05.1-2026.06.13", "202605.05.1-2026.05.24", true},  // same base, newer patch date
+		{"202605.05.1-2026.05.24", "202605.05.1-2026.06.13", false}, // same base, older patch date
+		{"202605.14.0-2026.06.13", "202605.05.1-2026.06.13", true},  // newer base, same patch date
+		{"202606.08.1-2026.06.13", "202606.08.1-2026.06.13", false}, // equal
 	}
 
 	for _, tc := range testCases {
@@ -45,5 +57,33 @@ func TestIsNewerVersion(t *testing.T) {
 				t.Errorf("isNewerVersion(%q, %q) = %v; want %v", tc.version1, tc.version2, result, tc.expected)
 			}
 		})
+	}
+}
+
+// TestFilteredNodeImagesSecurityPatch verifies that, given multiple security-patch versions for the
+// same OS/SKU (as returned by the SecurityPatchOnly nodeImageVersions response), FilteredNodeImages
+// selects the newest one. Ordering is intentionally not latest-first to guard against a regression
+// where the first-seen image is kept.
+func TestFilteredNodeImagesSecurityPatch(t *testing.T) {
+	img := func(sku, version string) *armcontainerservice.NodeImageVersion {
+		return &armcontainerservice.NodeImageVersion{
+			OS:      lo.ToPtr(AKSUbuntuGalleryName),
+			SKU:     lo.ToPtr(sku),
+			Version: lo.ToPtr(version),
+		}
+	}
+	input := []*armcontainerservice.NodeImageVersion{
+		img("2204gen2containerd", "202604.24.0-2026.05.24"), // oldest first on purpose
+		img("2204gen2containerd", "202605.05.1-2026.06.13"),
+		img("2204gen2containerd", "202606.08.1-2026.06.13"), // newest
+		img("2204gen2containerd", "202605.14.0-2026.05.24"),
+	}
+
+	filtered := FilteredNodeImages(input)
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 image after filtering, got %d", len(filtered))
+	}
+	if got := lo.FromPtr(filtered[0].Version); got != "202606.08.1-2026.06.13" {
+		t.Errorf("FilteredNodeImages selected version %q; want the newest %q", got, "202606.08.1-2026.06.13")
 	}
 }


### PR DESCRIPTION
**Description**

Adds initial support for the `SecurityPatch` node OS upgrade channel in managed NAP (part of #1439).

When a cluster's node OS upgrade channel is `SecurityPatch`, nodes should receive security-patched node images (from the security-patch VHD lineage) rather than the standard node images, which improves CVE patch speed.

This change:
- Adds a `NODE_OS_UPGRADE_CHANNEL` option (`--node-os-upgrade-channel`) that mirrors the managed cluster's `autoUpgradeProfile.nodeOSUpgradeChannel`, with validation for the accepted values.
- When the channel is `SecurityPatch` and `use-sig` is enabled, attaches a per-call policy that sets the `SecurityPatchOnly: true` header on `ListNodeImageVersions` requests, so the service returns node image versions from the security-patch lineage.
- Existing nodes converge to the new images via the normal node-image drift/roll path; no separate reconciler changes are required.

This is the reimage/roll step. In-place (live) patching via the Machine API is intentionally out of scope here and will follow separately.

Open item being confirmed with the node image versions API owners: the exact gallery name / version-string shape returned for the security-patch lineage, which may require follow-up adjustments to node image filtering.

**How was this change tested?**

* `go test ./pkg/operator/options/...` (option parsing + validation, including the new `SecurityPatch` cases)
* `go test ./pkg/providers/azclient/...` (unit test asserting the `SecurityPatchOnly` header is set on requests)
* E2E validation on the SecurityPatch channel is planned as a follow-up.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

**Release Note**

```release-note
NONE
```
