### PR TITLE
feat: support Azure Container Linux with bootstrapping client

### DIFF
--- a/pkg/controllers/nodeclass/status/validation.go
+++ b/pkg/controllers/nodeclass/status/validation.go
@@ -24,6 +24,7 @@ import (
 	sdkerrors "github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient/azapi"
 	"github.com/samber/lo"
@@ -64,12 +65,14 @@ func NewValidationReconciler(
 
 func (r *ValidationReconciler) Reconcile(ctx context.Context, nodeClass *v1beta1.AKSNodeClass) (reconcile.Result, error) {
 	logger := log.FromContext(ctx)
+	provisionOptions := options.FromContext(ctx)
 	if lo.FromPtr(nodeClass.Spec.ImageFamily) == v1beta1.AzureContainerLinuxImageFamily &&
-		!options.FromContext(ctx).IsAKSMachineAPIMode() {
+		provisionOptions.ProvisionMode != consts.ProvisionModeBootstrappingClient &&
+		!provisionOptions.IsAKSMachineAPIMode() {
 		nodeClass.StatusConditions().SetFalse(
 			v1beta1.ConditionTypeValidationSucceeded,
 			IncompatibleProvisionMode,
-			"AzureContainerLinux requires an AKS Machine API provision mode",
+			"AzureContainerLinux requires bootstrappingclient or an AKS Machine API provision mode",
 		)
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controllers/nodeclass/status/validation_test.go
+++ b/pkg/controllers/nodeclass/status/validation_test.go
@@ -94,13 +94,13 @@ var _ = Describe("Validation Reconciler", func() {
 				} else {
 					Expect(condition.IsFalse()).To(BeTrue())
 					Expect(condition.Reason).To(Equal(status.IncompatibleProvisionMode))
-					Expect(condition.Message).To(ContainSubstring("requires an AKS Machine API provision mode"))
+					Expect(condition.Message).To(ContainSubstring("requires bootstrappingclient or an AKS Machine API provision mode"))
 					Expect(result).To(Equal(reconcile.Result{}))
 				}
 			},
 			Entry("ACL with Machine API", v1beta1.AzureContainerLinuxImageFamily, consts.ProvisionModeAKSMachineAPI, true),
 			Entry("ACL with batched Machine API", v1beta1.AzureContainerLinuxImageFamily, consts.ProvisionModeAKSMachineAPIHeaderBatch, true),
-			Entry("ACL with bootstrapping client", v1beta1.AzureContainerLinuxImageFamily, consts.ProvisionModeBootstrappingClient, false),
+			Entry("ACL with bootstrapping client", v1beta1.AzureContainerLinuxImageFamily, consts.ProvisionModeBootstrappingClient, true),
 			Entry("ACL with local scriptless", v1beta1.AzureContainerLinuxImageFamily, consts.ProvisionModeAKSScriptless, false),
 			Entry("Ubuntu with bootstrapping client", v1beta1.UbuntuImageFamily, consts.ProvisionModeBootstrappingClient, true),
 			Entry("Azure Linux with local scriptless", v1beta1.AzureLinuxImageFamily, consts.ProvisionModeAKSScriptless, true),

--- a/pkg/providers/imagefamily/azurecontainerlinux.go
+++ b/pkg/providers/imagefamily/azurecontainerlinux.go
@@ -17,7 +17,6 @@ limitations under the License.
 package imagefamily
 
 import (
-	"context"
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
@@ -78,13 +77,7 @@ func azureContainerLinuxImage(imageDefinition, distro, architecture string) type
 type unsupportedScriptlessBootstrap struct{}
 
 func (unsupportedScriptlessBootstrap) Script() (string, error) {
-	return "", fmt.Errorf("AzureContainerLinux requires an AKS Machine API provision mode")
-}
-
-type unsupportedCustomScriptsBootstrap struct{}
-
-func (unsupportedCustomScriptsBootstrap) GetCustomDataAndCSE(context.Context) (string, string, error) {
-	return "", "", fmt.Errorf("AzureContainerLinux requires an AKS Machine API provision mode")
+	return "", fmt.Errorf("AzureContainerLinux requires bootstrappingclient or an AKS Machine API provision mode")
 }
 
 func (a AzureContainerLinux) ScriptlessCustomData(
@@ -98,20 +91,45 @@ func (a AzureContainerLinux) ScriptlessCustomData(
 }
 
 func (a AzureContainerLinux) CustomScriptsNodeBootstrapping(
-	_ *bootstrap.KubeletConfiguration,
-	_ []v1.Taint,
-	_ []v1.Taint,
-	_ map[string]string,
-	_ *cloudprovider.InstanceType,
-	_ string,
-	_ string,
-	_ types.NodeBootstrappingAPI,
-	_ *v1beta1.FIPSMode,
-	_ *v1beta1.LocalDNS,
-	_ *v1beta1.ArtifactStreaming,
-	_ *v1beta1.LinuxOSConfiguration,
-	_ *bool,
-	_ *bool,
+	kubeletConfig *bootstrap.KubeletConfiguration,
+	taints []v1.Taint,
+	startupTaints []v1.Taint,
+	labels map[string]string,
+	instanceType *cloudprovider.InstanceType,
+	imageDistro string,
+	storageProfile string,
+	nodeBootstrappingClient types.NodeBootstrappingAPI,
+	fipsMode *v1beta1.FIPSMode,
+	localDNS *v1beta1.LocalDNS,
+	artifactStreaming *v1beta1.ArtifactStreaming,
+	linuxOSConfig *v1beta1.LinuxOSConfiguration,
+	vtpmEnabled *bool,
+	secureBootEnabled *bool,
 ) customscriptsbootstrap.Bootstrapper {
-	return unsupportedCustomScriptsBootstrap{}
+	return customscriptsbootstrap.ProvisionClientBootstrap{
+		ClusterName:                    a.Options.ClusterName,
+		KubeletConfig:                  kubeletConfig,
+		Taints:                         taints,
+		StartupTaints:                  startupTaints,
+		Labels:                         labels,
+		SubnetID:                       a.Options.SubnetID,
+		Arch:                           a.Options.Arch,
+		SubscriptionID:                 a.Options.SubscriptionID,
+		ResourceGroup:                  a.Options.ResourceGroup,
+		KubeletClientTLSBootstrapToken: a.Options.KubeletClientTLSBootstrapToken,
+		KubernetesVersion:              a.Options.KubernetesVersion,
+		ImageDistro:                    imageDistro,
+		InstanceType:                   instanceType,
+		StorageProfile:                 storageProfile,
+		ClusterResourceGroup:           a.Options.ClusterResourceGroup,
+		GPUDriverInstallationEnabled:   a.Options.GPUDriverInstallationEnabled,
+		NodeBootstrappingProvider:      nodeBootstrappingClient,
+		OSSKU:                          customscriptsbootstrap.ImageFamilyOSSKUAzureContainerLinux,
+		FIPSMode:                       fipsMode,
+		LocalDNSProfile:                localDNS,
+		ArtifactStreaming:              artifactStreaming,
+		LinuxOSConfig:                  linuxOSConfig,
+		VTPMEnabled:                    vtpmEnabled,
+		SecureBootEnabled:              secureBootEnabled,
+	}
 }

--- a/pkg/providers/imagefamily/azurecontainerlinux_test.go
+++ b/pkg/providers/imagefamily/azurecontainerlinux_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/customscriptsbootstrap"
 	template "github.com/Azure/karpenter-provider-azure/pkg/providers/launchtemplate/parameters"
 	. "github.com/onsi/gomega"
 )
@@ -55,11 +56,15 @@ func TestAzureContainerLinux(t *testing.T) {
 
 	t.Run("scriptless bootstrap is unsupported", func(t *testing.T) {
 		_, err := family.ScriptlessCustomData(nil, nil, nil, nil, nil).Script()
-		NewWithT(t).Expect(err).To(MatchError(ContainSubstring("requires an AKS Machine API provision mode")))
+		NewWithT(t).Expect(err).To(MatchError(ContainSubstring("requires bootstrappingclient or an AKS Machine API provision mode")))
 	})
+}
 
-	t.Run("custom scripts bootstrap is unsupported", func(t *testing.T) {
-		_, _, err := family.CustomScriptsNodeBootstrapping(nil, nil, nil, nil, nil, "", "", nil, nil, nil, nil, nil, nil, nil).GetCustomDataAndCSE(t.Context())
-		NewWithT(t).Expect(err).To(MatchError(ContainSubstring("requires an AKS Machine API provision mode")))
-	})
+func TestAzureContainerLinuxCustomScriptsNodeBootstrapping(t *testing.T) {
+	family := &imagefamily.AzureContainerLinux{Options: &template.StaticParameters{}}
+	bootstrapper := family.CustomScriptsNodeBootstrapping(nil, nil, nil, nil, nil, "aks-acl-gen2-tl", "Managed", nil, nil, nil, nil, nil, nil, nil)
+	provisionBootstrapper, ok := bootstrapper.(customscriptsbootstrap.ProvisionClientBootstrap)
+	g := NewWithT(t)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(provisionBootstrapper.OSSKU).To(Equal(customscriptsbootstrap.ImageFamilyOSSKUAzureContainerLinux))
 }

--- a/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap.go
@@ -36,11 +36,12 @@ import (
 )
 
 const (
-	ImageFamilyOSSKUUbuntu2004  = "Ubuntu2004"
-	ImageFamilyOSSKUUbuntu2204  = "Ubuntu2204"
-	ImageFamilyOSSKUUbuntu2404  = "Ubuntu2404"
-	ImageFamilyOSSKUAzureLinux2 = "AzureLinux2"
-	ImageFamilyOSSKUAzureLinux3 = "AzureLinux3"
+	ImageFamilyOSSKUUbuntu2004          = "Ubuntu2004"
+	ImageFamilyOSSKUUbuntu2204          = "Ubuntu2204"
+	ImageFamilyOSSKUUbuntu2404          = "Ubuntu2404"
+	ImageFamilyOSSKUAzureLinux2         = "AzureLinux2"
+	ImageFamilyOSSKUAzureLinux3         = "AzureLinux3"
+	ImageFamilyOSSKUAzureContainerLinux = "AzureContainerLinux"
 )
 
 type ProvisionClientBootstrap struct {
@@ -155,6 +156,8 @@ func (p *ProvisionClientBootstrap) ConstructProvisionValues(ctx context.Context)
 		provisionProfile.OsSku = lo.ToPtr(models.OSSKUUbuntu)
 	case ImageFamilyOSSKUAzureLinux2, ImageFamilyOSSKUAzureLinux3:
 		provisionProfile.OsSku = lo.ToPtr(models.OSSKUAzureLinux)
+	case ImageFamilyOSSKUAzureContainerLinux:
+		provisionProfile.OsSku = lo.ToPtr(models.OSSKUAzureContainerLinux)
 	default:
 		return nil, fmt.Errorf("unsupported OSSKU %s", p.OSSKU)
 	}

--- a/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap_test.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/provisionclientbootstrap_test.go
@@ -410,6 +410,39 @@ func TestConstructProvisionValues(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "Azure Container Linux configuration",
+			bootstrapper: &customscriptsbootstrap.ProvisionClientBootstrap{
+				ClusterName:       "test-cluster",
+				KubeletConfig:     &bootstrap.KubeletConfiguration{MaxPods: int32(110)},
+				SubnetID:          "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+				Arch:              karpv1.ArchitectureAmd64,
+				ResourceGroup:     "test-rg",
+				KubernetesVersion: "1.34.0",
+				ImageDistro:       "aks-acl-gen2-tl",
+				StorageProfile:    consts.StorageProfileManagedDisks,
+				OSSKU:             customscriptsbootstrap.ImageFamilyOSSKUAzureContainerLinux,
+				Labels:            map[string]string{"key": "value"},
+				VTPMEnabled:       lo.ToPtr(true),
+				SecureBootEnabled: lo.ToPtr(true),
+				InstanceType: &cloudprovider.InstanceType{
+					Name: "Standard_D2s_v5",
+					Capacity: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, values *models.ProvisionValues) {
+				g := NewWithT(t)
+				profile := values.ProvisionProfile
+				g.Expect(*profile.OsSku).To(Equal(models.OSSKUAzureContainerLinux))
+				g.Expect(*profile.Distro).To(Equal("aks-acl-gen2-tl"))
+				g.Expect(*profile.SecurityProfile.EnableVTPM).To(BeTrue())
+				g.Expect(*profile.SecurityProfile.EnableSecureBoot).To(BeTrue())
+			},
+		},
+		{
 			name: "GPU instance type",
 			bootstrapper: &customscriptsbootstrap.ProvisionClientBootstrap{
 				ClusterName:                  "test-cluster",

--- a/pkg/providers/imagefamily/customscriptsbootstrap/utils.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/utils.go
@@ -17,7 +17,12 @@ limitations under the License.
 package customscriptsbootstrap
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
 	"math"
 	"strings"
 
@@ -36,9 +41,70 @@ func hydrateBootstrapTokenIfNeeded(customDataDehydratable string, cseDehydratabl
 		return "", "", err
 	}
 	decodedCustomDataHydrated := strings.ReplaceAll(string(decodedCustomDataDehydratableInBytes), "{{.TokenID}}.{{.TokenSecret}}", bootstrapToken)
+	decodedCustomDataHydrated, err = hydrateIgnitionFiles(decodedCustomDataHydrated, bootstrapToken)
+	if err != nil {
+		return "", "", err
+	}
 	customDataHydrated := base64.StdEncoding.EncodeToString([]byte(decodedCustomDataHydrated))
 
 	return customDataHydrated, cseHydrated, nil
+}
+
+func hydrateIgnitionFiles(customData string, bootstrapToken string) (string, error) {
+	var ignition map[string]any
+	if err := json.Unmarshal([]byte(customData), &ignition); err != nil || ignition["ignition"] == nil {
+		return customData, nil
+	}
+	storage, _ := ignition["storage"].(map[string]any)
+	files, _ := storage["files"].([]any)
+
+	for i, rawFile := range files {
+		file, _ := rawFile.(map[string]any)
+		contents, _ := file["contents"].(map[string]any)
+		source, _ := contents["source"].(string)
+		compression, _ := contents["compression"].(string)
+		const prefix = "data:;base64,"
+		if !strings.HasPrefix(source, prefix) {
+			continue
+		}
+		payload, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(source, prefix))
+		if err != nil {
+			return "", fmt.Errorf("decode Ignition file %d: %w", i, err)
+		}
+		if compression == "gzip" {
+			reader, err := gzip.NewReader(bytes.NewReader(payload))
+			if err != nil {
+				return "", fmt.Errorf("decompress Ignition file %d: %w", i, err)
+			}
+			payload, err = io.ReadAll(reader)
+			if closeErr := reader.Close(); err == nil {
+				err = closeErr
+			}
+			if err != nil {
+				return "", fmt.Errorf("read Ignition file %d: %w", i, err)
+			}
+		}
+
+		hydrated := []byte(strings.ReplaceAll(string(payload), "{{.TokenID}}.{{.TokenSecret}}", bootstrapToken))
+		if compression == "gzip" {
+			var compressed bytes.Buffer
+			writer := gzip.NewWriter(&compressed)
+			if _, err := writer.Write(hydrated); err != nil {
+				return "", fmt.Errorf("compress Ignition file %d: %w", i, err)
+			}
+			if err := writer.Close(); err != nil {
+				return "", fmt.Errorf("close Ignition file %d compressor: %w", i, err)
+			}
+			hydrated = compressed.Bytes()
+		}
+		contents["source"] = prefix + base64.StdEncoding.EncodeToString(hydrated)
+	}
+
+	hydrated, err := json.Marshal(ignition)
+	if err != nil {
+		return "", fmt.Errorf("marshal hydrated Ignition: %w", err)
+	}
+	return string(hydrated), nil
 }
 
 func reverseVMMemoryOverhead(vmMemoryOverheadPercent float64, adjustedMemory float64) float64 {

--- a/pkg/providers/imagefamily/customscriptsbootstrap/utils_test.go
+++ b/pkg/providers/imagefamily/customscriptsbootstrap/utils_test.go
@@ -17,9 +17,14 @@ limitations under the License.
 package customscriptsbootstrap
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
@@ -160,6 +165,13 @@ func TestConvertPodMaxPids(t *testing.T) {
 }
 
 func TestHydrateBootstrapTokenIfNeeded(t *testing.T) {
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	_, err := writer.Write([]byte("nested-{{.TokenID}}.{{.TokenSecret}}-value"))
+	NewWithT(t).Expect(err).ToNot(HaveOccurred())
+	NewWithT(t).Expect(writer.Close()).To(Succeed())
+	ignition := `{"ignition":{"version":"3.4.0"},"storage":{"files":[{"path":"/nested","contents":{"compression":"gzip","source":"data:;base64,` + base64.StdEncoding.EncodeToString(compressed.Bytes()) + `"}}]},"preserve":{"value":true}}`
+
 	tests := []struct {
 		name                   string
 		customDataDehydratable string
@@ -169,6 +181,14 @@ func TestHydrateBootstrapTokenIfNeeded(t *testing.T) {
 		expectedCSE            string
 		expectError            bool
 	}{
+		{
+			name:                   "Nested Ignition gzip token replacement",
+			customDataDehydratable: base64.StdEncoding.EncodeToString([]byte(ignition)),
+			cseDehydratable:        "cse-without-token-placeholder",
+			bootstrapToken:         "abc.123456",
+			expectedCSE:            "cse-without-token-placeholder",
+			expectError:            false,
+		},
 		{
 			name:                   "Valid token replacement",
 			customDataDehydratable: base64.StdEncoding.EncodeToString([]byte("custom-data-with-{{.TokenID}}.{{.TokenSecret}}-placeholder")),
@@ -207,8 +227,27 @@ func TestHydrateBootstrapTokenIfNeeded(t *testing.T) {
 			}
 
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(customData).To(Equal(tt.expectedCustomData))
+			if tt.expectedCustomData != "" {
+				g.Expect(customData).To(Equal(tt.expectedCustomData))
+			}
 			g.Expect(cse).To(Equal(tt.expectedCSE))
+			if tt.name == "Nested Ignition gzip token replacement" {
+				decoded, err := base64.StdEncoding.DecodeString(customData)
+				g.Expect(err).ToNot(HaveOccurred())
+				var doc map[string]any
+				g.Expect(json.Unmarshal(decoded, &doc)).To(Succeed())
+				g.Expect(doc).To(HaveKey("preserve"))
+				files := doc["storage"].(map[string]any)["files"].([]any)
+				source := files[0].(map[string]any)["contents"].(map[string]any)["source"].(string)
+				payload, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(source, "data:;base64,"))
+				g.Expect(err).ToNot(HaveOccurred())
+				reader, err := gzip.NewReader(bytes.NewReader(payload))
+				g.Expect(err).ToNot(HaveOccurred())
+				hydrated, err := io.ReadAll(reader)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(reader.Close()).To(Succeed())
+				g.Expect(string(hydrated)).To(Equal("nested-abc.123456-value"))
+			}
 		})
 	}
 }

--- a/pkg/provisionclients/models/enums.go
+++ b/pkg/provisionclients/models/enums.go
@@ -25,12 +25,13 @@ const (
 )
 
 const (
-	OSSKUUnspecified   int32 = 0
-	OSSKUUbuntu        int32 = 1
-	OSSKUAzureLinux    int32 = 7
-	OSSKUWindows2019   int32 = 3
-	OSSKUWindows2022   int32 = 4
-	OSSKUWindowsAnnual int32 = 8
+	OSSKUUnspecified         int32 = 0
+	OSSKUUbuntu              int32 = 1
+	OSSKUAzureLinux          int32 = 7
+	OSSKUWindows2019         int32 = 3
+	OSSKUWindows2022         int32 = 4
+	OSSKUWindowsAnnual       int32 = 8
+	OSSKUAzureContainerLinux int32 = 16
 )
 
 const (


### PR DESCRIPTION
## Summary

Extend Azure Container Linux support from #1841 to the `bootstrappingclient` provision mode.

This PR is intentionally stacked on #1841 so Machine API support remains independently reviewable. After #1841 merges, this PR can be retargeted to `main`.

## Changes

- Send `AzureContainerLinux` OSSKU (`16`) and the resolved ACL distro to Node Provisioner.
- Construct the direct-VM bootstrap payload using the existing provision-client path.
- Hydrate bootstrap-token placeholders inside nested Base64 and gzip-compressed Ignition files.
- Allow ACL with `bootstrappingclient` while continuing to reject local `aksscriptless` bootstrap.

## Dependency

Requires a companion AKS service change to select AgentBaker compact NBC/CSE Ignition for ACL bootstrapping requests. RP already carries AgentBaker `v0.20260814.0`; no dependency bump is required.

## Validation

- Targeted unit suites pass:
  - `pkg/controllers/nodeclass/status`
  - `pkg/providers/imagefamily`
  - `pkg/providers/imagefamily/customscriptsbootstrap`
  - `pkg/providers/instance`
  - `pkg/providers/instancetype`
  - `pkg/apis/v1beta1`
- The combined Karpenter/RP path was previously validated end-to-end: NodeClaim/node Ready, workload Running, CNS/Cilium healthy, Trusted Launch enabled, and AgentBaker Phase-2 complete.

```release-note
Support Azure Container Linux with the bootstrappingclient provision mode.
```