### PR TITLE
fix: bound instance type cache retention

### DIFF
--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -54,7 +54,8 @@ type UnavailableOfferings struct {
 	singleOfferingCache *cache.Cache
 	// key: <skuFamilyName>:<zone>:<capacityType> (lowercase), value: int64 (CPU count at or above which we block, or wholeVMFamilyBlockedSentinel if entire family is blocked)
 	vmFamilyCache *cache.Cache
-	seqNum        atomic.Uint64
+	// seqNum is updated on any material changes to unavailable offerrings cache (not updated on TTL only changes)
+	seqNum atomic.Uint64
 }
 
 func NewUnavailableOfferingsWithCache(singleOfferingCache, vmFamilyCache *cache.Cache) *UnavailableOfferings {

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -54,7 +54,7 @@ type UnavailableOfferings struct {
 	singleOfferingCache *cache.Cache
 	// key: <skuFamilyName>:<zone>:<capacityType> (lowercase), value: int64 (CPU count at or above which we block, or wholeVMFamilyBlockedSentinel if entire family is blocked)
 	vmFamilyCache *cache.Cache
-	// seqNum is updated on any material changes to unavailable offerrings cache (not updated on TTL only changes)
+	// seqNum is updated on any material changes to unavailable offerings cache (not updated on TTL only changes)
 	seqNum atomic.Uint64
 }
 

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -52,20 +52,19 @@ type UnavailableOfferings struct {
 	singleOfferingCache *cache.Cache
 	// key: <skuFamilyName>:<zone>:<capacityType> (lowercase), value: int64 (CPU count at or above which we block, or wholeVMFamilyBlockedSentinel if entire family is blocked)
 	vmFamilyCache *cache.Cache
-	SeqNum        uint64
+	seqNum        atomic.Uint64
 }
 
 func NewUnavailableOfferingsWithCache(singleOfferingCache, vmFamilyCache *cache.Cache) *UnavailableOfferings {
 	uo := &UnavailableOfferings{
 		singleOfferingCache: singleOfferingCache,
 		vmFamilyCache:       vmFamilyCache,
-		SeqNum:              0,
 	}
 	uo.singleOfferingCache.OnEvicted(func(_ string, _ any) {
-		atomic.AddUint64(&uo.SeqNum, 1)
+		uo.seqNum.Add(1)
 	})
 	uo.vmFamilyCache.OnEvicted(func(_ string, _ any) {
-		atomic.AddUint64(&uo.SeqNum, 1)
+		uo.seqNum.Add(1)
 	})
 	return uo
 }
@@ -75,6 +74,10 @@ func NewUnavailableOfferings() *UnavailableOfferings {
 		cache.New(UnavailableOfferingsTTL, UnavailableOfferingsCleanupInterval),
 		cache.New(UnavailableOfferingsTTL, UnavailableOfferingsCleanupInterval),
 	)
+}
+
+func (u *UnavailableOfferings) SeqNum() uint64 {
+	return u.seqNum.Load()
 }
 
 // IsUnavailable returns true if the offering appears in the cache
@@ -165,7 +168,7 @@ func (u *UnavailableOfferings) markFamilyUnavailableAtCPUCountImpl(ctx context.C
 
 	// call Set to update the cache entry, even if it already exists, to extend its TTL
 	u.vmFamilyCache.Set(key, cpuCount, ttl)
-	atomic.AddUint64(&u.SeqNum, 1)
+	u.seqNum.Add(1)
 }
 
 // MarkSpotUnavailable communicates recently observed temporary capacity shortages for spot
@@ -177,7 +180,7 @@ func (u *UnavailableOfferings) MarkSpotUnavailableWithTTL(ctx context.Context, t
 		"capacity-type", capacityType,
 		"ttl", ttl)
 	u.singleOfferingCache.Set(singleInstanceKey("", "", capacityType), struct{}{}, ttl)
-	atomic.AddUint64(&u.SeqNum, 1)
+	u.seqNum.Add(1)
 }
 
 // MarkUnavailableWithTTL allows us to mark an offering unavailable with a custom TTL.
@@ -193,7 +196,7 @@ func (u *UnavailableOfferings) MarkUnavailableWithTTL(ctx context.Context, unava
 		"capacity-type", capacityType,
 		"ttl", ttl)
 	u.singleOfferingCache.Set(singleInstanceKey(instanceType, zone, capacityType), struct{}{}, ttl)
-	atomic.AddUint64(&u.SeqNum, 1)
+	u.seqNum.Add(1)
 
 	// Also mark the VM family unavailable at this SKU's vCPU count, so larger sizes of the same family are blocked too
 	u.markFamilyUnavailableAtCPUCount(ctx, sku, zone, capacityType, ttl)
@@ -207,7 +210,7 @@ func (u *UnavailableOfferings) MarkUnavailable(ctx context.Context, unavailableR
 func (u *UnavailableOfferings) Flush() {
 	u.singleOfferingCache.Flush()
 	u.vmFamilyCache.Flush()
-	atomic.AddUint64(&u.SeqNum, 1)
+	u.seqNum.Add(1)
 }
 
 // singleInstanceKey returns the cache singleInstanceKey for all offerings in the cache

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -45,6 +46,7 @@ var (
 // GetInstanceTypes responses
 // Information available from skewer.SKU is used to determine details about the VM SKU for which we encountered allocation errors.
 type UnavailableOfferings struct {
+	mu sync.Mutex
 	// TODO: I think this singleOfferingCache could basically be removed in favor of the family cache at this point, as we are now marking family unavailable at CPU count for all error cases.
 	// I didn't do that purely because of the defensive fallback we have in markFamilyUnavailableAtCPUCountImpl, but in practice I am not sure if we'll ever have a nil family (I don't
 	// see any evidence it can happen in logs)
@@ -120,24 +122,28 @@ func (u *UnavailableOfferings) isFamilyUnavailable(sku *skewer.SKU, zone, capaci
 
 // markFamilyUnavailableAtCPUCount marks a VM family with custom TTL in a specific zone for all instance types that have CPU count at or above the SKU's vCPU count.
 // Information is derived from the provided skewer.SKU: family name via GetFamilyName() and CPU count via VCPU().
-func (u *UnavailableOfferings) markFamilyUnavailableAtCPUCount(ctx context.Context, sku *skewer.SKU, zone, capacityType string, ttl time.Duration) {
+func (u *UnavailableOfferings) markFamilyUnavailableAtCPUCount(ctx context.Context, sku *skewer.SKU, zone, capacityType string, ttl time.Duration) bool {
 	cpuCount, err := sku.VCPU()
 	if err != nil {
 		// default to 0 if we can't determine VCPU count, this shouldn't happen as long as data in skewer.SKU is correct
 		cpuCount = 0
 	}
-	u.markFamilyUnavailableAtCPUCountImpl(ctx, sku, zone, capacityType, cpuCount, ttl)
+	return u.markFamilyUnavailableAtCPUCountImpl(ctx, sku, zone, capacityType, cpuCount, ttl)
 }
 
 // MarkFamilyUnavailable marks the entire VM family as unavailable in a specific zone for a specific capacity type with custom TTL.
 // Family name is derived from the provided skewer.SKU.
 func (u *UnavailableOfferings) MarkFamilyUnavailable(ctx context.Context, sku *skewer.SKU, zone, capacityType string, ttl time.Duration) {
-	u.markFamilyUnavailableAtCPUCountImpl(ctx, sku, zone, capacityType, wholeVMFamilyBlockedSentinel, ttl)
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if u.markFamilyUnavailableAtCPUCountImpl(ctx, sku, zone, capacityType, wholeVMFamilyBlockedSentinel, ttl) {
+		u.seqNum.Add(1)
+	}
 }
 
 // markFamilyUnavailableAtCPUCountImpl is the internal implementation that marks a VM family unavailable at a given CPU count threshold.
 // Value of -1 is used as a "wholeVMFamilyBlockedSentinel" to indicate that the entire VM family is blocked in this zone for the specified capacity type.
-func (u *UnavailableOfferings) markFamilyUnavailableAtCPUCountImpl(ctx context.Context, sku *skewer.SKU, zone, capacityType string, cpuCount int64, ttl time.Duration) {
+func (u *UnavailableOfferings) markFamilyUnavailableAtCPUCountImpl(ctx context.Context, sku *skewer.SKU, zone, capacityType string, cpuCount int64, ttl time.Duration) bool {
 	skuFamilyName := sku.GetFamilyName()
 	// This is a hedge against skewer having bad data where family name is missing,
 	// If family name is missing, we won't do any family level blocking, but we'll still mark the specific offering as unavailable.
@@ -146,15 +152,17 @@ func (u *UnavailableOfferings) markFamilyUnavailableAtCPUCountImpl(ctx context.C
 			"instanceType", sku.GetName(),
 			"zone", zone,
 			"capacity-type", capacityType)
-		return
+		return false
 	}
 	key := vmFamilyKey(skuFamilyName, zone, capacityType)
+	changed := true
 
 	if existing, found := u.vmFamilyCache.Get(key); found {
 		if currentBlockedCPUCount, ok := existing.(int64); ok {
 			// Keep the more restrictive limit for CPU count(lower value, with -1 being most restrictive - wholeVMFamilyBlockedSentinel)
 			if currentBlockedCPUCount <= cpuCount {
 				cpuCount = currentBlockedCPUCount
+				changed = false
 			}
 		}
 	}
@@ -168,26 +176,34 @@ func (u *UnavailableOfferings) markFamilyUnavailableAtCPUCountImpl(ctx context.C
 
 	// call Set to update the cache entry, even if it already exists, to extend its TTL
 	u.vmFamilyCache.Set(key, cpuCount, ttl)
-	u.seqNum.Add(1)
+	return changed
 }
 
 // MarkSpotUnavailable communicates recently observed temporary capacity shortages for spot
 func (u *UnavailableOfferings) MarkSpotUnavailableWithTTL(ctx context.Context, ttl time.Duration) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
 	capacityType := karpv1.CapacityTypeSpot
+	_, wasUnavailable := u.singleOfferingCache.Get(spotKey)
 	// even if the key is already in the cache, we still need to call Set to extend the cached entry's TTL
 	log.FromContext(ctx).V(1).Info("removing offering from offerings",
 		"unavailable", "SpotUnavailable",
 		"capacity-type", capacityType,
 		"ttl", ttl)
-	u.singleOfferingCache.Set(singleInstanceKey("", "", capacityType), struct{}{}, ttl)
-	u.seqNum.Add(1)
+	u.singleOfferingCache.Set(spotKey, struct{}{}, ttl)
+	if !wasUnavailable {
+		u.seqNum.Add(1)
+	}
 }
 
 // MarkUnavailableWithTTL allows us to mark an offering unavailable with a custom TTL.
 // In addition to marking the specific instance type unavailable, it also marks the VM family
 // unavailable at the SKU's vCPU count, so that larger sizes of the same family are also blocked.
 func (u *UnavailableOfferings) MarkUnavailableWithTTL(ctx context.Context, unavailableReason string, sku *skewer.SKU, zone, capacityType string, ttl time.Duration) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
 	instanceType := sku.GetName()
+	wasUnavailable := u.IsUnavailable(sku, zone, capacityType)
 	// even if the key is already in the cache, we still need to call Set to extend the cached entry's TTL
 	log.FromContext(ctx).V(1).Info("removing offering from offerings",
 		"unavailable", unavailableReason,
@@ -196,10 +212,12 @@ func (u *UnavailableOfferings) MarkUnavailableWithTTL(ctx context.Context, unava
 		"capacity-type", capacityType,
 		"ttl", ttl)
 	u.singleOfferingCache.Set(singleInstanceKey(instanceType, zone, capacityType), struct{}{}, ttl)
-	u.seqNum.Add(1)
 
 	// Also mark the VM family unavailable at this SKU's vCPU count, so larger sizes of the same family are blocked too
-	u.markFamilyUnavailableAtCPUCount(ctx, sku, zone, capacityType, ttl)
+	familyChanged := u.markFamilyUnavailableAtCPUCount(ctx, sku, zone, capacityType, ttl)
+	if !wasUnavailable || familyChanged {
+		u.seqNum.Add(1)
+	}
 }
 
 // MarkUnavailable communicates recently observed temporary capacity shortages in the provided offerings
@@ -208,6 +226,8 @@ func (u *UnavailableOfferings) MarkUnavailable(ctx context.Context, unavailableR
 }
 
 func (u *UnavailableOfferings) Flush() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
 	u.singleOfferingCache.Flush()
 	u.vmFamilyCache.Flush()
 	u.seqNum.Add(1)

--- a/pkg/cache/unavailableofferings_test.go
+++ b/pkg/cache/unavailableofferings_test.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"context"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -236,4 +237,84 @@ func TestUnavailableOfferingsRestrictiveLimitPreservation(t *testing.T) {
 	for _, sku := range skus {
 		assertOfferingAvailable(t, u, sku, "westus-1", karpv1.CapacityTypeOnDemand, "Offering should not be marked as unavailable after cache expiration")
 	}
+}
+
+func TestUnavailableOfferingsSeqNumChangesOnlyWhenAvailabilityChanges(t *testing.T) {
+	singleInstanceCache := cache.New(time.Hour, time.Hour)
+	vmFamilyCache := cache.New(time.Hour, time.Hour)
+	u := NewUnavailableOfferingsWithCache(singleInstanceCache, vmFamilyCache)
+
+	nv8 := createTestSKU("Standard_NV8as_v4", "standardNVasv4Family", "NV8as_v4", 8)
+	nv16 := createTestSKU("Standard_NV16as_v4", "standardNVasv4Family", "NV16as_v4", 16)
+	nv24 := createTestSKU("Standard_NV24as_v4", "standardNVasv4Family", "NV24as_v4", 24)
+
+	u.MarkUnavailableWithTTL(context.TODO(), "test reason", nv16, "westus-1", karpv1.CapacityTypeOnDemand, time.Hour)
+	if got := u.SeqNum(); got != 1 {
+		t.Fatalf("expected first mark to advance one generation, got %d", got)
+	}
+
+	_, singleExpiration, _ := singleInstanceCache.GetWithExpiration(singleInstanceKey(nv16.GetName(), "westus-1", karpv1.CapacityTypeOnDemand))
+	_, familyExpiration, _ := vmFamilyCache.GetWithExpiration(vmFamilyKey(nv16.GetFamilyName(), "westus-1", karpv1.CapacityTypeOnDemand))
+	u.MarkUnavailableWithTTL(context.TODO(), "test reason", nv16, "westus-1", karpv1.CapacityTypeOnDemand, 2*time.Hour)
+	if got := u.SeqNum(); got != 1 {
+		t.Fatalf("expected duplicate mark to keep generation 1, got %d", got)
+	}
+	_, refreshedSingleExpiration, _ := singleInstanceCache.GetWithExpiration(singleInstanceKey(nv16.GetName(), "westus-1", karpv1.CapacityTypeOnDemand))
+	_, refreshedFamilyExpiration, _ := vmFamilyCache.GetWithExpiration(vmFamilyKey(nv16.GetFamilyName(), "westus-1", karpv1.CapacityTypeOnDemand))
+	if !refreshedSingleExpiration.After(singleExpiration) || !refreshedFamilyExpiration.After(familyExpiration) {
+		t.Fatal("expected duplicate mark to refresh both cache expirations")
+	}
+
+	u.MarkUnavailableWithTTL(context.TODO(), "test reason", nv24, "westus-1", karpv1.CapacityTypeOnDemand, time.Hour)
+	if got := u.SeqNum(); got != 1 {
+		t.Fatalf("expected redundant mark under stricter family limit to keep generation 1, got %d", got)
+	}
+
+	u.MarkUnavailableWithTTL(context.TODO(), "test reason", nv8, "westus-1", karpv1.CapacityTypeOnDemand, time.Hour)
+	if got := u.SeqNum(); got != 2 {
+		t.Fatalf("expected stricter family limit to advance generation to 2, got %d", got)
+	}
+
+	u.MarkFamilyUnavailable(context.TODO(), nv8, "westus-1", karpv1.CapacityTypeOnDemand, time.Hour)
+	if got := u.SeqNum(); got != 3 {
+		t.Fatalf("expected whole-family block to advance generation to 3, got %d", got)
+	}
+	u.MarkFamilyUnavailable(context.TODO(), nv8, "westus-1", karpv1.CapacityTypeOnDemand, time.Hour)
+	if got := u.SeqNum(); got != 3 {
+		t.Fatalf("expected duplicate whole-family block to keep generation 3, got %d", got)
+	}
+
+	u.MarkSpotUnavailableWithTTL(context.TODO(), time.Hour)
+	if got := u.SeqNum(); got != 4 {
+		t.Fatalf("expected first global spot block to advance generation to 4, got %d", got)
+	}
+	u.MarkSpotUnavailableWithTTL(context.TODO(), time.Hour)
+	if got := u.SeqNum(); got != 4 {
+		t.Fatalf("expected duplicate global spot block to keep generation 4, got %d", got)
+	}
+}
+
+func TestUnavailableOfferingsConcurrentDuplicateMarksAdvanceOneGeneration(t *testing.T) {
+	singleInstanceCache := cache.New(time.Hour, time.Hour)
+	vmFamilyCache := cache.New(time.Hour, time.Hour)
+	u := NewUnavailableOfferingsWithCache(singleInstanceCache, vmFamilyCache)
+	sku := createTestSKU("Standard_NV16as_v4", "standardNVasv4Family", "NV16as_v4", 16)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			u.MarkUnavailableWithTTL(context.TODO(), "test reason", sku, "westus-1", karpv1.CapacityTypeOnDemand, time.Hour)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := u.SeqNum(); got != 1 {
+		t.Fatalf("expected concurrent duplicate marks to advance one generation, got %d", got)
+	}
+	assertOfferingUnavailable(t, u, sku, "westus-1", karpv1.CapacityTypeOnDemand, "Offering should be unavailable after concurrent marks")
 }

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -161,29 +161,31 @@ func (p *DefaultProvider) List(
 	p.muInstanceTypesCache.Lock()
 	defer p.muInstanceTypesCache.Unlock()
 
-	for {
-		generation := p.currentInstanceTypesCacheGeneration()
-		if generation != p.instanceTypesCacheGeneration {
-			p.instanceTypesCache.Flush()
-			p.instanceTypesCacheGeneration = generation
-		}
-		if item, ok := p.instanceTypesCache.Get(key); ok {
-			// Ensure what's returned from this function is a shallow-copy of the slice (not a deep-copy of the data itself)
-			// so that modifications to the ordering of the data don't affect the original
-			return append([]*cloudprovider.InstanceType{}, item.([]*cloudprovider.InstanceType)...), nil
-		}
+	generation := p.currentInstanceTypesCacheGeneration()
+	if generation != p.instanceTypesCacheGeneration {
+		p.instanceTypesCache.Flush()
+		p.instanceTypesCacheGeneration = generation
+	}
+	if item, ok := p.instanceTypesCache.Get(key); ok {
+		// Ensure what's returned from this function is a shallow-copy of the slice (not a deep-copy of the data itself)
+		// so that modifications to the ordering of the data don't affect the original
+		return append([]*cloudprovider.InstanceType{}, item.([]*cloudprovider.InstanceType)...), nil
+	}
 
-		result := p.buildInstanceTypes(ctx, instanceTypeParams)
-
-		if generation != p.currentInstanceTypesCacheGeneration() {
-			continue
-		}
-		p.instanceTypesCache.SetDefault(key, result)
-		if generation != p.currentInstanceTypesCacheGeneration() {
-			continue
-		}
+	result := p.buildInstanceTypes(ctx, instanceTypeParams)
+	if latest := p.currentInstanceTypesCacheGeneration(); generation != latest {
+		// Availability changed while building; return this snapshot uncached instead of retrying indefinitely.
+		p.instanceTypesCache.Flush()
+		p.instanceTypesCacheGeneration = latest
 		return result, nil
 	}
+
+	p.instanceTypesCache.SetDefault(key, result)
+	if latest := p.currentInstanceTypesCacheGeneration(); generation != latest {
+		p.instanceTypesCache.Flush()
+		p.instanceTypesCacheGeneration = latest
+	}
+	return result, nil
 }
 
 func (p *DefaultProvider) buildInstanceTypes(ctx context.Context, params *instanceTypeParameters) []*cloudprovider.InstanceType {

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -71,7 +71,7 @@ type instanceTypeParameters struct {
 	LocalDNSEnabled          bool
 }
 
-type instanceTypesCacheGeneration struct {
+type instanceTypesSourceDataGeneration struct {
 	unavailableOfferings uint64
 	quota                uint64
 }
@@ -103,7 +103,7 @@ type DefaultProvider struct {
 	// Changes in the source data generation invalidate the cache as a whole instead of creating unreachable keys.
 	instanceTypesCache           *cache.Cache
 	muInstanceTypesCache         sync.Mutex
-	instanceTypesCacheGeneration instanceTypesCacheGeneration
+	instanceTypesCacheGeneration instanceTypesSourceDataGeneration
 
 	cm *pretty.ChangeMonitor
 
@@ -161,7 +161,7 @@ func (p *DefaultProvider) List(
 	p.muInstanceTypesCache.Lock()
 	defer p.muInstanceTypesCache.Unlock()
 
-	generation := p.currentInstanceTypesCacheGeneration()
+	generation := p.currentInstanceTypesSourceDataGeneration()
 	if generation != p.instanceTypesCacheGeneration {
 		p.instanceTypesCache.Flush()
 		p.instanceTypesCacheGeneration = generation
@@ -173,7 +173,7 @@ func (p *DefaultProvider) List(
 	}
 
 	result := p.buildInstanceTypes(ctx, instanceTypeParams)
-	if latest := p.currentInstanceTypesCacheGeneration(); generation != latest {
+	if latest := p.currentInstanceTypesSourceDataGeneration(); generation != latest {
 		// Availability changed while building; return this snapshot uncached instead of retrying indefinitely.
 		p.instanceTypesCache.Flush()
 		p.instanceTypesCacheGeneration = latest
@@ -181,7 +181,7 @@ func (p *DefaultProvider) List(
 	}
 
 	p.instanceTypesCache.SetDefault(key, result)
-	if latest := p.currentInstanceTypesCacheGeneration(); generation != latest {
+	if latest := p.currentInstanceTypesSourceDataGeneration(); generation != latest {
 		p.instanceTypesCache.Flush()
 		p.instanceTypesCacheGeneration = latest
 	}
@@ -215,8 +215,8 @@ func (p *DefaultProvider) buildInstanceTypes(ctx context.Context, params *instan
 	return result
 }
 
-func (p *DefaultProvider) currentInstanceTypesCacheGeneration() instanceTypesCacheGeneration {
-	return instanceTypesCacheGeneration{
+func (p *DefaultProvider) currentInstanceTypesSourceDataGeneration() instanceTypesSourceDataGeneration {
+	return instanceTypesSourceDataGeneration{
 		unavailableOfferings: p.unavailableOfferings.SeqNum(),
 		quota:                p.quotaProvider.SeqNum(),
 	}

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -173,18 +173,8 @@ func (p *DefaultProvider) List(
 	}
 
 	result := p.buildInstanceTypes(ctx, instanceTypeParams)
-	if latest := p.currentInstanceTypesSourceDataGeneration(); generation != latest {
-		// Availability changed while building; return this snapshot uncached instead of retrying indefinitely.
-		p.instanceTypesCache.Flush()
-		p.instanceTypesCacheGeneration = latest
-		return result, nil
-	}
 
 	p.instanceTypesCache.SetDefault(key, result)
-	if latest := p.currentInstanceTypesSourceDataGeneration(); generation != latest {
-		p.instanceTypesCache.Flush()
-		p.instanceTypesCacheGeneration = latest
-	}
 	// Return a shallow copy, matching the cache-hit path, so a caller reordering its slice doesn't reorder the cached one.
 	return append([]*cloudprovider.InstanceType{}, result...), nil
 }

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -185,7 +185,8 @@ func (p *DefaultProvider) List(
 		p.instanceTypesCache.Flush()
 		p.instanceTypesCacheGeneration = latest
 	}
-	return result, nil
+	// Return a shallow copy, matching the cache-hit path, so a caller reordering its slice doesn't reorder the cached one.
+	return append([]*cloudprovider.InstanceType{}, result...), nil
 }
 
 func (p *DefaultProvider) buildInstanceTypes(ctx context.Context, params *instanceTypeParameters) []*cloudprovider.InstanceType {

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -72,6 +72,11 @@ type instanceTypeParameters struct {
 	LocalDNSEnabled          bool
 }
 
+type instanceTypesCacheGeneration struct {
+	unavailableOfferings uint64
+	quota                uint64
+}
+
 type Provider interface {
 	LivenessProbe(*http.Request) error
 	List(context.Context, *v1beta1.AKSNodeClass) ([]*cloudprovider.InstanceType, error)
@@ -95,15 +100,14 @@ type DefaultProvider struct {
 	unavailableOfferings *kcache.UnavailableOfferings
 	quotaProvider        quota.Provider
 
-	// Values cached *before* considering insufficient capacity errors from the unavailableOfferings cache.
-	// Fully initialized Instance Types are also cached based on the set of all instance types,
-	// unavailableOfferings cache, AWSNodeClass, and kubelet configuration from the NodePool
-	instanceTypesCache *cache.Cache
+	// Fully initialized instance types are cached by the parameters that affect their construction.
+	// Source-data generations invalidate the cache as a whole instead of creating unreachable keys.
+	instanceTypesCache           *cache.Cache
+	muInstanceTypesCache         sync.Mutex
+	instanceTypesCacheGeneration instanceTypesCacheGeneration
 
 	cm *pretty.ChangeMonitor
 
-	// instanceTypesSeqNum is a monotonically increasing change counter used to avoid the expensive hashing operation on instance types
-	instanceTypesSeqNum uint64
 	muInstanceTypesInfo sync.RWMutex
 	instanceTypesInfo   map[string]*skewer.SKU
 }
@@ -125,7 +129,6 @@ func NewDefaultProvider(
 		quotaProvider:        quotaProvider,
 		instanceTypesCache:   cache,
 		cm:                   pretty.NewChangeMonitor(),
-		instanceTypesSeqNum:  0,
 	}
 }
 
@@ -154,20 +157,37 @@ func (p *DefaultProvider) List(
 		LocalDNSEnabled:          nodeClass.IsLocalDNSEnabled(),
 	}
 	paramsHash, _ := hashstructure.Hash(instanceTypeParams, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
-	key := fmt.Sprintf("%d-%d-%d-%016x",
-		p.instanceTypesSeqNum,
-		p.unavailableOfferings.SeqNum,
-		p.quotaProvider.SeqNum(),
-		paramsHash,
-	)
-	if item, ok := p.instanceTypesCache.Get(key); ok {
-		// Ensure what's returned from this function is a shallow-copy of the slice (not a deep-copy of the data itself)
-		// so that modifications to the ordering of the data don't affect the original
-		return append([]*cloudprovider.InstanceType{}, item.([]*cloudprovider.InstanceType)...), nil
-	}
+	key := fmt.Sprintf("%016x", paramsHash)
 
-	// Get Viable offerings
-	// Azure has zones availability directly from SKU info
+	p.muInstanceTypesCache.Lock()
+	defer p.muInstanceTypesCache.Unlock()
+
+	for {
+		generation := p.currentInstanceTypesCacheGeneration()
+		if generation != p.instanceTypesCacheGeneration {
+			p.instanceTypesCache.Flush()
+			p.instanceTypesCacheGeneration = generation
+		}
+		if item, ok := p.instanceTypesCache.Get(key); ok {
+			// Ensure what's returned from this function is a shallow-copy of the slice (not a deep-copy of the data itself)
+			// so that modifications to the ordering of the data don't affect the original
+			return append([]*cloudprovider.InstanceType{}, item.([]*cloudprovider.InstanceType)...), nil
+		}
+
+		result := p.buildInstanceTypes(ctx, instanceTypeParams)
+
+		if generation != p.currentInstanceTypesCacheGeneration() {
+			continue
+		}
+		p.instanceTypesCache.SetDefault(key, result)
+		if generation != p.currentInstanceTypesCacheGeneration() {
+			continue
+		}
+		return result, nil
+	}
+}
+
+func (p *DefaultProvider) buildInstanceTypes(ctx context.Context, params *instanceTypeParameters) []*cloudprovider.InstanceType {
 	var result []*cloudprovider.InstanceType
 	for _, sku := range p.instanceTypesInfo {
 		vmsize, err := sku.GetVMSize()
@@ -181,20 +201,23 @@ func (p *DefaultProvider) List(
 			continue
 		}
 		instanceTypeZones := p.instanceTypeZones(sku)
-		instanceType := newInstanceType(ctx, sku, vmsize, p.region, p.createOfferings(ctx, sku, instanceTypeZones), instanceTypeParams, architecture)
+		instanceType := newInstanceType(ctx, sku, vmsize, p.region, p.createOfferings(ctx, sku, instanceTypeZones), params, architecture)
 		if len(instanceType.Offerings) == 0 {
 			continue
 		}
-
-		if !p.isInstanceTypeSupportedByFilters(sku, architecture, instanceTypeParams) {
+		if !p.isInstanceTypeSupportedByFilters(sku, architecture, params) {
 			continue
 		}
-
 		result = append(result, instanceType)
 	}
+	return result
+}
 
-	p.instanceTypesCache.SetDefault(key, result)
-	return result, nil
+func (p *DefaultProvider) currentInstanceTypesCacheGeneration() instanceTypesCacheGeneration {
+	return instanceTypesCacheGeneration{
+		unavailableOfferings: atomic.LoadUint64(&p.unavailableOfferings.SeqNum),
+		quota:                p.quotaProvider.SeqNum(),
+	}
 }
 
 func (p *DefaultProvider) LivenessProbe(req *http.Request) error {
@@ -466,9 +489,9 @@ func (p *DefaultProvider) UpdateInstanceTypes(ctx context.Context) error {
 	logUnknownSKUFamilies(ctx, instanceTypes)
 
 	if p.cm.HasChanged("instance-types", instanceTypes) {
-		// Only update instanceTypesSeqNum with the instance types have been changed
-		// This is to not create new keys with duplicate instance types option
-		atomic.AddUint64(&p.instanceTypesSeqNum, 1)
+		p.muInstanceTypesCache.Lock()
+		p.instanceTypesCache.Flush()
+		p.muInstanceTypesCache.Unlock()
 		log.FromContext(ctx).V(1).Info("discovered instance types", "instanceTypeCount", len(instanceTypes))
 	}
 	p.instanceTypesInfo = instanceTypes
@@ -541,7 +564,9 @@ func (p *DefaultProvider) Reset() {
 	p.muInstanceTypesInfo.Lock()
 	defer p.muInstanceTypesInfo.Unlock()
 	p.instanceTypesInfo = map[string]*skewer.SKU{}
-	atomic.StoreUint64(&p.instanceTypesSeqNum, 0)
+	p.muInstanceTypesCache.Lock()
+	p.instanceTypesCache.Flush()
+	p.muInstanceTypesCache.Unlock()
 }
 
 func FindMaxEphemeralSizeGBAndPlacement(sku *skewer.SKU) (sizeGB int64, placement *armcompute.DiffDiskPlacement) {

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -100,7 +100,7 @@ type DefaultProvider struct {
 	quotaProvider        quota.Provider
 
 	// Fully initialized instance types are cached by the parameters that affect their construction.
-	// Source-data generations invalidate the cache as a whole instead of creating unreachable keys.
+	// Changes in the source data generation invalidate the cache as a whole instead of creating unreachable keys.
 	instanceTypesCache           *cache.Cache
 	muInstanceTypesCache         sync.Mutex
 	instanceTypesCacheGeneration instanceTypesCacheGeneration

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/mitchellh/hashstructure/v2"
@@ -215,7 +214,7 @@ func (p *DefaultProvider) buildInstanceTypes(ctx context.Context, params *instan
 
 func (p *DefaultProvider) currentInstanceTypesCacheGeneration() instanceTypesCacheGeneration {
 	return instanceTypesCacheGeneration{
-		unavailableOfferings: atomic.LoadUint64(&p.unavailableOfferings.SeqNum),
+		unavailableOfferings: p.unavailableOfferings.SeqNum(),
 		quota:                p.quotaProvider.SeqNum(),
 	}
 }

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -2269,9 +2269,12 @@ var _ = Describe("InstanceType Provider", func() {
 					})
 					ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
 					ExpectNotScheduled(ctx, env.Client, pod)
+					cacheEntries := azureEnv.InstanceTypeCache.ItemCount()
+					Expect(cacheEntries).To(BeNumerically(">", 0))
 					// capacity shortage is over - expire the items from the cache and try again
 					azureEnv.UnavailableOfferingsCache.Flush()
 					ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
+					Expect(azureEnv.InstanceTypeCache.ItemCount()).To(Equal(cacheEntries))
 					node := ExpectScheduled(ctx, env.Client, pod)
 					Expect(node.Labels).To(HaveKeyWithValue(v1.LabelInstanceTypeStable, "Standard_D2_v2"))
 				},
@@ -2503,6 +2506,8 @@ var _ = Describe("InstanceType Provider", func() {
 			})
 
 			It("should have available offerings for a SKU present in the SKU API but missing from pricing data", func() {
+				Expect(azureEnv.InstanceTypeCache.ItemCount()).To(Equal(1))
+
 				// Add a SKU to the fake SKU API that does NOT have pricing in the static pricing data.
 				// This simulates a new SKU appearing in the SKU API before pricing data is available.
 				// Standard_D2_v2_Promo is in known_skus.yaml but has no southcentralus pricing.
@@ -2546,8 +2551,10 @@ var _ = Describe("InstanceType Provider", func() {
 
 				// Re-fetch instance types with the new SKU
 				Expect(azureEnv.InstanceTypesProvider.UpdateInstanceTypes(ctx)).To(Succeed())
+				Expect(azureEnv.InstanceTypeCache.ItemCount()).To(BeZero())
 				updatedInstanceTypes, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(azureEnv.InstanceTypeCache.ItemCount()).To(Equal(1))
 
 				// Find the new SKU in the list
 				var promoSKU *corecloudprovider.InstanceType
@@ -3334,6 +3341,7 @@ var _ = Describe("InstanceType Provider", func() {
 		It("should invalidate instance type cache when quota data changes", func() {
 			targetFamily := defaultTestSKU.GetFamilyName()
 			Expect(targetFamily).ToNot(BeEmpty())
+			Expect(azureEnv.InstanceTypeCache.ItemCount()).To(BeZero())
 
 			// First call with plenty of quota
 			azureEnv.UsageAPI.Usages.Append(
@@ -3347,6 +3355,7 @@ var _ = Describe("InstanceType Provider", func() {
 
 			instanceTypes, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
 			Expect(err).To(BeNil())
+			Expect(azureEnv.InstanceTypeCache.ItemCount()).To(Equal(1))
 			foundFamily := false
 			for _, it := range instanceTypes {
 				sku := fake.MakeSKU(it.Name)
@@ -3375,6 +3384,7 @@ var _ = Describe("InstanceType Provider", func() {
 			// Second call should reflect the new quota (cache invalidated by SeqNum change)
 			instanceTypes, err = azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
 			Expect(err).To(BeNil())
+			Expect(azureEnv.InstanceTypeCache.ItemCount()).To(Equal(1))
 			foundFamily = false
 			for _, it := range instanceTypes {
 				sku := fake.MakeSKU(it.Name)

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -23,10 +23,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -60,7 +58,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/skewer"
-	"github.com/patrickmn/go-cache"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/bootstrap"
@@ -79,7 +76,6 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instancetype"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing"
-	"github.com/Azure/karpenter-provider-azure/pkg/providers/quota"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
 	. "github.com/Azure/karpenter-provider-azure/pkg/test/expectations"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
@@ -100,29 +96,6 @@ var cloudProvider, cloudProviderNonZonal, cloudProviderBootstrap *cloudprovider.
 var fakeZone1 = zones.MakeAKSLabelZoneFromARMZone(fake.Region, "1")
 
 var defaultTestSKU = fake.MakeSKU("Standard_D2_v3")
-
-type generationChangingQuotaProvider struct {
-	changed atomic.Bool
-	seqNum  atomic.Uint64
-}
-
-var _ quota.Provider = (*generationChangingQuotaProvider)(nil)
-
-func (p *generationChangingQuotaProvider) Update(context.Context) error { return nil }
-func (p *generationChangingQuotaProvider) GetUsage(string) (bool, *armcompute.Usage) {
-	return false, nil
-}
-func (p *generationChangingQuotaProvider) GetTotalRegionalUsage() (bool, *armcompute.Usage) {
-	return false, nil
-}
-func (p *generationChangingQuotaProvider) HasQuotaFor(context.Context, *skewer.SKU) bool {
-	if p.changed.CompareAndSwap(false, true) {
-		p.seqNum.Add(1)
-	}
-	return true
-}
-func (p *generationChangingQuotaProvider) SeqNum() uint64 { return p.seqNum.Load() }
-func (p *generationChangingQuotaProvider) Reset()         {}
 
 func TestAzure(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -2682,6 +2655,23 @@ var _ = Describe("InstanceType Provider", func() {
 			})
 		})
 
+		Context("Caching", func() {
+			It("should isolate cached instance type ordering from caller mutations", func() {
+				instanceTypes, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(instanceTypes)).To(BeNumerically(">", 1))
+				original := append([]*corecloudprovider.InstanceType{}, instanceTypes...)
+
+				// A caller is free to reorder its own returned slice; this must not reorder the cached entry.
+				instanceTypes[0], instanceTypes[1] = instanceTypes[1], instanceTypes[0]
+
+				cached, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(lo.Map(cached, func(it *corecloudprovider.InstanceType, _ int) string { return it.Name })).To(
+					Equal(lo.Map(original, func(it *corecloudprovider.InstanceType, _ int) string { return it.Name })))
+			})
+		})
+
 		Context("MaxPods", func() {
 			BeforeEach(func() {
 				ctx = options.ToContext(ctx, test.Options())
@@ -3221,45 +3211,6 @@ var _ = Describe("InstanceType Provider", func() {
 	})
 
 	Context("Quota Filtering", func() {
-		It("should return an uncached snapshot when quota changes during construction", func() {
-			instanceTypeCache := cache.New(time.Hour, time.Hour)
-			quotaProvider := &generationChangingQuotaProvider{}
-			provider := instancetype.NewDefaultProvider(
-				fake.Region,
-				instanceTypeCache,
-				azureEnv.SKUsAPI,
-				azureEnv.PricingProvider,
-				azureEnv.UnavailableOfferingsCache,
-				quotaProvider,
-			)
-			Expect(provider.UpdateInstanceTypes(ctx)).To(Succeed())
-
-			instanceTypes, err := provider.List(ctx, nodeClass)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(instanceTypes).ToNot(BeEmpty())
-			Expect(instanceTypeCache.ItemCount()).To(BeZero())
-
-			instanceTypes, err = provider.List(ctx, nodeClass)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(instanceTypes).ToNot(BeEmpty())
-			Expect(instanceTypeCache.ItemCount()).To(Equal(1))
-		})
-
-		It("should not let a caller reordering the returned slice affect a later cache hit", func() {
-			instanceTypes, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(instanceTypes)).To(BeNumerically(">", 1))
-			original := append([]*corecloudprovider.InstanceType{}, instanceTypes...)
-
-			// A caller is free to reorder its own returned slice; this must not reorder the cached entry.
-			sort.Slice(instanceTypes, func(i, j int) bool { return instanceTypes[i].Name < instanceTypes[j].Name })
-
-			cached, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(lo.Map(cached, func(it *corecloudprovider.InstanceType, _ int) string { return it.Name })).To(
-				Equal(lo.Map(original, func(it *corecloudprovider.InstanceType, _ int) string { return it.Name })))
-		})
-
 		It("should exclude on-demand offering when family quota is exhausted", func() {
 			targetFamily := defaultTestSKU.GetFamilyName()
 			Expect(targetFamily).ToNot(BeEmpty())

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -58,6 +59,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/skewer"
+	"github.com/patrickmn/go-cache"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/bootstrap"
@@ -76,6 +78,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instancetype"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/loadbalancer"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/pricing"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/quota"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
 	. "github.com/Azure/karpenter-provider-azure/pkg/test/expectations"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
@@ -96,6 +99,29 @@ var cloudProvider, cloudProviderNonZonal, cloudProviderBootstrap *cloudprovider.
 var fakeZone1 = zones.MakeAKSLabelZoneFromARMZone(fake.Region, "1")
 
 var defaultTestSKU = fake.MakeSKU("Standard_D2_v3")
+
+type generationChangingQuotaProvider struct {
+	changed atomic.Bool
+	seqNum  atomic.Uint64
+}
+
+var _ quota.Provider = (*generationChangingQuotaProvider)(nil)
+
+func (p *generationChangingQuotaProvider) Update(context.Context) error { return nil }
+func (p *generationChangingQuotaProvider) GetUsage(string) (bool, *armcompute.Usage) {
+	return false, nil
+}
+func (p *generationChangingQuotaProvider) GetTotalRegionalUsage() (bool, *armcompute.Usage) {
+	return false, nil
+}
+func (p *generationChangingQuotaProvider) HasQuotaFor(context.Context, *skewer.SKU) bool {
+	if p.changed.CompareAndSwap(false, true) {
+		p.seqNum.Add(1)
+	}
+	return true
+}
+func (p *generationChangingQuotaProvider) SeqNum() uint64 { return p.seqNum.Load() }
+func (p *generationChangingQuotaProvider) Reset()         {}
 
 func TestAzure(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -3194,6 +3220,30 @@ var _ = Describe("InstanceType Provider", func() {
 	})
 
 	Context("Quota Filtering", func() {
+		It("should return an uncached snapshot when quota changes during construction", func() {
+			instanceTypeCache := cache.New(time.Hour, time.Hour)
+			quotaProvider := &generationChangingQuotaProvider{}
+			provider := instancetype.NewDefaultProvider(
+				fake.Region,
+				instanceTypeCache,
+				azureEnv.SKUsAPI,
+				azureEnv.PricingProvider,
+				azureEnv.UnavailableOfferingsCache,
+				quotaProvider,
+			)
+			Expect(provider.UpdateInstanceTypes(ctx)).To(Succeed())
+
+			instanceTypes, err := provider.List(ctx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(instanceTypes).ToNot(BeEmpty())
+			Expect(instanceTypeCache.ItemCount()).To(BeZero())
+
+			instanceTypes, err = provider.List(ctx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(instanceTypes).ToNot(BeEmpty())
+			Expect(instanceTypeCache.ItemCount()).To(Equal(1))
+		})
+
 		It("should exclude on-demand offering when family quota is exhausted", func() {
 			targetFamily := defaultTestSKU.GetFamilyName()
 			Expect(targetFamily).ToNot(BeEmpty())

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -3242,6 +3243,21 @@ var _ = Describe("InstanceType Provider", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(instanceTypes).ToNot(BeEmpty())
 			Expect(instanceTypeCache.ItemCount()).To(Equal(1))
+		})
+
+		It("should not let a caller reordering the returned slice affect a later cache hit", func() {
+			instanceTypes, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(instanceTypes)).To(BeNumerically(">", 1))
+			original := append([]*corecloudprovider.InstanceType{}, instanceTypes...)
+
+			// A caller is free to reorder its own returned slice; this must not reorder the cached entry.
+			sort.Slice(instanceTypes, func(i, j int) bool { return instanceTypes[i].Name < instanceTypes[j].Name })
+
+			cached, err := azureEnv.InstanceTypesProvider.List(ctx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(lo.Map(cached, func(it *corecloudprovider.InstanceType, _ int) string { return it.Name })).To(
+				Equal(lo.Map(original, func(it *corecloudprovider.InstanceType, _ int) string { return it.Name })))
 		})
 
 		It("should exclude on-demand offering when family quota is exhausted", func() {

--- a/pkg/providers/quota/quota.go
+++ b/pkg/providers/quota/quota.go
@@ -68,6 +68,7 @@ type DefaultProvider struct {
 	usages      map[string]*armcompute.Usage
 	cm          *pretty.ChangeMonitor
 	seqNum      uint64
+	reset       bool
 }
 
 func NewProvider(usageClient UsageAPI, location string) *DefaultProvider {
@@ -101,10 +102,11 @@ func (p *DefaultProvider) Update(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.usages = freshUsages
-	if p.cm.HasChanged("quota-usages", freshUsages) {
+	if p.cm.HasChanged("quota-usages", freshUsages) || p.reset {
 		atomic.AddUint64(&p.seqNum, 1)
 		log.FromContext(ctx).V(1).Info("updated quota usages", "familyQuotas", formatFamilyQuotas(freshUsages))
 	}
+	p.reset = false
 	return nil
 }
 
@@ -149,7 +151,12 @@ func (p *DefaultProvider) SeqNum() uint64 {
 func (p *DefaultProvider) Reset() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if len(p.usages) == 0 {
+		return
+	}
 	p.usages = map[string]*armcompute.Usage{}
+	p.reset = true
+	atomic.AddUint64(&p.seqNum, 1)
 }
 
 // formatFamilyQuotas returns a compact summary of family quotas like "standardDSv3Family: 78/500, standardDv5Family: 20/100".

--- a/pkg/providers/quota/quota.go
+++ b/pkg/providers/quota/quota.go
@@ -68,7 +68,6 @@ type DefaultProvider struct {
 	usages      map[string]*armcompute.Usage
 	cm          *pretty.ChangeMonitor
 	seqNum      atomic.Uint64
-	reset       bool
 }
 
 func NewProvider(usageClient UsageAPI, location string) *DefaultProvider {
@@ -102,11 +101,10 @@ func (p *DefaultProvider) Update(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.usages = freshUsages
-	if p.cm.HasChanged("quota-usages", freshUsages) || p.reset {
+	if p.cm.HasChanged("quota-usages", freshUsages) {
 		p.seqNum.Add(1)
 		log.FromContext(ctx).V(1).Info("updated quota usages", "familyQuotas", formatFamilyQuotas(freshUsages))
 	}
-	p.reset = false
 	return nil
 }
 
@@ -155,7 +153,7 @@ func (p *DefaultProvider) Reset() {
 		return
 	}
 	p.usages = map[string]*armcompute.Usage{}
-	p.reset = true
+	p.cm = pretty.NewChangeMonitor()
 	p.seqNum.Add(1)
 }
 

--- a/pkg/providers/quota/quota.go
+++ b/pkg/providers/quota/quota.go
@@ -67,7 +67,7 @@ type DefaultProvider struct {
 	mu          sync.RWMutex
 	usages      map[string]*armcompute.Usage
 	cm          *pretty.ChangeMonitor
-	seqNum      uint64
+	seqNum      atomic.Uint64
 	reset       bool
 }
 
@@ -103,7 +103,7 @@ func (p *DefaultProvider) Update(ctx context.Context) error {
 	defer p.mu.Unlock()
 	p.usages = freshUsages
 	if p.cm.HasChanged("quota-usages", freshUsages) || p.reset {
-		atomic.AddUint64(&p.seqNum, 1)
+		p.seqNum.Add(1)
 		log.FromContext(ctx).V(1).Info("updated quota usages", "familyQuotas", formatFamilyQuotas(freshUsages))
 	}
 	p.reset = false
@@ -145,7 +145,7 @@ func (p *DefaultProvider) HasQuotaFor(ctx context.Context, sku *skewer.SKU) bool
 }
 
 func (p *DefaultProvider) SeqNum() uint64 {
-	return atomic.LoadUint64(&p.seqNum)
+	return p.seqNum.Load()
 }
 
 func (p *DefaultProvider) Reset() {
@@ -156,7 +156,7 @@ func (p *DefaultProvider) Reset() {
 	}
 	p.usages = map[string]*armcompute.Usage{}
 	p.reset = true
-	atomic.AddUint64(&p.seqNum, 1)
+	p.seqNum.Add(1)
 }
 
 // formatFamilyQuotas returns a compact summary of family quotas like "standardDSv3Family: 78/500, standardDv5Family: 20/100".

--- a/pkg/providers/quota/quota_test.go
+++ b/pkg/providers/quota/quota_test.go
@@ -277,3 +277,29 @@ func Test_SeqNum_IncrementsOnlyWhenDataChanges(t *testing.T) {
 	lo.Must0(quotaProvider.Update(ctx))
 	g.Expect(quotaProvider.SeqNum()).To(Equal(uint64(2)))
 }
+
+func Test_Reset_InvalidatesQuotaDataAndSubsequentRecovery(t *testing.T) {
+	t.Parallel()
+	ctx := TestContextWithLogger(t)
+	g := NewWithT(t)
+	usageAPI, quotaProvider := newTestProvider(t)
+
+	usageAPI.Usages.Append(&armcompute.Usage{
+		Name:         &armcompute.UsageName{Value: lo.ToPtr("standardDSv3Family")},
+		CurrentValue: lo.ToPtr[int32](10),
+		Limit:        lo.ToPtr[int64](100),
+	})
+	lo.Must0(quotaProvider.Update(ctx))
+	g.Expect(quotaProvider.SeqNum()).To(Equal(uint64(1)))
+
+	quotaProvider.Reset()
+	g.Expect(quotaProvider.SeqNum()).To(Equal(uint64(2)))
+	found, _ := quotaProvider.GetUsage("standardDSv3Family")
+	g.Expect(found).To(BeFalse())
+
+	quotaProvider.Reset()
+	g.Expect(quotaProvider.SeqNum()).To(Equal(uint64(2)))
+
+	lo.Must0(quotaProvider.Update(ctx))
+	g.Expect(quotaProvider.SeqNum()).To(Equal(uint64(3)))
+}


### PR DESCRIPTION
Fixes #1844

**Description**

The fully initialized instance type cache currently includes monotonically increasing SKU, unavailable-offering, and quota sequence numbers in each cache key. Every availability change therefore retains another complete instance type graph until the 23-hour TTL expires.

This change:

- keys derived instance types only by the NodeClass parameters that can legitimately coexist;
- flushes derived entries when quota, unavailable-offering, or Skewer SKU data changes;
- serializes cache rebuilding so concurrent misses share one result;
- coalesces duplicate unavailable-offering marks so TTL refreshes do not trigger redundant instance type rebuilds;
- invalidates cached quota availability across fail-open reset and recovery;
- uses typed atomic counters for quota and unavailable-offering generations;
- returns an independent copy of built instance types on a cache miss, matching the cache-hit path, so a caller reordering its returned slice cannot mutate the cached entry.

The existing TTL remains responsible for removing unused NodeClass parameter variants rather than obsolete source-data generations.

**How was this change tested?**

* Added cache-cardinality coverage for quota, unavailable-offering, and Skewer invalidation.
* Added quota reset and recovery coverage.
* Added deterministic coverage for quota availability changing during instance type construction.
* Added duplicate, stricter, global spot, TTL refresh, and concurrent unavailable-offering mark coverage.
* Added coverage that reorders an instance-type slice returned from a cache miss and asserts a later cache hit for the same key is unaffected.
* `go test ./pkg/cache ./pkg/providers/quota ./pkg/providers/instancetype -count=1`
* `go test -race ./pkg/cache ./pkg/providers/quota -count=1`
* `make verify`
* ✅ [E2EMatrixTrigger · Azure/karpenter-provider-azure@3d55e8c](https://github.com/Azure/karpenter-provider-azure/actions/runs/31962583272)
* ✅ [E2EMatrixTrigger · Azure/karpenter-provider-azure@d763392](https://github.com/Azure/karpenter-provider-azure/actions/runs/31977443520)
* ✅ [E2EMatrixTrigger · Azure/karpenter-provider-azure@8478d70](https://github.com/Azure/karpenter-provider-azure/actions/runs/32084795044)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

**Release Note**

```release-note
Fix excessive controller memory retention when Azure quota or offering availability changes.
```