### PR TITLE
feat: enforce the AKS cluster-level FIPS setting

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -114,7 +114,10 @@ func (c *CloudProvider) WaitForInstancePromises() {
 	c.instancePromiseWg.Wait()
 }
 
-func (c *CloudProvider) validateNodeClass(nodeClass *v1beta1.AKSNodeClass) error {
+func (c *CloudProvider) validateNodeClass(ctx context.Context, nodeClass *v1beta1.AKSNodeClass) error {
+	if options.FromContext(ctx).EnableFIPS && lo.FromPtr(nodeClass.Spec.FIPSMode) != v1beta1.FIPSModeFIPS {
+		return cloudprovider.NewNodeClassNotReadyError(stderrors.New("AKSNodeClass spec.fipsMode must be set to FIPS because FIPS is enabled at the cluster level"))
+	}
 	nodeClassReady := nodeClass.StatusConditions().Get(status.ConditionReady)
 	if nodeClassReady.IsFalse() {
 		return cloudprovider.NewNodeClassNotReadyError(stderrors.New(nodeClassReady.Message))
@@ -152,7 +155,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 			return nil, err
 		}
 	*/
-	if err = c.validateNodeClass(nodeClass); err != nil {
+	if err = c.validateNodeClass(ctx, nodeClass); err != nil {
 		return nil, err
 	}
 

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -23,12 +23,27 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
+	"github.com/Azure/karpenter-provider-azure/pkg/test"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils/zones"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestValidateNodeClassRejectsNonFIPSBeforeStatusReconciliation(t *testing.T) {
+	g := NewWithT(t)
+	ctx := options.ToContext(context.Background(), test.Options(test.OptionsFields{EnableFIPS: lo.ToPtr(true)}))
+	nodeClass := &v1beta1.AKSNodeClass{
+		Spec: v1beta1.AKSNodeClassSpec{},
+	}
+	nodeClass.StatusConditions().SetTrue("Ready")
+
+	err := (&CloudProvider{}).validateNodeClass(ctx, nodeClass)
+
+	g.Expect(err).To(MatchError(ContainSubstring("spec.fipsMode must be set to FIPS")))
+}
 
 func TestGenerateNodeClaimName(t *testing.T) {
 	tests := []struct {

--- a/pkg/controllers/nodeclass/status/validation.go
+++ b/pkg/controllers/nodeclass/status/validation.go
@@ -24,13 +24,16 @@ import (
 	sdkerrors "github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient/azapi"
+	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
 	DiskEncryptionSetRBACMissing = "DiskEncryptionSetRBACMissing"
+	FIPSRequired                 = "FIPSRequired"
 	// TODO: May want to rethink how we handle successful validation + potential for RBAC removal.
 	// See this PR comment for considerations:
 	// https://github.com/Azure/karpenter-provider-azure/pull/1372#discussion_r2795367386
@@ -61,6 +64,14 @@ func NewValidationReconciler(
 
 func (r *ValidationReconciler) Reconcile(ctx context.Context, nodeClass *v1beta1.AKSNodeClass) (reconcile.Result, error) {
 	logger := log.FromContext(ctx)
+	if options.FromContext(ctx).EnableFIPS && lo.FromPtr(nodeClass.Spec.FIPSMode) != v1beta1.FIPSModeFIPS {
+		nodeClass.StatusConditions().SetFalse(
+			v1beta1.ConditionTypeValidationSucceeded,
+			FIPSRequired,
+			"AKSNodeClass spec.fipsMode must be set to FIPS because FIPS is enabled at the cluster level",
+		)
+		return reconcile.Result{}, nil
+	}
 
 	// Check BYOK RBAC if DES ID is configured
 	if r.parsedDiskEncryptionSetID != nil {

--- a/pkg/controllers/nodeclass/status/validation_test.go
+++ b/pkg/controllers/nodeclass/status/validation_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclass/status"
 	"github.com/Azure/karpenter-provider-azure/pkg/fake"
+	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
+	"github.com/Azure/karpenter-provider-azure/pkg/test"
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -64,7 +66,7 @@ var _ = Describe("Validation Reconciler", func() {
 	var emptyDiskEncryptionSetID *arm.ResourceID
 
 	BeforeEach(func() {
-		ctx = context.Background()
+		ctx = options.ToContext(context.Background(), test.Options())
 		fakeDesAPI = &fake.DiskEncryptionSetsAPI{}
 
 		reconciler = status.NewValidationReconciler(fakeDesAPI, emptyDiskEncryptionSetID)
@@ -103,6 +105,45 @@ var _ = Describe("Validation Reconciler", func() {
 					createZoneOverride("cluster.local", false),
 				},
 			}
+
+			result, err := reconciler.Reconcile(ctx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(status.ValidationSuccessRequeueInterval))
+
+			condition := nodeClass.StatusConditions().Get(v1beta1.ConditionTypeValidationSucceeded)
+			Expect(condition.IsTrue()).To(BeTrue())
+		})
+	})
+
+	Context("cluster-level FIPS validation", func() {
+		BeforeEach(func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{EnableFIPS: lo.ToPtr(true)}))
+		})
+
+		It("should reject a NodeClass with unset FIPS mode", func() {
+			result, err := reconciler.Reconcile(ctx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			condition := nodeClass.StatusConditions().Get(v1beta1.ConditionTypeValidationSucceeded)
+			Expect(condition.IsFalse()).To(BeTrue())
+			Expect(condition.Reason).To(Equal(status.FIPSRequired))
+			Expect(condition.Message).To(Equal("AKSNodeClass spec.fipsMode must be set to FIPS because FIPS is enabled at the cluster level"))
+		})
+
+		It("should reject a NodeClass with FIPS explicitly disabled", func() {
+			nodeClass.Spec.FIPSMode = lo.ToPtr(v1beta1.FIPSModeDisabled)
+
+			_, err := reconciler.Reconcile(ctx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+
+			condition := nodeClass.StatusConditions().Get(v1beta1.ConditionTypeValidationSucceeded)
+			Expect(condition.IsFalse()).To(BeTrue())
+			Expect(condition.Reason).To(Equal(status.FIPSRequired))
+		})
+
+		It("should accept a NodeClass with FIPS enabled", func() {
+			nodeClass.Spec.FIPSMode = lo.ToPtr(v1beta1.FIPSModeFIPS)
 
 			result, err := reconciler.Reconcile(ctx, nodeClass)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -91,6 +91,7 @@ type Options struct {
 	AdditionalTags             map[string]string `json:"additionalTags,omitempty"`
 	EnableAzureSDKLogging      bool              `json:"enableAzureSDKLogging,omitempty"` // Controls whether Azure SDK middleware logging is enabled
 	DiskEncryptionSetID        string            `json:"diskEncryptionSetId,omitempty"`
+	EnableFIPS                 bool              `json:"enableFIPS,omitempty"`
 
 	// If set to true, existing AKS machines created with an AKS Machine API provision mode will be managed even with other provision modes. This option does not have any effect if PROVISION_MODE is already an AKS Machine API mode, as it will behave as if this option is set to true.
 	ManageExistingAKSMachines bool `json:"manageExistingAKSMachines,omitempty"`
@@ -127,6 +128,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.SIGAccessTokenServerURL, "sig-access-token-server-url", env.WithDefaultString("SIG_ACCESS_TOKEN_SERVER_URL", ""), "The URL for the SIG access token server. Only used for AKS managed karpenter. UseSIG must be set tot true for this to take effect.")
 	fs.StringVar(&o.SIGSubscriptionID, "sig-subscription-id", env.WithDefaultString("SIG_SUBSCRIPTION_ID", ""), "The subscription ID of the shared image gallery.")
 	fs.StringVar(&o.DiskEncryptionSetID, "node-osdisk-diskencryptionset-id", env.WithDefaultString("NODE_OSDISK_DISKENCRYPTIONSET_ID", ""), "The ARM resource ID of the disk encryption set to use for customer-managed key (BYOK) encryption.")
+	fs.BoolVar(&o.EnableFIPS, "enable-fips", env.WithDefaultBool("ENABLE_FIPS", false), "If set to true, AKSNodeClasses must explicitly enable FIPS mode. This setting mirrors the AKS cluster-level FIPS configuration.")
 	fs.BoolVar(&o.ManageExistingAKSMachines, "manage-existing-aks-machines", env.WithDefaultBool("MANAGE_EXISTING_AKS_MACHINES", false), "If set to true, existing AKS machines created with an AKS Machine API provision mode will be managed even with other provision modes. This option does not have any effect when already on an AKS Machine API mode.")
 	fs.StringVar(&o.AKSMachinesPoolName, "aks-machines-pool-name", env.WithDefaultString("AKS_MACHINES_POOL_NAME", ""), "The name of the agent pool that the AKS machines are/will be in with AKS machine API provision modes. Existing AKS machines outside of this pool will be ignored. Required when PROVISION_MODE is an AKS machine API mode.")
 	fs.DurationVar(&o.ProviderBatchIdleDuration, "provider-batch-idle-duration", env.WithDefaultDuration("PROVIDER_BATCH_IDLE_DURATION", time.Second), "Idle duration for provider batch accumulation. Use Go duration format such as `1s`. Only used on provision mode aksmachineapiheaderbatch.")

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -71,6 +71,7 @@ var _ = Describe("Options", func() {
 		"LINUX_ADMIN_USERNAME",
 		"ADDITIONAL_TAGS",
 		"ENABLE_AZURE_SDK_LOGGING",
+		"ENABLE_FIPS",
 		"AKS_MACHINES_POOL_NAME",
 		"MANAGE_EXISTING_AKS_MACHINES",
 		"PROVIDER_BATCH_IDLE_DURATION",
@@ -129,6 +130,7 @@ var _ = Describe("Options", func() {
 			os.Setenv("KUBELET_IDENTITY_CLIENT_ID", "12345678-1234-1234-1234-123456789012")
 			os.Setenv("LINUX_ADMIN_USERNAME", "customadminusername")
 			os.Setenv("ADDITIONAL_TAGS", "test-tag=test-value")
+			os.Setenv("ENABLE_FIPS", "true")
 			os.Setenv("AKS_MACHINES_POOL_NAME", "testmpool")
 			os.Setenv("MANAGE_EXISTING_AKS_MACHINES", "true")
 			os.Setenv("PROVIDER_BATCH_IDLE_DURATION", "1500ms")
@@ -161,6 +163,7 @@ var _ = Describe("Options", func() {
 				NodeResourceGroup:              lo.ToPtr("my-node-rg"),
 				KubeletIdentityClientID:        lo.ToPtr("12345678-1234-1234-1234-123456789012"),
 				AdditionalTags:                 map[string]string{"test-tag": "test-value"},
+				EnableFIPS:                     lo.ToPtr(true),
 				ClusterDNSServiceIP:            lo.ToPtr("10.244.0.1"),
 				ManageExistingAKSMachines:      lo.ToPtr(true),
 				AKSMachinesPoolName:            lo.ToPtr("testmpool"),

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -47,6 +47,7 @@ type OptionsFields struct {
 	AdditionalTags                 map[string]string
 	EnableAzureSDKLogging          *bool
 	DiskEncryptionSetID            *string
+	EnableFIPS                     *bool
 	ClusterDNSServiceIP            *string
 	ManageExistingAKSMachines      *bool
 	AKSMachinesPoolName            *string
@@ -91,6 +92,7 @@ func Options(overrides ...OptionsFields) *azoptions.Options {
 		SIGAccessTokenServerURL:        lo.FromPtrOr(options.SIGAccessTokenServerURL, "https://test-sig-access-token-server.com"),
 		AdditionalTags:                 options.AdditionalTags,
 		DiskEncryptionSetID:            lo.FromPtrOr(options.DiskEncryptionSetID, ""),
+		EnableFIPS:                     lo.FromPtrOr(options.EnableFIPS, false),
 		DNSServiceIP:                   lo.FromPtrOr(options.ClusterDNSServiceIP, ""),
 		ManageExistingAKSMachines:      lo.FromPtrOr(options.ManageExistingAKSMachines, false),
 		AKSMachinesPoolName:            lo.FromPtrOr(options.AKSMachinesPoolName, "aksmanagedap"),


### PR DESCRIPTION
## Description

Adds support for enforcing the AKS cluster-level FIPS setting in managed NAP.

When FIPS is enabled for the cluster, Karpenter accepts only `AKSNodeClass` resources that explicitly set `spec.fipsMode: FIPS`. NodeClasses with an unset or `Disabled` FIPS mode become not ready and cannot provision new nodes.

## Design

This implementation mirrors the existing AKS cluster-level setting:

```yaml
properties:
  enableFIPS: true
```

Managed NAP passes the setting to Karpenter through `ENABLE_FIPS`. The option is a boolean to preserve the semantics of the cluster API and defaults to `false`, leaving self-hosted installations and clusters without FIPS enforcement unchanged.

When `ENABLE_FIPS=true`, Karpenter requires:

```yaml
apiVersion: karpenter.azure.com/v1beta1
kind: AKSNodeClass
spec:
  fipsMode: FIPS
```

Both an unset `fipsMode` and an explicit `fipsMode: Disabled` are rejected. Karpenter does not dynamically default an unset NodeClass field from the cluster setting because that would change the effective NodeClass configuration, and potentially its image selection, without a NodeClass spec update.

## Runtime validation

The check uses the existing `ValidationSucceeded` condition rather than admission-time validation:

- Cluster configuration is not available to CRD CEL validation.
- Runtime validation is continuously reevaluated and applies to existing as well as newly created NodeClasses.
- An incompatible NodeClass receives `ValidationSucceeded=False` with reason `FIPSRequired`, which makes the aggregate `Ready` condition false and blocks provisioning.

The cloud-provider create path repeats the check before provisioning. This preserves enforcement during startup if an existing NodeClass still has a stale `Ready=True` status before its first status reconciliation.

The setting does not rewrite NodeClass specs and does not automatically drift existing nodes. Cluster-level update validation and lifecycle behavior remain owned by AKS.

## Testing

- Option parsing from `ENABLE_FIPS`.
- Unset `fipsMode` is rejected when cluster FIPS is enabled.
- Explicit `fipsMode: Disabled` is rejected when cluster FIPS is enabled.
- Explicit `fipsMode: FIPS` succeeds.
- Provisioning-boundary validation rejects an incompatible NodeClass even if its stored status is still `Ready=True`.
- `make verify` passes.
- `make presubmit` passes all 39 suites with 68.5% composite coverage.

## Documentation

- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

## Release Note

```release-note
Managed NAP blocks non-FIPS AKSNodeClasses when FIPS is enabled at the AKS cluster level.
```
