### PR TITLE
feat: deadline-aware Azure Spot interruption controller

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -73,6 +73,15 @@ const (
 	NodeClassReadinessUnknownReason    = "NodeClassReadinessUnknown"
 	InstanceTypeResolutionFailedReason = "InstanceTypeResolutionFailed"
 	CreateInstanceFailedReason         = "CreateInstanceFailed"
+
+	// SpotConditionPreemptionScheduled is the Node condition the AKS node-problem-detector sets when
+	// Azure schedules an eviction for the underlying Spot VM.
+	//
+	// Deprecated: this condition is no longer a repair policy. Azure Spot preemption is owned by the
+	// deadline-aware controller in pkg/controllers/node/interruption, which keys off
+	// interruption.ConditionTypePreemptionScheduled. This constant is retained only for source
+	// compatibility with external importers and will be removed in a future release.
+	SpotConditionPreemptionScheduled = "PreemptionScheduled"
 )
 
 var _ cloudprovider.CloudProvider = (*CloudProvider)(nil)

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -73,7 +73,6 @@ const (
 	NodeClassReadinessUnknownReason    = "NodeClassReadinessUnknown"
 	InstanceTypeResolutionFailedReason = "InstanceTypeResolutionFailed"
 	CreateInstanceFailedReason         = "CreateInstanceFailed"
-	SpotConditionPreemptionScheduled   = "PreemptionScheduled"
 )
 
 var _ cloudprovider.CloudProvider = (*CloudProvider)(nil)
@@ -543,16 +542,13 @@ func (c *CloudProvider) RepairPolicies() []cloudprovider.RepairPolicy {
 			ConditionStatus:    corev1.ConditionFalse,
 			TolerationDuration: 0,
 		},
-		// Fast-path repair for Azure Spot VMs that received a platform eviction signal.
-		// The condition is emitted by a node-level agent that polls the Instance Metadata
-		// Service for SpotRebalanceRecommendation / Preempt events. Spot eviction notice
-		// is ~30s, so toleration is 0 — we want to start the replacement immediately
-		// rather than waiting for the NodeReady=Unknown 10-minute backstop.
-		{
-			ConditionType:      SpotConditionPreemptionScheduled,
-			ConditionStatus:    corev1.ConditionTrue,
-			TolerationDuration: 0,
-		},
+		// NOTE: Azure Spot preemption (the `PreemptionScheduled` condition) is deliberately absent here.
+		// Node repair reacts to every policy the same way -- it overwrites
+		// karpenter.sh/nodeclaim-termination-timestamp with `now`, discarding the eviction deadline Azure
+		// published, and gates the repair behind the cluster-wide unhealthy-node circuit breaker, which
+		// can hold the repair past the point where the VM has already been reclaimed. Spot preemption is
+		// handled by the dedicated, deadline-aware pkg/controllers/node/interruption controller instead;
+		// re-adding it here would let node.health race that controller and win.
 	}
 }
 

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -39,6 +39,7 @@ import (
 	nodeclasstermination "github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclass/termination"
 
 	instancetypecontroller "github.com/Azure/karpenter-provider-azure/pkg/controllers/instancetype"
+	nodeinterruption "github.com/Azure/karpenter-provider-azure/pkg/controllers/node/interruption"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclaim/inplaceupdate"
 	quotacontroller "github.com/Azure/karpenter-provider-azure/pkg/controllers/quota"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient/azapi"
@@ -78,6 +79,10 @@ func NewControllers(
 
 		nodeclaimgarbagecollection.NewInstance(kubeClient, cloudProvider),
 		nodeclaimgarbagecollection.NewNetworkInterface(kubeClient, vmInstanceProvider),
+
+		// Owns the response to Azure Spot preemption notices. See the package docs for why this is a
+		// dedicated controller rather than a cloudprovider.RepairPolicy.
+		nodeinterruption.NewController(kubeClient, cloudProvider, recorder, clk),
 
 		// TODO: nodeclaim tagging
 		inplaceupdate.NewController(kubeClient, vmInstanceProvider, aksMachineInstanceProvider),

--- a/pkg/controllers/node/interruption/controller.go
+++ b/pkg/controllers/node/interruption/controller.go
@@ -1,0 +1,260 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package interruption reacts to Azure Spot preemption notices.
+//
+// # Ownership
+//
+// This controller owns the response to the `PreemptionScheduled` Node condition for Nodes managed by
+// this cloud provider. It is deliberately *not* modeled as a `cloudprovider.RepairPolicy`: upstream's
+// `node.health` controller treats every repair policy identically, stamping
+// `karpenter.sh/nodeclaim-termination-timestamp` with `now` (which collapses every pod's grace period
+// to ~1s) and gating the repair behind the cluster-wide unhealthy-node circuit breaker (which can delay
+// action past the point where the VM is already gone). Neither behavior is correct for a Spot notice
+// that carries a real, known deadline. Registering `PreemptionScheduled` in both places would let the
+// two controllers race, and `node.health` would win by overwriting the real deadline with `now`.
+//
+// # Deadline semantics
+//
+// Azure publishes a Scheduled Event with a `NotBefore` timestamp: a guarantee that the VM will not be
+// evicted before that instant. Observed notice for a regular Spot preemption is roughly 30s, but it can
+// be materially shorter, and it is never longer than Azure decides. The deadline is therefore treated
+// as a hard budget, never as a promise:
+//
+//   - `NotBefore` is written to `karpenter.sh/nodeclaim-termination-timestamp` before the NodeClaim is
+//     deleted, so upstream's NodeClaim lifecycle preserves it rather than deriving its own.
+//   - Upstream `node.termination` then taints the node `NoSchedule` immediately, drains through the
+//     normal eviction queue (honoring PDBs and `karpenter.sh/do-not-disrupt` while time remains),
+//     clamps each pod's grace period to the time actually left, preemptively deletes pods whose full
+//     grace period no longer fits, and stops waiting on volume detachment at the deadline.
+//   - Everything after the deadline passes is best effort. Karpenter cannot stop Azure from reclaiming
+//     the VM, and this controller makes no attempt to pre-provision replacement capacity: replacement is
+//     reactive, driven by the pods that become unschedulable during the drain.
+package interruption
+
+import (
+	"context"
+	"time"
+
+	"github.com/awslabs/operatorpkg/reasonable"
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1 "k8s.io/api/core/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/metrics"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
+)
+
+// SpotInterruptionReason labels NodeClaims disrupted by an Azure Spot preemption notice.
+const SpotInterruptionReason = "spot_interruption"
+
+// Controller drains Azure Spot nodes against the eviction deadline Azure published for them.
+type Controller struct {
+	kubeClient    client.Client
+	cloudProvider cloudprovider.CloudProvider
+	recorder      events.Recorder
+	clock         clock.Clock
+}
+
+// NewController constructs a controller instance.
+func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, recorder events.Recorder, clk clock.Clock) *Controller {
+	return &Controller{
+		kubeClient:    kubeClient,
+		cloudProvider: cloudProvider,
+		recorder:      recorder,
+		clock:         clk,
+	}
+}
+
+func (c *Controller) Name() string {
+	return "node.interruption"
+}
+
+// Reconcile is level-triggered on the Node's `PreemptionScheduled` condition rather than edge-triggered
+// on `PreemptScheduled` Kubernetes Events. Azure republishes the same notice roughly every 2s for as long
+// as it is outstanding, so event counts are meaningless; the condition is the durable signal and survives
+// a controller restart. Every step below is a no-op when it has already been performed, so duplicate
+// reconciles, replayed watch events, and restarts all converge on the same state.
+func (c *Controller) Reconcile(ctx context.Context, node *corev1.Node) (reconcile.Result, error) {
+	ctx = injection.WithControllerName(ctx, c.Name())
+
+	if !nodeutils.IsManaged(node, c.cloudProvider) {
+		return reconcile.Result{}, nil
+	}
+	condition := nodeutils.GetCondition(node, ConditionTypePreemptionScheduled)
+	if condition.Status != corev1.ConditionTrue {
+		return reconcile.Result{}, nil
+	}
+
+	nodeClaim, err := nodeutils.NodeClaimForNode(ctx, c.kubeClient, node)
+	if err != nil {
+		// A Node with no NodeClaim (or, ambiguously, more than one) is not ours to terminate. Both are
+		// terminal for this Node until its NodeClaim mapping changes, which re-triggers the watch.
+		return reconcile.Result{}, nodeutils.IgnoreDuplicateNodeClaimError(nodeutils.IgnoreNodeClaimNotFoundError(err))
+	}
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("NodeClaim", klog.KObj(nodeClaim)))
+
+	deadline := c.evictionDeadline(ctx, node, condition)
+	if err := c.annotateTerminationTimestamp(ctx, nodeClaim, deadline); err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+	return reconcile.Result{}, c.deleteNodeClaim(ctx, node, nodeClaim, deadline)
+}
+
+// evictionDeadline resolves the instant Azure may start evicting the VM.
+//
+// A `PreemptionScheduled` condition is a statement that the VM is being reclaimed, not a suggestion. If
+// the deadline cannot be recovered from the message, ignoring the notice would leave pods running on a
+// node that is about to disappear without warning, so the controller fails closed and cleans up
+// immediately. That is exactly the behavior Karpenter had before deadlines were understood, so the
+// fallback can never be worse than the status quo -- but it is loud, because losing the deadline means
+// losing the entire drain budget.
+func (c *Controller) evictionDeadline(ctx context.Context, node *corev1.Node, condition corev1.NodeCondition) time.Time {
+	notice, err := ParsePreemptionNotice(condition.Message)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "unable to determine the azure spot eviction deadline, falling back to immediate node cleanup",
+			"condition", ConditionTypePreemptionScheduled, "reason", condition.Reason)
+		c.recorder.Publish(UnknownSpotEvictionDeadline(node, condition.Message))
+		return c.clock.Now()
+	}
+	log.FromContext(ctx).V(1).Info("observed azure spot preemption notice",
+		"eventID", notice.EventID, "notBefore", notice.NotBefore.Format(time.RFC3339),
+		"remaining", notice.NotBefore.Sub(c.clock.Now()).Round(time.Second).String())
+	return notice.NotBefore
+}
+
+// annotateTerminationTimestamp records the eviction deadline on the NodeClaim so that upstream's
+// termination flow drains against Azure's clock instead of a synthesized one.
+//
+// The annotation only ever moves earlier. A deadline already at or before ours is either a shorter
+// notice we have already handled or a terminationGracePeriod that expires sooner, and honoring the
+// later of the two would let pods keep a grace period Azure will not respect.
+func (c *Controller) annotateTerminationTimestamp(ctx context.Context, nodeClaim *karpv1.NodeClaim, deadline time.Time) error {
+	terminationTime := deadline.UTC().Format(time.RFC3339)
+	if existing, ok := nodeClaim.Annotations[karpv1.NodeClaimTerminationTimestampAnnotationKey]; ok {
+		// An unparseable value is treated as absent: upstream cannot act on it either.
+		if existingTime, err := time.Parse(time.RFC3339, existing); err == nil && !existingTime.After(deadline) {
+			return nil
+		}
+	}
+	stored := nodeClaim.DeepCopy()
+	nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{
+		karpv1.NodeClaimTerminationTimestampAnnotationKey: terminationTime,
+	})
+	if equality.Semantic.DeepEqual(stored, nodeClaim) {
+		return nil
+	}
+	// Optimistic locking: upstream's node.health and nodeclaim lifecycle controllers write the same
+	// annotation. On conflict we requeue and re-evaluate against the freshly read NodeClaim rather than
+	// clobbering a deadline that may be shorter than ours.
+	if err := c.kubeClient.Patch(ctx, nodeClaim, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); err != nil {
+		return err
+	}
+	log.FromContext(ctx).WithValues(karpv1.NodeClaimTerminationTimestampAnnotationKey, terminationTime).
+		Info("annotated nodeclaim with the azure spot eviction deadline")
+	return nil
+}
+
+// deleteNodeClaim hands the node to upstream's termination flow, which taints it unschedulable and
+// drains it against the annotated deadline.
+func (c *Controller) deleteNodeClaim(ctx context.Context, node *corev1.Node, nodeClaim *karpv1.NodeClaim, deadline time.Time) error {
+	if !nodeClaim.DeletionTimestamp.IsZero() {
+		// Already terminating; upstream owns the drain from here and re-deleting would be a no-op.
+		return nil
+	}
+	if err := c.kubeClient.Delete(ctx, nodeClaim); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	log.FromContext(ctx).Info("deleting nodeclaim preempted by azure spot eviction",
+		"deadline", deadline.UTC().Format(time.RFC3339))
+	c.recorder.Publish(SpotInterrupted(node, deadline))
+	metrics.NodeClaimsDisruptedTotal.Inc(map[string]string{
+		metrics.ReasonLabel:       SpotInterruptionReason,
+		metrics.NodePoolLabel:     nodeClaim.Labels[karpv1.NodePoolLabelKey],
+		metrics.CapacityTypeLabel: nodeClaim.Labels[karpv1.CapacityTypeLabelKey],
+	})
+	return nil
+}
+
+func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named(c.Name()).
+		For(&corev1.Node{}, builder.WithPredicates(
+			nodeutils.IsManagedPredicateFuncs(c.cloudProvider),
+			preemptionScheduledPredicate(),
+		)).
+		WithOptions(controller.Options{
+			RateLimiter: reasonable.RateLimiter(),
+			// Mass Spot evictions arrive as a burst of independent Node updates, and every second of
+			// queueing is a second of drain budget spent, so reconcile them in parallel.
+			MaxConcurrentReconciles: 10,
+		}).
+		Complete(reconcile.AsReconciler(m.GetClient(), c))
+}
+
+// preemptionScheduledPredicate narrows the Node watch to meaningful changes of the PreemptionScheduled
+// condition. The AKS node-problem-detector re-asserts an outstanding notice continuously, so without
+// this every refresh would enqueue a redundant reconcile.
+func preemptionScheduledPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			// On (re)start every Node is replayed as a create, which is how an interrupted notice is
+			// picked back up after a controller restart.
+			return isPreemptionScheduled(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNode, oldOK := e.ObjectOld.(*corev1.Node)
+			newNode, newOK := e.ObjectNew.(*corev1.Node)
+			if !oldOK || !newOK {
+				return false
+			}
+			newCondition := nodeutils.GetCondition(newNode, ConditionTypePreemptionScheduled)
+			if newCondition.Status != corev1.ConditionTrue {
+				return false
+			}
+			oldCondition := nodeutils.GetCondition(oldNode, ConditionTypePreemptionScheduled)
+			// A changed message can carry an earlier deadline, so it is not redundant.
+			return oldCondition.Status != newCondition.Status ||
+				oldCondition.Message != newCondition.Message ||
+				oldCondition.LastTransitionTime != newCondition.LastTransitionTime
+		},
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+	}
+}
+
+func isPreemptionScheduled(o client.Object) bool {
+	node, ok := o.(*corev1.Node)
+	if !ok {
+		return false
+	}
+	return nodeutils.GetCondition(node, ConditionTypePreemptionScheduled).Status == corev1.ConditionTrue
+}

--- a/pkg/controllers/node/interruption/events.go
+++ b/pkg/controllers/node/interruption/events.go
@@ -1,0 +1,53 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interruption
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/karpenter/pkg/events"
+)
+
+// SpotInterrupted records that Azure is reclaiming the node's Spot capacity and that Karpenter is
+// draining it against the published deadline.
+func SpotInterrupted(node *corev1.Node, deadline time.Time) events.Event {
+	return events.Event{
+		InvolvedObject: node,
+		Type:           corev1.EventTypeWarning,
+		Reason:         "SpotInterrupted",
+		Message: fmt.Sprintf("Azure Spot eviction scheduled, draining node before %s",
+			deadline.UTC().Format(time.RFC3339)),
+		DedupeValues: []string{string(node.UID)},
+	}
+}
+
+// UnknownSpotEvictionDeadline records that a preemption notice arrived without a usable deadline. The
+// node is still cleaned up, but with no drain budget at all, so this is actionable: it means the
+// condition message format changed and the parser needs updating.
+func UnknownSpotEvictionDeadline(node *corev1.Node, message string) events.Event {
+	return events.Event{
+		InvolvedObject: node,
+		Type:           corev1.EventTypeWarning,
+		Reason:         "UnknownSpotEvictionDeadline",
+		Message: fmt.Sprintf("Azure Spot eviction scheduled but no deadline could be parsed from %q, "+
+			"draining node immediately", message),
+		DedupeValues: []string{string(node.UID)},
+	}
+}

--- a/pkg/controllers/node/interruption/preemption.go
+++ b/pkg/controllers/node/interruption/preemption.go
@@ -1,0 +1,110 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interruption
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// ConditionTypePreemptionScheduled is the Node condition the AKS node-problem-detector sets when the
+	// Azure Instance Metadata Service publishes a `Preempt` Scheduled Event for the underlying Spot VM.
+	//
+	// It is deliberately narrower than the `VMEventScheduled` condition, which also covers Reboot,
+	// Redeploy, Freeze and Terminate events. Only `Preempt` means the platform is reclaiming the VM
+	// because it is Spot capacity, so only `Preempt` should trigger deadline-aware cleanup here.
+	ConditionTypePreemptionScheduled = corev1.NodeConditionType("PreemptionScheduled")
+
+	// ConditionReasonSpotEvictionIncoming is the reason the AKS node-problem-detector reports alongside
+	// ConditionTypePreemptionScheduled. It is recorded for observability only; the controller keys off the
+	// condition type and status so that a reason rename cannot silently disable Spot handling.
+	ConditionReasonSpotEvictionIncoming = "SpotEvictionIncoming"
+
+	preemptScheduledPrefix = "Preempt Scheduled:"
+
+	// rfc1123SingleDigitDayLayout accepts the `1*2DIGIT` day permitted by RFC 1123 section 5.2.14,
+	// which time.RFC1123 (a fixed two-digit layout) rejects.
+	rfc1123SingleDigitDayLayout = "Mon, 2 Jan 2006 15:04:05 MST"
+)
+
+// The condition message is emitted by the AKS node-problem-detector and looks like:
+//
+//	Preempt Scheduled: Sat, 01 Aug 2026 05:41:02 GMT. For more information, see
+//	<docs link>. EventId: 40B7BD88-C56E-44E4-93F6-75CEDACE2869
+//
+// The timestamp is the Scheduled Event's `NotBefore` field, forwarded verbatim from the Azure Instance
+// Metadata Service, which documents it as an RFC 1123 timestamp in GMT (e.g. "Mon, 19 Sep 2016 18:29:47
+// GMT"). Only that shape is accepted: coercing an unrecognized layout into a deadline risks draining
+// against a wildly wrong time, which is worse than the caller's documented fallback of cleaning up
+// immediately.
+var (
+	notBeforeRegexp = regexp.MustCompile(`Preempt Scheduled:\s*(?P<NotBefore>[A-Za-z]{3},\s+\d{1,2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{1,2}:\d{2}:\d{2}\s+[A-Za-z]{2,4})`)
+	eventIDRegexp   = regexp.MustCompile(`(?i)EventId:\s*(?P<EventID>[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})`)
+)
+
+// PreemptionNotice is the parsed content of a ConditionTypePreemptionScheduled condition message.
+type PreemptionNotice struct {
+	// NotBefore is the Azure Scheduled Event deadline, normalized to UTC. Azure will not evict the VM
+	// before this instant, so it is the budget Karpenter has to drain the node. It may already be in the
+	// past by the time the condition is observed.
+	NotBefore time.Time
+	// EventID is the Azure Scheduled Event identifier. Azure republishes the same EventId for the
+	// lifetime of a notice, so it identifies the preemption rather than an individual observation of it.
+	// It is best-effort: it is used for correlation with Azure-side telemetry, never for control flow.
+	EventID string
+}
+
+// ParsePreemptionNotice extracts the eviction deadline and Azure Scheduled Event ID from a
+// ConditionTypePreemptionScheduled condition message. It returns an error, never a guessed deadline,
+// when the message does not carry a deadline in the documented format.
+func ParsePreemptionNotice(message string) (*PreemptionNotice, error) {
+	match := notBeforeRegexp.FindStringSubmatch(message)
+	if match == nil {
+		return nil, fmt.Errorf("no %q timestamp found in condition message %q", preemptScheduledPrefix, message)
+	}
+	// Collapse irregular whitespace so the fixed-width layouts below line up.
+	raw := strings.Join(strings.Fields(match[notBeforeRegexp.SubexpIndex("NotBefore")]), " ")
+
+	// Go fabricates a zero-offset location for zone abbreviations it cannot resolve, so an unexpected
+	// abbreviation such as "PST" would silently parse as if it were UTC. Require the documented zone.
+	zone := raw[strings.LastIndex(raw, " ")+1:]
+	if !strings.EqualFold(zone, "GMT") && !strings.EqualFold(zone, "UTC") {
+		return nil, fmt.Errorf("unsupported time zone %q in %q, only GMT/UTC eviction deadlines are understood", zone, raw)
+	}
+
+	var notBefore time.Time
+	var err error
+	for _, layout := range []string{time.RFC1123, rfc1123SingleDigitDayLayout} {
+		if notBefore, err = time.Parse(layout, raw); err == nil {
+			break
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as an RFC 1123 timestamp: %w", raw, err)
+	}
+
+	notice := &PreemptionNotice{NotBefore: notBefore.UTC()}
+	if eventIDMatch := eventIDRegexp.FindStringSubmatch(message); eventIDMatch != nil {
+		notice.EventID = strings.ToUpper(eventIDMatch[eventIDRegexp.SubexpIndex("EventID")])
+	}
+	return notice, nil
+}

--- a/pkg/controllers/node/interruption/preemption_test.go
+++ b/pkg/controllers/node/interruption/preemption_test.go
@@ -1,0 +1,148 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interruption
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestParsePreemptionNotice(t *testing.T) {
+	tests := []struct {
+		name              string
+		message           string
+		expectedNotBefore time.Time
+		expectedEventID   string
+		expectedErr       string
+	}{
+		{
+			// Verbatim shape emitted by the AKS node-problem-detector.
+			name:              "observed AKS node-problem-detector message",
+			message:           "Preempt Scheduled: Sat, 01 Aug 2026 05:41:02 GMT. For more information, see https://aka.ms/aks-spot-eviction. EventId: A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+			expectedNotBefore: time.Date(2026, 8, 1, 5, 41, 2, 0, time.UTC),
+			expectedEventID:   "A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+		},
+		{
+			name:              "lower case event id is normalized",
+			message:           "Preempt Scheduled: Sat, 01 Aug 2026 05:41:02 GMT. EventId: A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+			expectedNotBefore: time.Date(2026, 8, 1, 5, 41, 2, 0, time.UTC),
+			expectedEventID:   "A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+		},
+		{
+			// RFC 1123 section 5.2.14 permits a single digit day; time.RFC1123 alone rejects it.
+			name:              "single digit day",
+			message:           "Preempt Scheduled: Mon, 3 Aug 2026 05:41:02 GMT. EventId: A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+			expectedNotBefore: time.Date(2026, 8, 3, 5, 41, 2, 0, time.UTC),
+			expectedEventID:   "A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+		},
+		{
+			name:              "UTC zone",
+			message:           "Preempt Scheduled: Sat, 01 Aug 2026 05:41:02 UTC. EventId: A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+			expectedNotBefore: time.Date(2026, 8, 1, 5, 41, 2, 0, time.UTC),
+			expectedEventID:   "A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+		},
+		{
+			name:              "irregular whitespace",
+			message:           "Preempt Scheduled:   Sat,  01  Aug  2026  05:41:02  GMT.  EventId:   A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+			expectedNotBefore: time.Date(2026, 8, 1, 5, 41, 2, 0, time.UTC),
+			expectedEventID:   "A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+		},
+		{
+			// The EventId is correlation metadata only, so its absence must not cost us the deadline.
+			name:              "missing event id still yields a deadline",
+			message:           "Preempt Scheduled: Sat, 01 Aug 2026 05:41:02 GMT.",
+			expectedNotBefore: time.Date(2026, 8, 1, 5, 41, 2, 0, time.UTC),
+			expectedEventID:   "",
+		},
+		{
+			name:        "empty message",
+			message:     "",
+			expectedErr: "no \"Preempt Scheduled:\" timestamp found",
+		},
+		{
+			name:        "no deadline in message",
+			message:     "Preempt Scheduled. EventId: A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+			expectedErr: "no \"Preempt Scheduled:\" timestamp found",
+		},
+		{
+			name:        "truncated timestamp",
+			message:     "Preempt Scheduled: Sat, 01 Aug 2026 GMT. EventId: A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+			expectedErr: "no \"Preempt Scheduled:\" timestamp found",
+		},
+		{
+			// Go silently invents a zero-offset zone for abbreviations it cannot resolve, which would
+			// turn a PST deadline into a UTC one and skew the drain budget by hours.
+			name:        "non UTC time zone is rejected rather than misparsed",
+			message:     "Preempt Scheduled: Sat, 01 Aug 2026 05:41:02 PST. EventId: A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+			expectedErr: "unsupported time zone \"PST\"",
+		},
+		{
+			name:        "impossible date",
+			message:     "Preempt Scheduled: Sat, 32 Aug 2026 05:41:02 GMT. EventId: A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+			expectedErr: "as an RFC 1123 timestamp",
+		},
+		{
+			name:        "RFC3339 is not accepted",
+			message:     "Preempt Scheduled: 2026-08-01T05:41:02Z. EventId: A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+			expectedErr: "no \"Preempt Scheduled:\" timestamp found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			notice, err := ParsePreemptionNotice(tc.message)
+			if tc.expectedErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tc.expectedErr))
+				g.Expect(notice).To(BeNil())
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(notice.NotBefore).To(Equal(tc.expectedNotBefore))
+			g.Expect(notice.NotBefore.Location()).To(Equal(time.UTC))
+			g.Expect(notice.EventID).To(Equal(tc.expectedEventID))
+		})
+	}
+}
+
+// TestParsePreemptionNoticeIsDeterministicAcrossHostTimeZones guards the parse from the host's local
+// zone database: the controller may run anywhere, but a GMT deadline always means the same instant.
+func TestParsePreemptionNoticeIsDeterministicAcrossHostTimeZones(t *testing.T) {
+	g := NewWithT(t)
+
+	original := time.Local
+	defer func() { time.Local = original }()
+
+	expected := time.Date(2026, 8, 1, 5, 41, 2, 0, time.UTC)
+	for _, name := range []string{"UTC", "America/Los_Angeles", "Asia/Kolkata", "Europe/London"} {
+		location, err := time.LoadLocation(name)
+		if err != nil {
+			// Hosts without a zone database (common on Windows CI) can only exercise UTC.
+			continue
+		}
+		time.Local = location
+
+		notice, err := ParsePreemptionNotice("Preempt Scheduled: Sat, 01 Aug 2026 05:41:02 GMT. EventId: A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(notice.NotBefore.Equal(expected)).To(BeTrue(), "expected %s in %s to equal %s", notice.NotBefore, name, expected)
+	}
+}

--- a/pkg/controllers/node/interruption/suite_test.go
+++ b/pkg/controllers/node/interruption/suite_test.go
@@ -1,0 +1,397 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interruption_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/awslabs/operatorpkg/object"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
+	clock "k8s.io/utils/clock/testing"
+
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/controllers/node/health"
+	"sigs.k8s.io/karpenter/pkg/events"
+	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
+	coretest "sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
+	. "sigs.k8s.io/karpenter/pkg/utils/testing"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/apis"
+	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/cloudprovider"
+	"github.com/Azure/karpenter-provider-azure/pkg/controllers/node/interruption"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
+	"github.com/Azure/karpenter-provider-azure/pkg/test"
+)
+
+var ctx context.Context
+var env *coretest.Environment
+var azureEnv *test.Environment
+var cloudProvider *cloudprovider.CloudProvider
+var controller *interruption.Controller
+var healthController *health.Controller
+var fakeClock *clock.FakeClock
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SpotInterruption")
+}
+
+var _ = BeforeSuite(func() {
+	ctx = coreoptions.ToContext(ctx, coretest.Options())
+	ctx = options.ToContext(ctx, test.Options())
+	env = coretest.NewEnvironment(
+		coretest.WithCRDs(apis.CRDs...),
+		coretest.WithCRDs(v1alpha1.CRDs...),
+		coretest.WithFieldIndexers(coretest.NodeClaimProviderIDFieldIndexer(ctx), coretest.NodeProviderIDFieldIndexer(ctx)),
+	)
+	azureEnv = test.NewEnvironment(ctx, env)
+	recorder := events.NewRecorder(&record.FakeRecorder{})
+	cloudProvider = cloudprovider.New(azureEnv.InstanceTypesProvider, azureEnv.VMInstanceProvider, azureEnv.AKSMachineProvider, recorder, env.Client, azureEnv.ImageProvider, azureEnv.InstanceTypeStore)
+	fakeClock = clock.NewFakeClock(time.Now())
+	controller = interruption.NewController(env.Client, cloudProvider, recorder, fakeClock)
+	healthController = health.NewController(env.Client, cloudProvider, fakeClock, recorder)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = Describe("Spot Interruption", func() {
+	var nodePool *karpv1.NodePool
+	var nodeClaim *karpv1.NodeClaim
+	var node *corev1.Node
+
+	BeforeEach(func() {
+		fakeClock.SetTime(time.Now())
+		azureEnv.Reset(ctx)
+
+		nodePool = coretest.NodePool()
+		nodeClaim, node = coretest.NodeClaimAndNode(karpv1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Finalizers: []string{karpv1.TerminationFinalizer},
+				Labels:     map[string]string{karpv1.CapacityTypeLabelKey: karpv1.CapacityTypeSpot},
+			},
+			Spec: karpv1.NodeClaimSpec{
+				NodeClassRef: &karpv1.NodeClassReference{
+					Group: v1beta1.Group,
+					Kind:  "AKSNodeClass",
+					Name:  "default",
+				},
+			},
+		})
+		node.Labels[karpv1.NodePoolLabelKey] = nodePool.Name
+		nodeClaim.Labels[karpv1.NodePoolLabelKey] = nodePool.Name
+	})
+
+	AfterEach(func() {
+		ExpectCleanedUp(ctx, env.Client)
+	})
+
+	Context("Deadline handling", func() {
+		It("should drain against the deadline Azure published for a normal ~38s notice", func() {
+			deadline := fakeClock.Now().Add(38 * time.Second).UTC().Truncate(time.Second)
+			node = withPreemptionScheduled(node, preemptionMessage(deadline))
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).To(HaveKeyWithValue(karpv1.NodeClaimTerminationTimestampAnnotationKey, deadline.Format(time.RFC3339)))
+			Expect(nodeClaim.DeletionTimestamp).ToNot(BeNil())
+		})
+		It("should honor a short ~13s notice without extending it", func() {
+			deadline := fakeClock.Now().Add(13 * time.Second).UTC().Truncate(time.Second)
+			node = withPreemptionScheduled(node, preemptionMessage(deadline))
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).To(HaveKeyWithValue(karpv1.NodeClaimTerminationTimestampAnnotationKey, deadline.Format(time.RFC3339)))
+			Expect(nodeClaim.DeletionTimestamp).ToNot(BeNil())
+		})
+		It("should still clean up when the deadline has already passed", func() {
+			// The notice can be observed late (controller restart, watch lag). There is no drain budget
+			// left, but leaving the pods on a node Azure is reclaiming is strictly worse.
+			deadline := fakeClock.Now().Add(-2 * time.Minute).UTC().Truncate(time.Second)
+			node = withPreemptionScheduled(node, preemptionMessage(deadline))
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).To(HaveKeyWithValue(karpv1.NodeClaimTerminationTimestampAnnotationKey, deadline.Format(time.RFC3339)))
+			Expect(nodeClaim.DeletionTimestamp).ToNot(BeNil())
+		})
+		It("should fall back to immediate cleanup when the deadline cannot be parsed", func() {
+			// Failing closed matches the pre-deadline behavior, so it can never be worse than the status
+			// quo, and it never silently drops a mandatory preemption.
+			node = withPreemptionScheduled(node, "Preempt Scheduled: soon. EventId: not-a-guid")
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).To(HaveKeyWithValue(karpv1.NodeClaimTerminationTimestampAnnotationKey, fakeClock.Now().UTC().Format(time.RFC3339)))
+			Expect(nodeClaim.DeletionTimestamp).ToNot(BeNil())
+		})
+		It("should fall back to immediate cleanup when the condition carries no message", func() {
+			node = withPreemptionScheduled(node, "")
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).To(HaveKeyWithValue(karpv1.NodeClaimTerminationTimestampAnnotationKey, fakeClock.Now().UTC().Format(time.RFC3339)))
+			Expect(nodeClaim.DeletionTimestamp).ToNot(BeNil())
+		})
+	})
+
+	Context("Existing termination timestamp", func() {
+		It("should preserve an existing earlier deadline", func() {
+			earlier := fakeClock.Now().Add(5 * time.Second).UTC().Truncate(time.Second)
+			nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{
+				karpv1.NodeClaimTerminationTimestampAnnotationKey: earlier.Format(time.RFC3339),
+			})
+			node = withPreemptionScheduled(node, preemptionMessage(fakeClock.Now().Add(38*time.Second)))
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).To(HaveKeyWithValue(karpv1.NodeClaimTerminationTimestampAnnotationKey, earlier.Format(time.RFC3339)))
+		})
+		It("should shorten an existing later deadline", func() {
+			// e.g. a NodePool terminationGracePeriod that Azure will not wait for.
+			later := fakeClock.Now().Add(time.Hour).UTC().Truncate(time.Second)
+			deadline := fakeClock.Now().Add(38 * time.Second).UTC().Truncate(time.Second)
+			nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{
+				karpv1.NodeClaimTerminationTimestampAnnotationKey: later.Format(time.RFC3339),
+			})
+			node = withPreemptionScheduled(node, preemptionMessage(deadline))
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).To(HaveKeyWithValue(karpv1.NodeClaimTerminationTimestampAnnotationKey, deadline.Format(time.RFC3339)))
+		})
+		It("should overwrite an unparseable existing deadline", func() {
+			deadline := fakeClock.Now().Add(38 * time.Second).UTC().Truncate(time.Second)
+			nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{
+				karpv1.NodeClaimTerminationTimestampAnnotationKey: "not-a-timestamp",
+			})
+			node = withPreemptionScheduled(node, preemptionMessage(deadline))
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).To(HaveKeyWithValue(karpv1.NodeClaimTerminationTimestampAnnotationKey, deadline.Format(time.RFC3339)))
+		})
+	})
+
+	Context("Idempotency", func() {
+		It("should converge when the same notice is reconciled repeatedly", func() {
+			// AKS NPD re-asserts the condition roughly every 2s, so the same notice is observed many
+			// times. Nothing may depend on how often it is seen.
+			deadline := fakeClock.Now().Add(38 * time.Second).UTC().Truncate(time.Second)
+			node = withPreemptionScheduled(node, preemptionMessage(deadline))
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+			first := ExpectExists(ctx, env.Client, nodeClaim)
+
+			for i := 0; i < 3; i++ {
+				fakeClock.Step(2 * time.Second)
+				ExpectObjectReconciled(ctx, env.Client, controller, node)
+			}
+
+			latest := ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(latest.Annotations).To(HaveKeyWithValue(karpv1.NodeClaimTerminationTimestampAnnotationKey, deadline.Format(time.RFC3339)))
+			Expect(latest.ResourceVersion).To(Equal(first.ResourceVersion))
+			Expect(latest.DeletionTimestamp).ToNot(BeNil())
+		})
+		It("should be a no-op for a NodeClaim that is already terminating", func() {
+			// Models a controller restart mid-drain: the condition is replayed as a create event while
+			// upstream is already draining the node.
+			deadline := fakeClock.Now().Add(38 * time.Second).UTC().Truncate(time.Second)
+			nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{
+				karpv1.NodeClaimTerminationTimestampAnnotationKey: deadline.Format(time.RFC3339),
+			})
+			node = withPreemptionScheduled(node, preemptionMessage(deadline))
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			Expect(env.Client.Delete(ctx, nodeClaim)).To(Succeed())
+			terminating := ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(terminating.DeletionTimestamp).ToNot(BeNil())
+
+			fakeClock.Step(10 * time.Second)
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+
+			latest := ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(latest.Annotations).To(HaveKeyWithValue(karpv1.NodeClaimTerminationTimestampAnnotationKey, deadline.Format(time.RFC3339)))
+			Expect(latest.ResourceVersion).To(Equal(terminating.ResourceVersion))
+		})
+		It("should shorten the deadline of a terminating NodeClaim when Azure moves it earlier", func() {
+			original := fakeClock.Now().Add(38 * time.Second).UTC().Truncate(time.Second)
+			earlier := fakeClock.Now().Add(13 * time.Second).UTC().Truncate(time.Second)
+			nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{
+				karpv1.NodeClaimTerminationTimestampAnnotationKey: original.Format(time.RFC3339),
+			})
+			node = withPreemptionScheduled(node, preemptionMessage(earlier))
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			Expect(env.Client.Delete(ctx, nodeClaim)).To(Succeed())
+
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+
+			latest := ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(latest.Annotations).To(HaveKeyWithValue(karpv1.NodeClaimTerminationTimestampAnnotationKey, earlier.Format(time.RFC3339)))
+		})
+	})
+
+	Context("Scope", func() {
+		It("should ignore VMEventScheduled, which also covers reboot, redeploy and freeze", func() {
+			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+				Type:               corev1.NodeConditionType("VMEventScheduled"),
+				Status:             corev1.ConditionTrue,
+				Reason:             "VMEventScheduled",
+				Message:            preemptionMessage(fakeClock.Now().Add(38 * time.Second)),
+				LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+			})
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).ToNot(HaveKey(karpv1.NodeClaimTerminationTimestampAnnotationKey))
+			Expect(nodeClaim.DeletionTimestamp).To(BeNil())
+		})
+		It("should ignore a PreemptionScheduled condition that is not True", func() {
+			node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+				Type:               interruption.ConditionTypePreemptionScheduled,
+				Status:             corev1.ConditionFalse,
+				Message:            preemptionMessage(fakeClock.Now().Add(38 * time.Second)),
+				LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+			})
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).ToNot(HaveKey(karpv1.NodeClaimTerminationTimestampAnnotationKey))
+			Expect(nodeClaim.DeletionTimestamp).To(BeNil())
+		})
+		It("should ignore nodes that are not managed by this cloud provider", func() {
+			delete(node.Labels, karpv1.NodeClassLabelKey(schemaGroupKind()))
+			node = withPreemptionScheduled(node, preemptionMessage(fakeClock.Now().Add(38*time.Second)))
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).ToNot(HaveKey(karpv1.NodeClaimTerminationTimestampAnnotationKey))
+			Expect(nodeClaim.DeletionTimestamp).To(BeNil())
+		})
+		It("should not error when the node has no NodeClaim", func() {
+			node = withPreemptionScheduled(node, preemptionMessage(fakeClock.Now().Add(38*time.Second)))
+			ExpectApplied(ctx, env.Client, nodePool, node)
+
+			result, err := controller.Reconcile(ctx, node)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+		})
+		It("should not error when the NodeClaim was already removed", func() {
+			node = withPreemptionScheduled(node, preemptionMessage(fakeClock.Now().Add(38*time.Second)))
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+			ExpectObjectReconciled(ctx, env.Client, controller, node)
+			ExpectFinalizersRemoved(ctx, env.Client, nodeClaim)
+			ExpectNotFound(ctx, env.Client, nodeClaim)
+
+			result, err := controller.Reconcile(ctx, node)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+		})
+	})
+
+	Context("Node repair interaction", func() {
+		// These two specs pin the decision to take Spot preemption out of the generic repair path.
+		// node.health treats every RepairPolicy identically: it overwrites the termination timestamp with
+		// `now` (collapsing every pod's grace period) and gates on the cluster-wide unhealthy-node
+		// circuit breaker (which can hold the repair past the eviction deadline).
+		It("should not advertise PreemptionScheduled as a repair policy", func() {
+			Expect(cloudProvider.RepairPolicies()).ToNot(ContainElement(HaveField("ConditionType", interruption.ConditionTypePreemptionScheduled)))
+		})
+		It("should leave PreemptionScheduled nodes untouched by node repair", func() {
+			deadline := fakeClock.Now().Add(38 * time.Second).UTC().Truncate(time.Second)
+			node = withPreemptionScheduled(node, preemptionMessage(deadline))
+			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
+
+			// Push well past every repair policy's toleration window so that only policy membership,
+			// not timing, decides the outcome.
+			fakeClock.Step(time.Hour)
+			ExpectObjectReconciled(ctx, env.Client, healthController, node)
+
+			nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+			Expect(nodeClaim.Annotations).ToNot(HaveKey(karpv1.NodeClaimTerminationTimestampAnnotationKey))
+			Expect(nodeClaim.DeletionTimestamp).To(BeNil())
+		})
+		It("should keep the other repair policies", func() {
+			Expect(cloudProvider.RepairPolicies()).To(ContainElements(
+				HaveField("ConditionType", corev1.NodeReady),
+				HaveField("ConditionType", corev1.NodeConditionType("kubernetes.azure.com/NodeHealthy")),
+			))
+		})
+	})
+})
+
+// preemptionMessage renders the condition message shape emitted by the AKS node-problem-detector.
+func preemptionMessage(notBefore time.Time) string {
+	return fmt.Sprintf("Preempt Scheduled: %s. For more information, see https://aka.ms/aks-spot-eviction. EventId: A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+		notBefore.UTC().Format(time.RFC1123))
+}
+
+func withPreemptionScheduled(node *corev1.Node, message string) *corev1.Node {
+	node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+		Type:               interruption.ConditionTypePreemptionScheduled,
+		Status:             corev1.ConditionTrue,
+		Reason:             interruption.ConditionReasonSpotEvictionIncoming,
+		Message:            message,
+		LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+	})
+	return node
+}
+
+func schemaGroupKind() schema.GroupKind {
+	return object.GVK(&v1beta1.AKSNodeClass{}).GroupKind()
+}
+
+var _ corecloudprovider.CloudProvider = &cloudprovider.CloudProvider{}

--- a/pkg/controllers/node/interruption/suite_test.go
+++ b/pkg/controllers/node/interruption/suite_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -327,7 +328,7 @@ var _ = Describe("Spot Interruption", func() {
 
 			result, err := controller.Reconcile(ctx, node)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
+			Expect(result).To(Equal(reconcile.Result{}))
 		})
 		It("should not error when the NodeClaim was already removed", func() {
 			node = withPreemptionScheduled(node, preemptionMessage(fakeClock.Now().Add(38*time.Second)))
@@ -338,7 +339,7 @@ var _ = Describe("Spot Interruption", func() {
 
 			result, err := controller.Reconcile(ctx, node)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result.Requeue).To(BeFalse())
+			Expect(result).To(Equal(reconcile.Result{}))
 		})
 	})
 
@@ -369,6 +370,12 @@ var _ = Describe("Spot Interruption", func() {
 				HaveField("ConditionType", corev1.NodeReady),
 				HaveField("ConditionType", corev1.NodeConditionType("kubernetes.azure.com/NodeHealthy")),
 			))
+		})
+		It("should keep the deprecated cloudprovider alias in sync with the owning controller", func() {
+			// cloudprovider.SpotConditionPreemptionScheduled is retained for source compatibility with
+			// external importers. It is a separate literal, so guard the two against drifting apart.
+			//nolint:staticcheck // SA1019: deliberately referencing the deprecated alias to pin its value
+			Expect(cloudprovider.SpotConditionPreemptionScheduled).To(Equal(string(interruption.ConditionTypePreemptionScheduled)))
 		})
 	})
 })

--- a/test/suites/integration/repair_policy_test.go
+++ b/test/suites/integration/repair_policy_test.go
@@ -95,11 +95,6 @@ var _ = Describe("Repair Policy", func() {
 			Status:             corev1.ConditionFalse,
 			LastTransitionTime: metav1.Time{Time: time.Now()},
 		}),
-		Entry("Preemption Scheduled", corev1.NodeCondition{
-			Type:               corev1.NodeConditionType("PreemptionScheduled"),
-			Status:             corev1.ConditionTrue,
-			LastTransitionTime: metav1.Time{Time: time.Now()},
-		}),
 	)
 	It("should ignore disruption budgets", func() {
 		nodePool.Spec.Disruption.Budgets = []karpenterv1.Budget{

--- a/test/suites/integration/spot_interruption_test.go
+++ b/test/suites/integration/spot_interruption_test.go
@@ -1,0 +1,90 @@
+// Portions Copyright (c) Microsoft Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	coretest "sigs.k8s.io/karpenter/pkg/test"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/controllers/node/interruption"
+	"github.com/Azure/karpenter-provider-azure/test/pkg/environment/common"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/samber/lo"
+)
+
+// Azure Spot preemption is handled by the provider's own deadline-aware interruption controller rather
+// than by node repair, so unlike the Repair Policy suite these specs do not need the NodeRepair feature
+// gate and are not subject to its unhealthy-node circuit breaker.
+var _ = Describe("Spot Interruption", func() {
+	var selector labels.Selector
+	var dep *appsv1.Deployment
+	var numPods int
+
+	BeforeEach(func() {
+		numPods = 1
+		dep = coretest.Deployment(coretest.DeploymentOptions{
+			Replicas: int32(numPods),
+			PodOptions: coretest.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "my-app"},
+				},
+				TerminationGracePeriodSeconds: lo.ToPtr[int64](0),
+			},
+		})
+		selector = labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
+	})
+
+	DescribeTable("should drain and replace a node with a scheduled Spot eviction",
+		func(notice func() string) {
+			env.ExpectCreated(nodeClass, nodePool, dep)
+			pod := env.EventuallyExpectHealthyPodCount(selector, numPods)[0]
+			node := env.ExpectCreatedNodeCount("==", 1)[0]
+			env.EventuallyExpectInitializedNodeCount("==", 1)
+
+			node = common.ReplaceNodeConditions(node, corev1.NodeCondition{
+				Type:               interruption.ConditionTypePreemptionScheduled,
+				Status:             corev1.ConditionTrue,
+				Reason:             interruption.ConditionReasonSpotEvictionIncoming,
+				Message:            notice(),
+				LastTransitionTime: metav1.Time{Time: time.Now()},
+			})
+			env.ExpectStatusUpdated(node)
+
+			env.EventuallyExpectNotFound(pod, node)
+			env.EventuallyExpectHealthyPodCount(selector, numPods)
+		},
+		Entry("with the notice Azure normally gives", func() string {
+			return preemptionNotice(time.Now().Add(30 * time.Second))
+		}),
+		Entry("with a deadline that has already passed", func() string {
+			return preemptionNotice(time.Now().Add(-time.Minute))
+		}),
+		// The deadline is unrecoverable, so the controller must fail closed and clean up immediately
+		// rather than leave pods on a node Azure is reclaiming.
+		Entry("with an unparseable notice", func() string { return "Preempt Scheduled: unknown" }),
+	)
+})
+
+func preemptionNotice(notBefore time.Time) string {
+	return fmt.Sprintf("Preempt Scheduled: %s. For more information, see https://aka.ms/aks-spot-eviction. EventId: A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+		notBefore.UTC().Format(time.RFC1123))
+}


### PR DESCRIPTION
## Problem

Azure publishes a Scheduled Event with a `NotBefore` deadline before it reclaims a Spot VM, and the AKS
node-problem-detector surfaces that notice as the `PreemptionScheduled=True` node condition
(reason `SpotEvictionIncoming`) with the deadline embedded in the condition message:

```
Preempt Scheduled: Sat, 01 Aug 2026 05:41:02 GMT. For more information, see <link>. EventId: <guid>
```

Today the provider registers `PreemptionScheduled` as a generic `cloudprovider.RepairPolicy`
(added in #1695). That routes Spot preemption through upstream's `node.health` controller, which
treats every repair policy identically:

1. **The real deadline is thrown away.** `node.health` stamps
   `karpenter.sh/nodeclaim-termination-timestamp` with **`now`**. Upstream's termination flow then
   clamps every pod's grace period to the remaining time, which is zero, so pods are deleted with the
   1s floor regardless of their configured `terminationGracePeriodSeconds`. Workloads that would have
   shut down cleanly inside the notice window instead get killed abruptly.
2. **The repair can be delayed past the eviction.** `node.health` gates on the cluster-wide
   unhealthy-node circuit breaker (up to 20% of a NodePool may be unhealthy before repair pauses for
   5 minutes). During a real Spot reclaim this backs off precisely when many nodes are being preempted
   at once, which can push the cleanup past `NotBefore` — by which point Azure has already taken the VM
   and there was no drain at all.

Net effect: Karpenter has a usable eviction budget and spends none of it.

## Change

Add a provider-owned `node.interruption` controller (`pkg/controllers/node/interruption`) that:

1. Watches **managed Nodes** for the `PreemptionScheduled` condition becoming/being `True`.
2. Parses `NotBefore` and the Scheduled Event ID out of the condition message.
3. Resolves the NodeClaim via upstream `nodeutils.NodeClaimForNode`.
4. Writes `NotBefore` to `karpenter.sh/nodeclaim-termination-timestamp` **before** deleting the
   NodeClaim, using an optimistic-locked patch.
5. Deletes the NodeClaim, handing off to upstream's existing lifecycle.

and removes `PreemptionScheduled` from `RepairPolicies()` so `node.health` cannot race the new
controller and overwrite the deadline with `now`. Other repair policies are unchanged.

### Resulting lifecycle

Because the annotation is set before deletion, upstream `nodeclaim.lifecycle` preserves it rather than
deriving its own, and `node.termination` then:

- taints the node `karpenter.sh/disrupted:NoSchedule` immediately, so it stops accepting new pods;
- drains through the normal eviction queue, respecting PDBs and `karpenter.sh/do-not-disrupt` while
  time remains;
- preemptively deletes pods whose full `terminationGracePeriodSeconds` no longer fits before the
  deadline, clamping the delete grace period to the time actually left (floor of 1s, so at-most-one
  pod semantics are preserved and pods are never force-deleted from etcd);
- stops waiting on volume detachment at the deadline;
- then deletes the provider resource.

So a ~30s notice is spent draining instead of being discarded, and a short notice degrades smoothly
into the same behavior we have today rather than failing differently.

## Safety and edge cases

- **Level-triggered, not event-counting.** The controller reconciles the durable node *condition*.
  Azure republishes `PreemptScheduled` Kubernetes Events roughly every 2s for the same notice, so
  nothing here depends on event counts or ordering.
- **Idempotent.** Every step is a no-op once performed. Duplicate reconciles, replayed watch events and
  a controller restart mid-drain all converge on the same state; a Node create event on startup is how
  an in-flight notice is picked back up.
- **The annotation only ever moves earlier.** An existing earlier deadline (a shorter notice already
  handled) is preserved; a later one (e.g. a NodePool `terminationGracePeriod` Azure will not wait for)
  is shortened. An unparseable existing value is treated as absent.
- **A deadline in the past still triggers cleanup.** There is no budget left, but leaving pods on a VM
  Azure is reclaiming is strictly worse.
- **A notice we cannot parse fails closed.** If the deadline cannot be recovered, the controller drains
  immediately, logs an error and emits an `UnknownSpotEvictionDeadline` warning event. That is exactly
  the pre-change behavior, so the fallback can never be worse than the status quo, and a mandatory
  preemption is never silently ignored. It is loud because losing the deadline means losing the whole
  drain budget.
- **Strict timestamp handling.** Only the RFC 1123 GMT/UTC format Azure documents for `NotBefore` is
  accepted. Go silently invents a zero-offset zone for abbreviations it cannot resolve, so an
  unexpected abbreviation (e.g. `PST`) would otherwise parse as UTC and skew the budget by hours —
  that case is rejected and takes the fail-closed path instead.
- **Narrow scope.** Only `PreemptionScheduled` is acted on, never the broader `VMEventScheduled`
  condition, which also covers Reboot, Redeploy, Freeze and Terminate.
- **Ignores what isn't ours.** Unmanaged nodes, nodes with no NodeClaim, and ambiguous
  (duplicate-NodeClaim) nodes are skipped without error. Already-terminating NodeClaims are not
  re-deleted.
- No RBAC change is needed: the chart already grants `nodes` read and `nodeclaims` patch/delete.

## Regular and mass Spot relevance

For a single preemption this converts a discarded notice into a real drain window. For a mass Spot
reclaim it matters more, not less: each node is handled independently and in parallel
(`MaxConcurrentReconciles: 10`), and removing the repair policy also removes the unhealthy-node
circuit breaker from this path, which was the mechanism most likely to stall cleanup exactly when many
nodes were being preempted simultaneously.

## What this does *not* do

**It does not guarantee replacement capacity is ready before the node goes away.** Karpenter cannot
stop Azure from reclaiming the VM, and no attempt is made to pre-provision a replacement on the
strength of a preemption notice. In observed measurements a GPU replacement node took on the order of
tens of seconds merely to launch and a few minutes to register — far longer than any Spot notice — so
pre-spinning ready capacity inside the notice window is not achievable. Replacement remains reactive:
it is driven by the pods that become unschedulable during the drain. The contribution here is strictly
that the eviction budget Azure *does* give us is used for cleanup instead of being thrown away.

## Tests

- `preemption_test.go` — table tests for the parser: the verbatim AKS node-problem-detector message,
  lowercase/absent EventId, single-digit day (permitted by RFC 1123 §5.2.14), irregular whitespace,
  truncated/missing/RFC3339 timestamps, an impossible date, and the non-UTC zone case. Plus a test that
  parsing is deterministic regardless of the host's local time zone.
- `suite_test.go` — envtest specs for the controller: normal (~38s) notice, short (~13s) notice,
  already-past deadline, unparseable message, empty message, existing earlier deadline preserved,
  existing later deadline shortened, unparseable existing annotation overwritten, repeated reconciles
  of the same notice making no further writes, restart against an already-terminating NodeClaim,
  shortening a terminating NodeClaim's deadline, `VMEventScheduled` ignored, non-`True` condition
  ignored, unmanaged node ignored, missing NodeClaim, and already-deleted NodeClaim.
- Two specs pin the `RepairPolicies()` decision, including one that runs upstream's `node.health`
  controller against this provider and asserts it leaves a `PreemptionScheduled` node alone. **Both of
  these fail against the current behavior** (verified by temporarily restoring the policy: 2 failures)
  and pass with this change.
- E2E: the `Preemption Scheduled` entry is moved out of the Repair Policy table — it is no longer a
  repair policy and no longer needs the `NodeRepair` feature gate — into a dedicated `Spot Interruption`
  spec covering a normal notice, an already-passed deadline, and an unparseable notice.

Local results: `pkg/controllers/...` and `pkg/cloudprovider/...` all specs pass (20/20 for the new
suite, 152/152 for cloudprovider). `go build ./...` and `go vet ./pkg/... ./test/... ./cmd/...` are
clean. The only failures seen locally are the pre-existing Windows envtest `AfterSuite` teardown errors
(`unable to signal for process ... not supported by windows`), which affect every suite in the repo
including untouched ones.
