### PR TITLE
feat: add AKS Machine create metrics

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -260,6 +260,7 @@ func (c *CloudProvider) handleInstancePromise(ctx context.Context, instancePromi
 			c.handleInstancePromiseWaitError(ctx, instancePromise, nodeClaim, err)
 			return toCreateError(err, "creating standalone instance failed")
 		}
+		return nil
 	}
 	// For NodePool-managed nodeclaims, launch a single goroutine to poll the returned promise.
 	// Note that we could store the LRO details on the NodeClaim, but we don't bother today because Karpenter

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -18,6 +18,7 @@ package cloudprovider
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,7 +29,29 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
+
+type countingInstancePromise struct {
+	waitCalls atomic.Int32
+}
+
+func (p *countingInstancePromise) Cleanup(context.Context) error { return nil }
+func (p *countingInstancePromise) Wait() error {
+	p.waitCalls.Add(1)
+	return nil
+}
+func (p *countingInstancePromise) GetInstanceName() string { return "test-instance" }
+
+func TestHandleInstancePromiseWaitsOnceForStandaloneNodeClaim(t *testing.T) {
+	g := NewWithT(t)
+	cloudProvider := &CloudProvider{}
+	promise := &countingInstancePromise{}
+
+	g.Expect(cloudProvider.handleInstancePromise(context.Background(), promise, &karpv1.NodeClaim{})).To(Succeed())
+	cloudProvider.WaitForInstancePromises()
+	g.Expect(promise.waitCalls.Load()).To(Equal(int32(1)))
+}
 
 func TestGenerateNodeClaimName(t *testing.T) {
 	tests := []struct {

--- a/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
@@ -124,6 +124,12 @@ func expectAKSMachineMetricSeriesCounts(start, failure int) {
 	Expect(failureMetrics).To(HaveLen(failure))
 }
 
+func requireAKSMachineAPIProvisionMode(expected, skipMessage string) {
+	if testOptions.ProvisionMode != expected {
+		Skip(skipMessage)
+	}
+}
+
 func runSharedAKSMachineAPITests() {
 	Context("metrics integration", func() {
 		BeforeEach(func() {
@@ -298,9 +304,7 @@ func runSharedAKSMachineAPITests() {
 		})
 
 		It("records one failure for a partial header-batch failure", func() {
-			if testOptions.ProvisionMode != consts.ProvisionModeAKSMachineAPIHeaderBatch {
-				Skip("partial failure applies only to header-batch mode")
-			}
+			requireAKSMachineAPIProvisionMode(consts.ProvisionModeAKSMachineAPIHeaderBatch, "partial failure applies only to header-batch mode")
 
 			const (
 				successfulMachineName = "metric-success"
@@ -419,9 +423,7 @@ func runSharedAKSMachineAPITests() {
 		})
 
 		It("preserves the poller error code when the diagnostic GET fails", func() {
-			if testOptions.ProvisionMode != consts.ProvisionModeAKSMachineAPI {
-				Skip("SDK poller diagnostics apply only to direct mode")
-			}
+			requireAKSMachineAPIProvisionMode(consts.ProvisionModeAKSMachineAPI, "SDK poller diagnostics apply only to direct mode")
 
 			const pollerErrorCode = "InternalOperationError"
 			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.Error.Set(&azcore.ResponseError{
@@ -440,6 +442,45 @@ func runSharedAKSMachineAPITests() {
 				ErrorCode:  "DiagnosticGetFailed",
 				StatusCode: http.StatusInternalServerError,
 			})
+			Expect(promise.Wait()).ToNot(Succeed())
+
+			labels := map[string]string{
+				providermetrics.ImageLabel:        lo.FromPtr(promise.AKSMachineTemplate.Properties.NodeImageVersion),
+				providermetrics.SizeLabel:         promise.InstanceType.Name,
+				providermetrics.ZoneLabel:         promise.Zone,
+				providermetrics.CapacityTypeLabel: promise.CapacityType,
+				providermetrics.NodePoolLabel:     nodePool.Name,
+			}
+			expectNoAKSMachineCreateFailures(labels, "sync")
+			asyncFailureLabels := providermetrics.FailureMetricLabels(labels, "async", map[string]string{providermetrics.ErrorCodeLabel: pollerErrorCode})
+			metric, err := providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", asyncFailureLabels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+			expectAKSMachineMetricSeriesCounts(1, 1)
+		})
+
+		It("preserves the poller error code when diagnostic provisioning details are uncoded", func() {
+			requireAKSMachineAPIProvisionMode(consts.ProvisionModeAKSMachineAPI, "SDK poller diagnostics apply only to direct mode")
+
+			const pollerErrorCode = "InternalOperationError"
+			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.Error.Set(&azcore.ResponseError{
+				ErrorCode:  pollerErrorCode,
+				StatusCode: http.StatusInternalServerError,
+			})
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+			instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+			Expect(err).ToNot(HaveOccurred())
+
+			promise, err := azureEnv.AKSMachineProvider.BeginCreate(ctx, nodeClass, nodeClaim, instanceTypes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(promise).ToNot(BeNil())
+
+			machine, ok := azureEnv.AKSDataStorage.AKSMachines.Load(promise.AKSMachineID)
+			Expect(ok).To(BeTrue())
+			machine.Properties.ProvisioningState = lo.ToPtr(consts.ProvisioningStateFailed)
+			machine.Properties.Status.ProvisioningError = &armcontainerservice.ErrorDetail{}
+			azureEnv.AKSDataStorage.AKSMachines.Store(promise.AKSMachineID, machine)
 			Expect(promise.Wait()).ToNot(Succeed())
 
 			labels := map[string]string{

--- a/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
@@ -434,6 +434,41 @@ func runSharedAKSMachineAPITests() {
 			expectAKSMachineMetricSeriesCounts(2, 1)
 		})
 
+		It("preserves the initial GET error code during header-batch polling", func() {
+			requireAKSMachineAPIProvisionMode(consts.ProvisionModeAKSMachineAPIHeaderBatch, "cache polling applies only to header-batch mode")
+
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+			instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+			Expect(err).ToNot(HaveOccurred())
+
+			promise, err := azureEnv.AKSMachineProvider.BeginCreate(ctx, nodeClass, nodeClaim, instanceTypes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(promise).ToNot(BeNil())
+
+			const pollerErrorCode = "InternalOperationError"
+			azureEnv.AKSMachineCache.InvalidateAll()
+			azureEnv.AKSMachinesAPI.AKSMachineGetBehavior.Error.Set(&azcore.ResponseError{
+				ErrorCode:  pollerErrorCode,
+				StatusCode: http.StatusInternalServerError,
+			})
+			Expect(promise.Wait()).ToNot(Succeed())
+
+			labels := map[string]string{
+				providermetrics.ImageLabel:        aksMachineMetricImageID(lo.FromPtr(promise.AKSMachineTemplate.Properties.NodeImageVersion)),
+				providermetrics.SizeLabel:         promise.InstanceType.Name,
+				providermetrics.ZoneLabel:         promise.Zone,
+				providermetrics.CapacityTypeLabel: promise.CapacityType,
+				providermetrics.NodePoolLabel:     nodePool.Name,
+			}
+			expectNoAKSMachineCreateFailures(labels, "sync")
+			asyncFailureLabels := providermetrics.FailureMetricLabels(labels, "async", map[string]string{providermetrics.ErrorCodeLabel: pollerErrorCode})
+			metric, err := providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", asyncFailureLabels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+			expectAKSMachineMetricSeriesCounts(1, 1)
+		})
+
 		It("preserves the poller error code when the diagnostic GET fails", func() {
 			requireAKSMachineAPIProvisionMode(consts.ProvisionModeAKSMachineAPI, "SDK poller diagnostics apply only to direct mode")
 

--- a/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
@@ -18,6 +18,11 @@ package cloudprovider
 
 // TODO v1beta1 extra refactor into suite_test.go / cloudprovider_test.go
 import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
 	. "github.com/Azure/karpenter-provider-azure/pkg/test/expectations"
 	"github.com/awslabs/operatorpkg/object"
 	. "github.com/onsi/ginkgo/v2"
@@ -26,6 +31,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
@@ -43,7 +49,9 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclass/status"
 	"github.com/Azure/karpenter-provider-azure/pkg/fake"
+	providermetrics "github.com/Azure/karpenter-provider-azure/pkg/metrics"
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
+	instancemetrics "github.com/Azure/karpenter-provider-azure/pkg/providers/instance"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils/zones"
@@ -58,9 +66,343 @@ func validateAKSMachineNodeClaim(nodeClaim *karpv1.NodeClaim, nodePool *karpv1.N
 	Expect(nodeClaim.Annotations[v1beta1.AnnotationAKSMachineResourceID]).ToNot(BeEmpty())
 }
 
+func aksMachineBeginError(errorCode string) *azcore.ResponseError {
+	return &azcore.ResponseError{
+		ErrorCode:  errorCode,
+		StatusCode: http.StatusBadRequest,
+		RawResponse: &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Status:     "400 Bad Request",
+			Body:       io.NopCloser(strings.NewReader(`{"code":"` + errorCode + `","message":"simulated begin create failure"}`)),
+		},
+	}
+}
+
+func aksMachineMetricLabelsFromCreateInput(input *fake.AKSMachineCreateOrUpdateInput, nodePoolName string) map[string]string {
+	labels := map[string]string{
+		providermetrics.NodePoolLabel: nodePoolName,
+	}
+	if input == nil || input.AKSMachine.Properties == nil {
+		return labels
+	}
+
+	properties := input.AKSMachine.Properties
+	zone, err := zones.MakeAKSLabelZoneFromARMZones(fake.Region, input.AKSMachine.Zones)
+	Expect(err).ToNot(HaveOccurred())
+
+	capacityType := karpv1.CapacityTypeOnDemand
+	if lo.FromPtr(properties.Priority) == armcontainerservice.ScaleSetPrioritySpot {
+		capacityType = karpv1.CapacityTypeSpot
+	}
+
+	return lo.Assign(labels, map[string]string{
+		providermetrics.ImageLabel:        lo.FromPtr(properties.NodeImageVersion),
+		providermetrics.SizeLabel:         lo.FromPtr(properties.Hardware.VMSize),
+		providermetrics.ZoneLabel:         zone,
+		providermetrics.CapacityTypeLabel: capacityType,
+	})
+}
+
 // runSharedAKSMachineAPITests contains the common test cases that should be run
 // for both ManageExistingAKSMachines = true and false configurations
 func runSharedAKSMachineAPITests() {
+	Context("metrics integration", func() {
+		BeforeEach(func() {
+			instancemetrics.AKSMachineCreateStartMetric.Reset()
+			instancemetrics.AKSMachineCreateFailureMetric.Reset()
+		})
+
+		It("records AKS Machine create start metric during successful launch", func() {
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Reset()
+
+			createdNodeClaim, err := CreateAndWaitForPromises(ctx, cloudProvider, azureEnv, nodeClaim)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createdNodeClaim).ToNot(BeNil())
+
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			createInput := azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Pop()
+			labels := aksMachineMetricLabelsFromCreateInput(createInput, nodePool.Name)
+
+			metric, err := providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_start_total", labels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+
+			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "sync"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).To(BeNil())
+
+			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "async"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).To(BeNil())
+		})
+
+		It("does not record a create attempt when reusing an existing AKS Machine", func() {
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+			createdNodeClaim, err := CreateAndWaitForPromises(ctx, cloudProvider, azureEnv, nodeClaim)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createdNodeClaim).ToNot(BeNil())
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			createInput := azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Pop()
+			labels := aksMachineMetricLabelsFromCreateInput(createInput, nodePool.Name)
+
+			instancemetrics.AKSMachineCreateStartMetric.Reset()
+			instancemetrics.AKSMachineCreateFailureMetric.Reset()
+			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Reset()
+
+			reusedNodeClaim, err := CreateAndWaitForPromises(ctx, cloudProvider, azureEnv, nodeClaim)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(reusedNodeClaim).ToNot(BeNil())
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(0))
+
+			metric, err := providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_start_total", labels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).To(BeNil())
+
+			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "sync"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).To(BeNil())
+		})
+
+		It("records AKS Machine create sync failure metric when Azure rejects the request", func() {
+			beginErr := aksMachineBeginError("OperationNotAllowed")
+			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.BeginError.Set(beginErr)
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+
+			createdNodeClaim, err := CreateAndWaitForPromises(ctx, cloudProvider, azureEnv, nodeClaim)
+			Expect(err).To(HaveOccurred())
+			Expect(createdNodeClaim).To(BeNil())
+
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			createInput := azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Pop()
+			labels := aksMachineMetricLabelsFromCreateInput(createInput, nodePool.Name)
+
+			metric, err := providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_start_total", labels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+
+			syncFailureLabels := providermetrics.FailureMetricLabels(labels, "sync", map[string]string{providermetrics.ErrorCodeLabel: beginErr.ErrorCode})
+			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", syncFailureLabels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+
+			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "async"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).To(BeNil())
+		})
+
+		It("records UnknownError for local create dispatch failures", func() {
+			const errorMessage = "local failure containing a per-request identifier"
+			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.BeginError.Set(errors.New(errorMessage))
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+
+			createdNodeClaim, err := CreateAndWaitForPromises(ctx, cloudProvider, azureEnv, nodeClaim)
+			Expect(err).To(HaveOccurred())
+			Expect(createdNodeClaim).To(BeNil())
+
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			createInput := azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Pop()
+			labels := aksMachineMetricLabelsFromCreateInput(createInput, nodePool.Name)
+
+			unknownFailureLabels := providermetrics.FailureMetricLabels(labels, "sync", map[string]string{providermetrics.ErrorCodeLabel: "UnknownError"})
+			metric, err := providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", unknownFailureLabels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+
+			messageFailureLabels := providermetrics.FailureMetricLabels(labels, "sync", map[string]string{providermetrics.ErrorCodeLabel: errorMessage})
+			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", messageFailureLabels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).To(BeNil())
+		})
+
+		It("records AKS Machine create sync failure metric when the initial GET sees failed provisioning", func() {
+			provisioningError := fake.AKSMachineAPIProvisioningErrorLowPriorityCoresQuota(fake.Region)
+			azureEnv.AKSMachinesAPI.AfterPollProvisioningErrorOverride = provisioningError
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+
+			createdNodeClaim, err := CreateAndWaitForPromises(ctx, cloudProvider, azureEnv, nodeClaim)
+			Expect(err).To(HaveOccurred())
+			Expect(createdNodeClaim).To(BeNil())
+
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			createInput := azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Pop()
+			labels := aksMachineMetricLabelsFromCreateInput(createInput, nodePool.Name)
+
+			metric, err := providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_start_total", labels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+
+			syncFailureLabels := providermetrics.FailureMetricLabels(labels, "sync", map[string]string{providermetrics.ErrorCodeLabel: "OperationNotAllowed"})
+			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", syncFailureLabels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+
+			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "async"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).To(BeNil())
+		})
+
+		It("records one failure for a partial header-batch failure", func() {
+			if testOptions.ProvisionMode != consts.ProvisionModeAKSMachineAPIHeaderBatch {
+				Skip("partial failure applies only to header-batch mode")
+			}
+
+			const (
+				successfulMachineName = "metric-success"
+				failedMachineName     = "metric-failure"
+			)
+			azureEnv.AKSMachinesAPI.BatchMachineErrorFunc = func(machineName string) (string, string) {
+				if machineName == failedMachineName {
+					return "InvalidParameter", "simulated per-machine rejection"
+				}
+				return "", ""
+			}
+
+			newMetricNodeClaim := func(name string) *karpv1.NodeClaim {
+				return coretest.NodeClaim(karpv1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   name,
+						Labels: map[string]string{karpv1.NodePoolLabelKey: nodePool.Name},
+					},
+					Spec: karpv1.NodeClaimSpec{
+						NodeClassRef: &karpv1.NodeClassReference{
+							Group: object.GVK(nodeClass).Group,
+							Kind:  object.GVK(nodeClass).Kind,
+							Name:  nodeClass.Name,
+						},
+						Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+							{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn, Values: []string{"Standard_D2_v3"}},
+							{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{fakeZone1}},
+							{Key: karpv1.CapacityTypeLabelKey, Operator: v1.NodeSelectorOpIn, Values: []string{karpv1.CapacityTypeOnDemand}},
+						},
+					},
+				})
+			}
+
+			instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+			Expect(err).ToNot(HaveOccurred())
+			type createResult struct {
+				name    string
+				promise *instancemetrics.AKSMachinePromise
+				err     error
+			}
+			results := make(chan createResult, 2)
+			var successfulPromise *instancemetrics.AKSMachinePromise
+			for _, name := range []string{successfulMachineName, failedMachineName} {
+				claim := newMetricNodeClaim(name)
+				go func() {
+					promise, createErr := azureEnv.AKSMachineProvider.BeginCreate(ctx, nodeClass, claim, instanceTypes)
+					results <- createResult{name: name, promise: promise, err: createErr}
+				}()
+			}
+
+			for range 2 {
+				result := <-results
+				if result.name == failedMachineName {
+					Expect(result.err).To(HaveOccurred())
+					Expect(result.promise).To(BeNil())
+					continue
+				}
+				Expect(result.err).ToNot(HaveOccurred())
+				Expect(result.promise).ToNot(BeNil())
+				Expect(result.promise.Wait()).To(Succeed())
+				successfulPromise = result.promise
+			}
+
+			Expect(successfulPromise).ToNot(BeNil())
+			labels := map[string]string{
+				providermetrics.ImageLabel:        lo.FromPtr(successfulPromise.AKSMachineTemplate.Properties.NodeImageVersion),
+				providermetrics.SizeLabel:         successfulPromise.InstanceType.Name,
+				providermetrics.ZoneLabel:         successfulPromise.Zone,
+				providermetrics.CapacityTypeLabel: successfulPromise.CapacityType,
+				providermetrics.NodePoolLabel:     nodePool.Name,
+			}
+
+			metric, err := providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_start_total", labels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 2))
+
+			syncFailureLabels := providermetrics.FailureMetricLabels(labels, "sync", map[string]string{providermetrics.ErrorCodeLabel: "InvalidParameter"})
+			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", syncFailureLabels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+
+			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "async"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).To(BeNil())
+		})
+
+		It("records AKS Machine create async failure metric when provisioning fails", func() {
+			isHeaderBatch := testOptions.ProvisionMode == consts.ProvisionModeAKSMachineAPIHeaderBatch
+			expectedErrorCode := "InternalOperationError"
+			if isHeaderBatch {
+				expectedErrorCode = "OperationNotAllowed"
+				azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.SetCustomTransformer(func(input *fake.AKSMachineCreateOrUpdateInput) error {
+					machineID := fake.MkMachineID(input.ResourceGroupName, input.ResourceName, input.AgentPoolName, input.AKSMachineName)
+					machine, ok := azureEnv.AKSDataStorage.AKSMachines.Load(machineID)
+					Expect(ok).To(BeTrue())
+					machine.Properties.ProvisioningState = lo.ToPtr(consts.ProvisioningStateCreating)
+					if machine.Properties.Status == nil {
+						machine.Properties.Status = &armcontainerservice.MachineStatus{}
+					}
+					machine.Properties.Status.ProvisioningError = nil
+					azureEnv.AKSDataStorage.AKSMachines.Store(machineID, machine)
+					return nil
+				})
+			} else {
+				azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.Error.Set(aksMachineBeginError(expectedErrorCode))
+			}
+
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+			createdNodeClaim, err := cloudProvider.Create(ctx, nodeClaim)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createdNodeClaim).ToNot(BeNil())
+
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			createInput := azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Pop()
+			labels := aksMachineMetricLabelsFromCreateInput(createInput, nodePool.Name)
+
+			if isHeaderBatch {
+				machineID := fake.MkMachineID(createInput.ResourceGroupName, createInput.ResourceName, createInput.AgentPoolName, createInput.AKSMachineName)
+				machine, ok := azureEnv.AKSDataStorage.AKSMachines.Load(machineID)
+				Expect(ok).To(BeTrue())
+				machine.Properties.ProvisioningState = lo.ToPtr(consts.ProvisioningStateFailed)
+				machine.Properties.Status.ProvisioningError = fake.AKSMachineAPIProvisioningErrorLowPriorityCoresQuota(fake.Region)
+				azureEnv.AKSDataStorage.AKSMachines.Store(machineID, machine)
+				azureEnv.AKSMachineCache.InvalidateAll()
+			}
+
+			freshNodeClaim := &karpv1.NodeClaim{}
+			Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(nodeClaim), freshNodeClaim)).To(Succeed())
+			freshNodeClaim.StatusConditions().SetTrue(karpv1.ConditionTypeLaunched)
+			Expect(env.Client.Status().Update(ctx, freshNodeClaim)).To(Succeed())
+			cloudProvider.WaitForInstancePromises()
+
+			metric, err := providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_start_total", labels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+
+			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "sync"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).To(BeNil())
+
+			asyncFailureLabels := providermetrics.FailureMetricLabels(labels, "async", map[string]string{providermetrics.ErrorCodeLabel: expectedErrorCode})
+			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", asyncFailureLabels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+		})
+	})
+
 	It("should be able to handle basic operations", func() {
 		ExpectApplied(ctx, env.Client, nodeClass, nodePool)
 
@@ -288,13 +630,14 @@ func runSharedAKSMachineAPITests() {
 				// not this test which assumes provisioning succeeds then List fails afterward.
 				Skip("Batch provisioning depends on List to work")
 			}
-			// Set up error to occur during the NextPage call
-			azureEnv.AKSMachinesAPI.AKSMachineNewListPagerBehavior.Error.Set(fake.AKSMachineAPIErrorAny)
-
 			ExpectApplied(ctx, env.Client, nodeClass, nodePool)
 			pod := coretest.UnschedulablePod()
 			ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
 			ExpectScheduled(ctx, env.Client, pod)
+
+			// Force the next List through the API instead of serving the freshly created machine from cache.
+			azureEnv.AKSMachinesAPI.AKSMachineNewListPagerBehavior.Error.Set(fake.AKSMachineAPIErrorAny)
+			azureEnv.AKSMachineCache.InvalidateAll()
 
 			// Verify the list API was called but failed
 			azureEnv.AKSAgentPoolsAPI.AgentPoolGetBehavior.CalledWithInput.Reset()
@@ -400,13 +743,8 @@ func runSharedAKSMachineAPITests() {
 
 			// Verify the AKS machine was reused successfully
 			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(0))
-			// With cache enabled, the GET is served from cache rather than hitting the API directly.
-			if testOptions.ProvisionMode == consts.ProvisionModeAKSMachineAPIHeaderBatch {
-				// With cache enabled, the pre-create GET is served from cache — no API call recorded
-				Expect(azureEnv.AKSMachinesAPI.AKSMachineGetBehavior.CalledWithInput.Len()).To(Equal(0))
-			} else {
-				Expect(azureEnv.AKSMachinesAPI.AKSMachineGetBehavior.CalledWithInput.Len()).To(Equal(1))
-			}
+			// Both Machine API modes share the same provider cache, so a fresh pre-create GET avoids an API call.
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineGetBehavior.CalledWithInput.Len()).To(Equal(0))
 
 			// Since no new machine was created, verify the machine in the fake store matches original config.
 			aksMachineName := firstNodeClaim.Name
@@ -593,10 +931,10 @@ func runSharedAKSMachineAPITests() {
 }
 
 var _ = Describe("CloudProvider", func() {
-	Context("ProvisionMode = AKSMachineAPIHeaderBatch, ManageExistingAKSMachines = false", func() {
+	Context("ProvisionMode = AKSMachineAPI, ManageExistingAKSMachines = false", func() {
 		BeforeEach(func() {
 			testOptions = test.Options(test.OptionsFields{
-				ProvisionMode:             lo.ToPtr(consts.ProvisionModeAKSMachineAPIHeaderBatch),
+				ProvisionMode:             lo.ToPtr(consts.ProvisionModeAKSMachineAPI),
 				UseSIG:                    lo.ToPtr(true),
 				ManageExistingAKSMachines: lo.ToPtr(false), // should not have any effect, as ProvisionMode is AKSMachineAPI
 			})

--- a/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
@@ -78,6 +78,18 @@ func aksMachineBeginError(errorCode string) *azcore.ResponseError {
 	}
 }
 
+func aksMachineMetricImageID(nodeImageVersion string) string {
+	for _, image := range nodeClass.Status.Images {
+		resolvedNodeImageVersion, err := utils.GetAKSMachineNodeImageVersionFromImageID(image.ID)
+		Expect(err).ToNot(HaveOccurred())
+		if resolvedNodeImageVersion == nodeImageVersion {
+			return image.ID
+		}
+	}
+	Fail("failed to find resolved image ID for AKS Machine NodeImageVersion " + nodeImageVersion)
+	return ""
+}
+
 func aksMachineMetricLabelsFromCreateInput(input *fake.AKSMachineCreateOrUpdateInput, nodePoolName string) map[string]string {
 	labels := map[string]string{
 		providermetrics.NodePoolLabel: nodePoolName,
@@ -96,7 +108,7 @@ func aksMachineMetricLabelsFromCreateInput(input *fake.AKSMachineCreateOrUpdateI
 	}
 
 	return lo.Assign(labels, map[string]string{
-		providermetrics.ImageLabel:        lo.FromPtr(properties.NodeImageVersion),
+		providermetrics.ImageLabel:        aksMachineMetricImageID(lo.FromPtr(properties.NodeImageVersion)),
 		providermetrics.SizeLabel:         lo.FromPtr(properties.Hardware.VMSize),
 		providermetrics.ZoneLabel:         zone,
 		providermetrics.CapacityTypeLabel: capacityType,
@@ -388,7 +400,7 @@ func runSharedAKSMachineAPITests() {
 			Expect(*batchSize).To(Equal(2))
 
 			successfulLabels := map[string]string{
-				providermetrics.ImageLabel:        lo.FromPtr(successfulPromise.AKSMachineTemplate.Properties.NodeImageVersion),
+				providermetrics.ImageLabel:        aksMachineMetricImageID(lo.FromPtr(successfulPromise.AKSMachineTemplate.Properties.NodeImageVersion)),
 				providermetrics.SizeLabel:         successfulPromise.InstanceType.Name,
 				providermetrics.ZoneLabel:         successfulPromise.Zone,
 				providermetrics.CapacityTypeLabel: successfulPromise.CapacityType,
@@ -445,7 +457,7 @@ func runSharedAKSMachineAPITests() {
 			Expect(promise.Wait()).ToNot(Succeed())
 
 			labels := map[string]string{
-				providermetrics.ImageLabel:        lo.FromPtr(promise.AKSMachineTemplate.Properties.NodeImageVersion),
+				providermetrics.ImageLabel:        aksMachineMetricImageID(lo.FromPtr(promise.AKSMachineTemplate.Properties.NodeImageVersion)),
 				providermetrics.SizeLabel:         promise.InstanceType.Name,
 				providermetrics.ZoneLabel:         promise.Zone,
 				providermetrics.CapacityTypeLabel: promise.CapacityType,
@@ -484,7 +496,7 @@ func runSharedAKSMachineAPITests() {
 			Expect(promise.Wait()).ToNot(Succeed())
 
 			labels := map[string]string{
-				providermetrics.ImageLabel:        lo.FromPtr(promise.AKSMachineTemplate.Properties.NodeImageVersion),
+				providermetrics.ImageLabel:        aksMachineMetricImageID(lo.FromPtr(promise.AKSMachineTemplate.Properties.NodeImageVersion)),
 				providermetrics.SizeLabel:         promise.InstanceType.Name,
 				providermetrics.ZoneLabel:         promise.Zone,
 				providermetrics.CapacityTypeLabel: promise.CapacityType,

--- a/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
@@ -105,6 +105,25 @@ func aksMachineMetricLabelsFromCreateInput(input *fake.AKSMachineCreateOrUpdateI
 
 // runSharedAKSMachineAPITests contains the common test cases that should be run
 // for both ManageExistingAKSMachines = true and false configurations
+func expectNoAKSMachineCreateFailures(labels map[string]string, phase string) {
+	metrics, err := providermetrics.FindMetricsWithLabelSubset(
+		"karpenter_instance_aks_machine_create_failure_total",
+		providermetrics.FailureMetricLabels(labels, phase),
+	)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(metrics).To(BeEmpty())
+}
+
+func expectAKSMachineMetricSeriesCounts(start, failure int) {
+	startMetrics, err := providermetrics.FindMetricsWithLabelSubset("karpenter_instance_aks_machine_create_start_total", nil)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(startMetrics).To(HaveLen(start))
+
+	failureMetrics, err := providermetrics.FindMetricsWithLabelSubset("karpenter_instance_aks_machine_create_failure_total", nil)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(failureMetrics).To(HaveLen(failure))
+}
+
 func runSharedAKSMachineAPITests() {
 	Context("metrics integration", func() {
 		BeforeEach(func() {
@@ -129,13 +148,9 @@ func runSharedAKSMachineAPITests() {
 			Expect(metric).ToNot(BeNil())
 			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
 
-			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "sync"))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(metric).To(BeNil())
-
-			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "async"))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(metric).To(BeNil())
+			expectNoAKSMachineCreateFailures(labels, "sync")
+			expectNoAKSMachineCreateFailures(labels, "async")
+			expectAKSMachineMetricSeriesCounts(1, 0)
 		})
 
 		It("does not record a create attempt when reusing an existing AKS Machine", func() {
@@ -160,9 +175,32 @@ func runSharedAKSMachineAPITests() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(metric).To(BeNil())
 
-			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "sync"))
+			expectNoAKSMachineCreateFailures(labels, "sync")
+			expectNoAKSMachineCreateFailures(labels, "async")
+			expectAKSMachineMetricSeriesCounts(0, 0)
+		})
+
+		It("does not record create metrics for AKS Machine update or delete", func() {
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+			createdNodeClaim, err := CreateAndWaitForPromises(ctx, cloudProvider, azureEnv, nodeClaim)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(metric).To(BeNil())
+			Expect(createdNodeClaim).ToNot(BeNil())
+
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			createInput := azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Pop()
+			machine, err := azureEnv.AKSMachineProvider.Get(ctx, createInput.AKSMachineName)
+			Expect(err).ToNot(HaveOccurred())
+
+			instancemetrics.AKSMachineCreateStartMetric.Reset()
+			instancemetrics.AKSMachineCreateFailureMetric.Reset()
+			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Reset()
+
+			Expect(azureEnv.AKSMachineProvider.Update(ctx, createInput.AKSMachineName, *machine, machine.Properties.ETag)).To(Succeed())
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(1))
+			expectAKSMachineMetricSeriesCounts(0, 0)
+
+			Expect(azureEnv.AKSMachineProvider.Delete(ctx, createInput.AKSMachineName)).To(Succeed())
+			expectAKSMachineMetricSeriesCounts(0, 0)
 		})
 
 		It("records AKS Machine create sync failure metric when Azure rejects the request", func() {
@@ -189,9 +227,8 @@ func runSharedAKSMachineAPITests() {
 			Expect(metric).ToNot(BeNil())
 			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
 
-			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "async"))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(metric).To(BeNil())
+			expectNoAKSMachineCreateFailures(labels, "async")
+			expectAKSMachineMetricSeriesCounts(1, 1)
 		})
 
 		It("records UnknownError for local create dispatch failures", func() {
@@ -217,6 +254,9 @@ func runSharedAKSMachineAPITests() {
 			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", messageFailureLabels)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(metric).To(BeNil())
+
+			expectNoAKSMachineCreateFailures(labels, "async")
+			expectAKSMachineMetricSeriesCounts(1, 1)
 		})
 
 		It("records AKS Machine create sync failure metric when the initial GET sees failed provisioning", func() {
@@ -243,9 +283,8 @@ func runSharedAKSMachineAPITests() {
 			Expect(metric).ToNot(BeNil())
 			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
 
-			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "async"))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(metric).To(BeNil())
+			expectNoAKSMachineCreateFailures(labels, "async")
+			expectAKSMachineMetricSeriesCounts(1, 1)
 		})
 
 		It("records one failure for a partial header-batch failure", func() {
@@ -257,6 +296,7 @@ func runSharedAKSMachineAPITests() {
 				successfulMachineName = "metric-success"
 				failedMachineName     = "metric-failure"
 			)
+			failedZone := zones.MakeAKSLabelZoneFromARMZone(fake.Region, "2")
 			azureEnv.AKSMachinesAPI.BatchMachineErrorFunc = func(machineName string) (string, string) {
 				if machineName == failedMachineName {
 					return "InvalidParameter", "simulated per-machine rejection"
@@ -264,7 +304,7 @@ func runSharedAKSMachineAPITests() {
 				return "", ""
 			}
 
-			newMetricNodeClaim := func(name string) *karpv1.NodeClaim {
+			newMetricNodeClaim := func(name, zone string) *karpv1.NodeClaim {
 				return coretest.NodeClaim(karpv1.NodeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   name,
@@ -278,15 +318,20 @@ func runSharedAKSMachineAPITests() {
 						},
 						Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
 							{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn, Values: []string{"Standard_D2_v3"}},
-							{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{fakeZone1}},
+							{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{zone}},
 							{Key: karpv1.CapacityTypeLabelKey, Operator: v1.NodeSelectorOpIn, Values: []string{karpv1.CapacityTypeOnDemand}},
 						},
 					},
 				})
 			}
 
-			instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+			allInstanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
 			Expect(err).ToNot(HaveOccurred())
+			instanceType, ok := lo.Find(allInstanceTypes, func(instanceType *corecloudprovider.InstanceType) bool {
+				return instanceType.Name == "Standard_D2_v3"
+			})
+			Expect(ok).To(BeTrue())
+			instanceTypes := []*corecloudprovider.InstanceType{instanceType}
 			type createResult struct {
 				name    string
 				promise *instancemetrics.AKSMachinePromise
@@ -294,12 +339,19 @@ func runSharedAKSMachineAPITests() {
 			}
 			results := make(chan createResult, 2)
 			var successfulPromise *instancemetrics.AKSMachinePromise
-			for _, name := range []string{successfulMachineName, failedMachineName} {
-				claim := newMetricNodeClaim(name)
-				go func() {
+			requests := []struct {
+				name string
+				zone string
+			}{
+				{name: successfulMachineName, zone: fakeZone1},
+				{name: failedMachineName, zone: failedZone},
+			}
+			for _, request := range requests {
+				claim := newMetricNodeClaim(request.name, request.zone)
+				go func(name string, claim *karpv1.NodeClaim) {
 					promise, createErr := azureEnv.AKSMachineProvider.BeginCreate(ctx, nodeClass, claim, instanceTypes)
 					results <- createResult{name: name, promise: promise, err: createErr}
-				}()
+				}(request.name, claim)
 			}
 
 			for range 2 {
@@ -316,28 +368,44 @@ func runSharedAKSMachineAPITests() {
 			}
 
 			Expect(successfulPromise).ToNot(BeNil())
-			labels := map[string]string{
+			Expect(azureEnv.AKSMachinesAPI.BatchCreateSizes.Len()).To(Equal(1))
+			batchSize := azureEnv.AKSMachinesAPI.BatchCreateSizes.Pop()
+			Expect(batchSize).ToNot(BeNil())
+			Expect(*batchSize).To(Equal(2))
+
+			successfulLabels := map[string]string{
 				providermetrics.ImageLabel:        lo.FromPtr(successfulPromise.AKSMachineTemplate.Properties.NodeImageVersion),
 				providermetrics.SizeLabel:         successfulPromise.InstanceType.Name,
 				providermetrics.ZoneLabel:         successfulPromise.Zone,
 				providermetrics.CapacityTypeLabel: successfulPromise.CapacityType,
 				providermetrics.NodePoolLabel:     nodePool.Name,
 			}
+			failedLabels := make(map[string]string, len(successfulLabels))
+			for name, value := range successfulLabels {
+				failedLabels[name] = value
+			}
+			failedLabels[providermetrics.ZoneLabel] = failedZone
 
-			metric, err := providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_start_total", labels)
+			metric, err := providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_start_total", successfulLabels)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(metric).ToNot(BeNil())
-			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 2))
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
 
-			syncFailureLabels := providermetrics.FailureMetricLabels(labels, "sync", map[string]string{providermetrics.ErrorCodeLabel: "InvalidParameter"})
+			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_start_total", failedLabels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+
+			syncFailureLabels := providermetrics.FailureMetricLabels(failedLabels, "sync", map[string]string{providermetrics.ErrorCodeLabel: "InvalidParameter"})
 			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", syncFailureLabels)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(metric).ToNot(BeNil())
 			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
 
-			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "async"))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(metric).To(BeNil())
+			expectNoAKSMachineCreateFailures(successfulLabels, "sync")
+			expectNoAKSMachineCreateFailures(successfulLabels, "async")
+			expectNoAKSMachineCreateFailures(failedLabels, "async")
+			expectAKSMachineMetricSeriesCounts(2, 1)
 		})
 
 		It("records AKS Machine create async failure metric when provisioning fails", func() {
@@ -391,15 +459,14 @@ func runSharedAKSMachineAPITests() {
 			Expect(metric).ToNot(BeNil())
 			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
 
-			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", providermetrics.FailureMetricLabels(labels, "sync"))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(metric).To(BeNil())
+			expectNoAKSMachineCreateFailures(labels, "sync")
 
 			asyncFailureLabels := providermetrics.FailureMetricLabels(labels, "async", map[string]string{providermetrics.ErrorCodeLabel: expectedErrorCode})
 			metric, err = providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", asyncFailureLabels)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(metric).ToNot(BeNil())
 			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+			expectAKSMachineMetricSeriesCounts(1, 1)
 		})
 	})
 

--- a/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_integration_test.go
@@ -180,6 +180,16 @@ func runSharedAKSMachineAPITests() {
 			expectAKSMachineMetricSeriesCounts(0, 0)
 		})
 
+		It("does not record create metrics when offering selection fails", func() {
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+
+			promise, err := azureEnv.AKSMachineProvider.BeginCreate(ctx, nodeClass, nodeClaim, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(promise).To(BeNil())
+			Expect(azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(Equal(0))
+			expectAKSMachineMetricSeriesCounts(0, 0)
+		})
+
 		It("does not record create metrics for AKS Machine update or delete", func() {
 			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
 			createdNodeClaim, err := CreateAndWaitForPromises(ctx, cloudProvider, azureEnv, nodeClaim)
@@ -406,6 +416,46 @@ func runSharedAKSMachineAPITests() {
 			expectNoAKSMachineCreateFailures(successfulLabels, "async")
 			expectNoAKSMachineCreateFailures(failedLabels, "async")
 			expectAKSMachineMetricSeriesCounts(2, 1)
+		})
+
+		It("preserves the poller error code when the diagnostic GET fails", func() {
+			if testOptions.ProvisionMode != consts.ProvisionModeAKSMachineAPI {
+				Skip("SDK poller diagnostics apply only to direct mode")
+			}
+
+			const pollerErrorCode = "InternalOperationError"
+			azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.Error.Set(&azcore.ResponseError{
+				ErrorCode:  pollerErrorCode,
+				StatusCode: http.StatusInternalServerError,
+			})
+			ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+			instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+			Expect(err).ToNot(HaveOccurred())
+
+			promise, err := azureEnv.AKSMachineProvider.BeginCreate(ctx, nodeClass, nodeClaim, instanceTypes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(promise).ToNot(BeNil())
+
+			azureEnv.AKSMachinesAPI.AKSMachineGetBehavior.Error.Set(&azcore.ResponseError{
+				ErrorCode:  "DiagnosticGetFailed",
+				StatusCode: http.StatusInternalServerError,
+			})
+			Expect(promise.Wait()).ToNot(Succeed())
+
+			labels := map[string]string{
+				providermetrics.ImageLabel:        lo.FromPtr(promise.AKSMachineTemplate.Properties.NodeImageVersion),
+				providermetrics.SizeLabel:         promise.InstanceType.Name,
+				providermetrics.ZoneLabel:         promise.Zone,
+				providermetrics.CapacityTypeLabel: promise.CapacityType,
+				providermetrics.NodePoolLabel:     nodePool.Name,
+			}
+			expectNoAKSMachineCreateFailures(labels, "sync")
+			asyncFailureLabels := providermetrics.FailureMetricLabels(labels, "async", map[string]string{providermetrics.ErrorCodeLabel: pollerErrorCode})
+			metric, err := providermetrics.FindMetricWithLabelValues("karpenter_instance_aks_machine_create_failure_total", asyncFailureLabels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically("==", 1))
+			expectAKSMachineMetricSeriesCounts(1, 1)
 		})
 
 		It("records AKS Machine create async failure metric when provisioning fails", func() {

--- a/pkg/fake/aksmachinesapi.go
+++ b/pkg/fake/aksmachinesapi.go
@@ -86,6 +86,7 @@ type AKSMachinesBehavior struct {
 	// When any per-machine errors are returned, the fake produces a batch error response
 	// (BatchMachineClientError or BatchMachineInternalServerError) matching the real Azure API format.
 	BatchMachineErrorFunc func(machineName string) (errorCode string, errorMessage string)
+	BatchCreateSizes      AtomicPtrStack[int]
 }
 
 var AKSMachineAPIErrorFromAKSMachineNotFound = &azcore.ResponseError{
@@ -102,6 +103,14 @@ var AKSMachineAPIErrorFromAKSMachineImmutablePropertyChangeAttempted = &azcore.R
 }
 var AKSMachineAPIErrorAny = &azcore.ResponseError{
 	ErrorCode: "SomeRandomError",
+}
+
+func cloneResponseError(err *azcore.ResponseError) *azcore.ResponseError {
+	return &azcore.ResponseError{
+		ErrorCode:   err.ErrorCode,
+		StatusCode:  err.StatusCode,
+		RawResponse: err.RawResponse,
+	}
 }
 
 func AKSMachineAPIErrorVMSizeNotSupported(vmSize, subscription, location string) *azcore.ResponseError {
@@ -271,6 +280,7 @@ func (c *AKSMachinesAPI) Reset() {
 	c.aksDataStorage.AKSMachines.Clear()
 	c.AfterPollProvisioningErrorOverride = nil
 	c.BatchMachineErrorFunc = nil
+	c.BatchCreateSizes.Reset()
 }
 
 func (c *AKSMachinesAPI) BeginCreateOrUpdate(
@@ -293,7 +303,7 @@ func (c *AKSMachinesAPI) BeginCreateOrUpdate(
 
 	// Validate parent AgentPool
 	if !c.doesAgentPoolExists(input.ResourceGroupName, input.ResourceName, input.AgentPoolName) {
-		return nil, AKSMachineAPIErrorFromAKSMachinesPoolNotFound
+		return nil, cloneResponseError(AKSMachineAPIErrorFromAKSMachinesPoolNotFound)
 	}
 
 	// If batch entries are present, create a machine for each entry.
@@ -343,6 +353,9 @@ func (c *AKSMachinesAPI) createSingleMachine(input *AKSMachineCreateOrUpdateInpu
 //   - If only internal errors (5xx-style): returns 500 BatchMachineInternalServerError
 //   - If all succeed: returns success as before
 func (c *AKSMachinesAPI) createBatchMachines(input *AKSMachineCreateOrUpdateInput, template armcontainerservice.Machine, entries []aksmachinesheaderbatch.MachineEntry) (*runtime.Poller[armcontainerservice.MachinesClientCreateOrUpdateResponse], error) {
+	batchSize := len(entries)
+	c.BatchCreateSizes.Add(&batchSize)
+
 	// Collect per-machine errors if the error function is set
 	var perMachineErrors []fakeBatchMachineError
 	failedMachines := make(map[string]bool)
@@ -429,7 +442,7 @@ func (c *AKSMachinesAPI) createOneBatchMachine(input *AKSMachineCreateOrUpdateIn
 	// Check if AKS machine already exists — if so, check for immutable property conflicts
 	if existing, ok := c.aksDataStorage.AKSMachines.Load(id); ok {
 		if c.doImmutablePropertiesChanged(&existing, &machine) {
-			return armcontainerservice.Machine{}, AKSMachineAPIErrorFromAKSMachineImmutablePropertyChangeAttempted
+			return armcontainerservice.Machine{}, cloneResponseError(AKSMachineAPIErrorFromAKSMachineImmutablePropertyChangeAttempted)
 		}
 	}
 
@@ -529,7 +542,7 @@ func (c *AKSMachinesAPI) updateExistingAKSMachine(input *AKSMachineCreateOrUpdat
 
 	// Validate immutable properties not violated
 	if c.doImmutablePropertiesChanged(&existing, &aksMachine) {
-		return nil, AKSMachineAPIErrorFromAKSMachineImmutablePropertyChangeAttempted
+		return nil, cloneResponseError(AKSMachineAPIErrorFromAKSMachineImmutablePropertyChangeAttempted)
 	}
 
 	// Patch with new values
@@ -560,7 +573,7 @@ func (c *AKSMachinesAPI) simulateCreateStatusAtAsync(aksMachine armcontainerserv
 			aksMachine.Properties.Status = &armcontainerservice.MachineStatus{}
 		}
 		aksMachine.Properties.Status.ProvisioningError = c.AfterPollProvisioningErrorOverride
-		pollingError = AKSMachineAPIErrorAny
+		pollingError = cloneResponseError(AKSMachineAPIErrorAny)
 	} else {
 		aksMachine.Properties.ProvisioningState = lo.ToPtr(consts.ProvisioningStateSucceeded)
 	}
@@ -587,7 +600,7 @@ func (c *AKSMachinesAPI) Get(
 	return c.AKSMachineGetBehavior.Invoke(input, func(input *AKSMachineGetInput) (armcontainerservice.MachinesClientGetResponse, error) {
 		// Validate that the agent pool exists before attempting to get machines
 		if !c.doesAgentPoolExists(input.ResourceGroupName, input.ResourceName, input.AgentPoolName) {
-			return armcontainerservice.MachinesClientGetResponse{}, AKSMachineAPIErrorFromAKSMachinesPoolNotFound
+			return armcontainerservice.MachinesClientGetResponse{}, cloneResponseError(AKSMachineAPIErrorFromAKSMachinesPoolNotFound)
 		}
 
 		// First try direct lookup using the standard machine ID format
@@ -597,7 +610,7 @@ func (c *AKSMachinesAPI) Get(
 				Machine: aksMachine,
 			}, nil
 		} else {
-			return armcontainerservice.MachinesClientGetResponse{}, AKSMachineAPIErrorFromAKSMachineNotFound
+			return armcontainerservice.MachinesClientGetResponse{}, cloneResponseError(AKSMachineAPIErrorFromAKSMachineNotFound)
 		}
 	})
 }
@@ -624,7 +637,7 @@ func (c *AKSMachinesAPI) NewListPager(
 				// Check if the agent pool exists when fetching the page
 				if !c.doesAgentPoolExists(input.ResourceGroupName, input.ResourceName, input.AgentPoolName) {
 					// AKS machines pool not found. Return ARM not found error to match real API behavior.
-					return armcontainerservice.MachinesClientListResponse{}, AKSMachineAPIErrorFromAKSMachinesPoolNotFound
+					return armcontainerservice.MachinesClientListResponse{}, cloneResponseError(AKSMachineAPIErrorFromAKSMachinesPoolNotFound)
 				}
 
 				var aksMachines []*armcontainerservice.Machine

--- a/pkg/metrics/test_helpers.go
+++ b/pkg/metrics/test_helpers.go
@@ -94,7 +94,8 @@ func metricLabelsContain(metric *dto.Metric, expected map[string]string) bool {
 		actual[label.GetName()] = label.GetValue()
 	}
 	for name, value := range expected {
-		if actual[name] != value {
+		actualValue, ok := actual[name]
+		if !ok || actualValue != value {
 			return false
 		}
 	}

--- a/pkg/metrics/test_helpers.go
+++ b/pkg/metrics/test_helpers.go
@@ -44,6 +44,28 @@ func FindMetricWithLabelValues(metricName string, labels map[string]string) (*dt
 	return nil, nil
 }
 
+// FindMetricsWithLabelSubset locates every metric whose labels contain the requested name-value pairs.
+// An empty label map returns every series in the metric family.
+func FindMetricsWithLabelSubset(metricName string, labels map[string]string) ([]*dto.Metric, error) {
+	metricFamilies, err := crmetrics.Registry.Gather()
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []*dto.Metric
+	for _, mf := range metricFamilies {
+		if mf.GetName() != metricName {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			if metricLabelsContain(metric, labels) {
+				matches = append(matches, metric)
+			}
+		}
+	}
+	return matches, nil
+}
+
 // FailureMetricLabels produces a failure metric label set by merging the provided base labels with
 // the phase label and any additional label maps. Later maps override earlier values when conflicts occur.
 func FailureMetricLabels(base map[string]string, phase string, extra ...map[string]string) map[string]string {
@@ -64,4 +86,17 @@ func metricLabelsEqual(metric *dto.Metric, expected map[string]string) bool {
 	}
 
 	return maps.Equal(snapshot, expected)
+}
+
+func metricLabelsContain(metric *dto.Metric, expected map[string]string) bool {
+	actual := make(map[string]string, len(metric.GetLabel()))
+	for _, label := range metric.GetLabel() {
+		actual[label.GetName()] = label.GetValue()
+	}
+	for name, value := range expected {
+		if actual[name] != value {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/metrics/test_helpers_test.go
+++ b/pkg/metrics/test_helpers_test.go
@@ -1,0 +1,35 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestMetricLabelsContainRequiresLabelPresence(t *testing.T) {
+	name := "present"
+	value := ""
+	metric := &dto.Metric{
+		Label: []*dto.LabelPair{{Name: &name, Value: &value}},
+	}
+
+	if metricLabelsContain(metric, map[string]string{"missing": ""}) {
+		t.Fatal("metricLabelsContain() matched an absent label with an empty expected value")
+	}
+}

--- a/pkg/providers/instance/aksmachineinstance.go
+++ b/pkg/providers/instance/aksmachineinstance.go
@@ -446,7 +446,11 @@ func (p *DefaultAKSMachineProvider) beginCreateMachine(
 	ultraSSD := resolveUltraSSDRequested(nodeClaim)
 
 	// Build the AKS machine template
-	aksMachineTemplate, err := p.buildAKSMachineTemplate(ctx, instanceType, capacityType, placementScope, zone, ultraSSD, nodeClass, nodeClaim)
+	vmImageID, err := p.imageResolver.ResolveNodeImageFromNodeClass(nodeClass, instanceType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build AKS machine template from template: failed to resolve VM image ID: %w", err)
+	}
+	aksMachineTemplate, err := p.buildAKSMachineTemplate(ctx, instanceType, vmImageID, capacityType, placementScope, zone, ultraSSD, nodeClass, nodeClaim)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build AKS machine template from template: %w", err)
 	}
@@ -457,7 +461,7 @@ func (p *DefaultAKSMachineProvider) beginCreateMachine(
 	}
 
 	metricLabels := prometheus.Labels{
-		providermetrics.ImageLabel:        lo.FromPtr(aksMachineTemplate.Properties.NodeImageVersion),
+		providermetrics.ImageLabel:        vmImageID,
 		providermetrics.SizeLabel:         lo.FromPtr(aksMachineTemplate.Properties.Hardware.VMSize),
 		providermetrics.ZoneLabel:         zone,
 		providermetrics.CapacityTypeLabel: capacityType,

--- a/pkg/providers/instance/aksmachineinstance.go
+++ b/pkg/providers/instance/aksmachineinstance.go
@@ -600,10 +600,9 @@ func (p *DefaultAKSMachineProvider) beginCreateMachineNonBatch(
 				metricErrorCode = ErrorCodeForMetrics(err)
 
 				// Get once after begin create to retrieve error details. This is because if the poller returns error, the SDK doesn't let us look at the real results.
-				failedAKSMachine, getErr := p.machineCache.GetWithFallback(ctx, aksMachineName, false)
-				if getErr == nil && failedAKSMachine != nil && failedAKSMachine.Properties != nil && failedAKSMachine.Properties.Status != nil && failedAKSMachine.Properties.Status.ProvisioningError != nil {
-					metricErrorCode = aksMachineProvisioningErrorCodeForMetrics(failedAKSMachine.Properties.Status.ProvisioningError)
-					pollingErr = p.handleMachineProvisioningError(ctx, "LRO", aksMachineName, instanceType, zone, capacityType, failedAKSMachine.Properties.Status.ProvisioningError)
+				if provisioningError := p.getProvisioningErrorAfterPollFailure(ctx, aksMachineName); provisioningError != nil {
+					metricErrorCode = aksMachineProvisioningErrorCodeOrFallback(provisioningError, metricErrorCode)
+					pollingErr = p.handleMachineProvisioningError(ctx, "LRO", aksMachineName, instanceType, zone, capacityType, provisioningError)
 					return
 				}
 				// This should not be expected.
@@ -737,6 +736,14 @@ func (p *DefaultAKSMachineProvider) reuseExistingMachine(ctx context.Context, ak
 		existingAKSMachineVMResourceID,
 		existingAKSMachineCreationTimestamp,
 	), nil
+}
+
+func (p *DefaultAKSMachineProvider) getProvisioningErrorAfterPollFailure(ctx context.Context, aksMachineName string) *armcontainerservice.ErrorDetail {
+	failedAKSMachine, err := p.machineCache.GetWithFallback(ctx, aksMachineName, false)
+	if err != nil || failedAKSMachine == nil || failedAKSMachine.Properties == nil || failedAKSMachine.Properties.Status == nil {
+		return nil
+	}
+	return failedAKSMachine.Properties.Status.ProvisioningError
 }
 
 func (p *DefaultAKSMachineProvider) getCreatedMachineAndHandleEarlyProvisioningError(ctx context.Context, aksMachineName string, instanceType *corecloudprovider.InstanceType, zone string, capacityType string, metricLabels prometheus.Labels) (*armcontainerservice.Machine, error) {

--- a/pkg/providers/instance/aksmachineinstance.go
+++ b/pkg/providers/instance/aksmachineinstance.go
@@ -596,17 +596,17 @@ func (p *DefaultAKSMachineProvider) beginCreateMachineNonBatch(
 			// Use SDK poller (non-batch case)
 			_, err := poller.PollUntilDone(ctx, defaultPollerOptions()) // This may panic if it is deleted mid-way.
 			if err != nil {
-				// Could be quota error; will be handled with custom logic below
+				// Could be quota error; will be handled with custom logic below.
+				metricErrorCode = ErrorCodeForMetrics(err)
 
-				// Get once after begin create to retrieve error details. This is because if the poller returns error, the sdk doesn't let us look at the real results.
-				failedAKSMachine, _ := p.machineCache.GetWithFallback(ctx, aksMachineName, false)
-				if failedAKSMachine.Properties != nil && failedAKSMachine.Properties.Status != nil && failedAKSMachine.Properties.Status.ProvisioningError != nil {
+				// Get once after begin create to retrieve error details. This is because if the poller returns error, the SDK doesn't let us look at the real results.
+				failedAKSMachine, getErr := p.machineCache.GetWithFallback(ctx, aksMachineName, false)
+				if getErr == nil && failedAKSMachine != nil && failedAKSMachine.Properties != nil && failedAKSMachine.Properties.Status != nil && failedAKSMachine.Properties.Status.ProvisioningError != nil {
 					metricErrorCode = aksMachineProvisioningErrorCodeForMetrics(failedAKSMachine.Properties.Status.ProvisioningError)
 					pollingErr = p.handleMachineProvisioningError(ctx, "LRO", aksMachineName, instanceType, zone, capacityType, failedAKSMachine.Properties.Status.ProvisioningError)
 					return
 				}
 				// This should not be expected.
-				metricErrorCode = ErrorCodeForMetrics(err)
 				pollingErr = fmt.Errorf("failed to create AKS machine %q during LRO, AKS API returned error: %w", aksMachineName, err)
 				return
 			}

--- a/pkg/providers/instance/aksmachineinstance.go
+++ b/pkg/providers/instance/aksmachineinstance.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -33,6 +34,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	"github.com/Azure/karpenter-provider-azure/pkg/cache"
 	"github.com/Azure/karpenter-provider-azure/pkg/consts"
+	providermetrics "github.com/Azure/karpenter-provider-azure/pkg/metrics"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/allocationstrategy"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
@@ -454,11 +456,20 @@ func (p *DefaultAKSMachineProvider) beginCreateMachine(
 		logger.Info("creating AKS machine", "aksMachineName", aksMachineName, "instance-type", instanceType.Name, "aksMachine", BuildJSONFromAKSMachine(aksMachineTemplate))
 	}
 
+	metricLabels := prometheus.Labels{
+		providermetrics.ImageLabel:        lo.FromPtr(aksMachineTemplate.Properties.NodeImageVersion),
+		providermetrics.SizeLabel:         lo.FromPtr(aksMachineTemplate.Properties.Hardware.VMSize),
+		providermetrics.ZoneLabel:         zone,
+		providermetrics.CapacityTypeLabel: capacityType,
+		providermetrics.NodePoolLabel:     nodeClaim.Labels[karpv1.NodePoolLabelKey],
+	}
+	AKSMachineCreateStartMetric.With(metricLabels).Inc()
+
 	// Branch between batch and non-batch creation paths.
 	if p.batchCreationEnabled {
-		return p.beginCreateMachineBatch(ctx, aksMachineTemplate, aksMachineName, instanceType, capacityType, zone)
+		return p.beginCreateMachineBatch(ctx, aksMachineTemplate, aksMachineName, instanceType, capacityType, zone, metricLabels)
 	}
-	return p.beginCreateMachineNonBatch(ctx, aksMachineTemplate, aksMachineName, instanceType, capacityType, zone)
+	return p.beginCreateMachineNonBatch(ctx, aksMachineTemplate, aksMachineName, instanceType, capacityType, zone, metricLabels)
 }
 
 // beginCreateMachineBatch handles the batch creation path using the AKS machines header batch API and GET-based poller.
@@ -469,19 +480,22 @@ func (p *DefaultAKSMachineProvider) beginCreateMachineBatch(
 	instanceType *corecloudprovider.InstanceType,
 	capacityType string,
 	zone string,
+	metricLabels prometheus.Labels,
 ) (*AKSMachinePromise, error) {
 	handlableError, err := p.azClient.AKSMachinesBatchClient().BeginCreateWithBatch(ctx, p.clusterResourceGroup, p.clusterName, p.aksMachinesPoolName, aksMachineName, aksMachineTemplate)
 	if err != nil {
+		recordAKSMachineCreateFailure(metricLabels, phaseSyncFailure, "UnknownError")
 		return nil, fmt.Errorf("failed to begin create AKS machine %q, unhandled error: %w", aksMachineName, err)
 	}
 	if handlableError != nil {
+		recordAKSMachineCreateFailure(metricLabels, phaseSyncFailure, handlableError.Code)
 		return nil, p.handleMachineBeginCreateError(ctx, aksMachineName, instanceType, zone, capacityType, handlableError)
 	}
 
 	// Get once after begin create to retrieve VMResourceID.
 	// In fact, the AKS machine object we want here is already returned with the PUT request above. However, the SDK have prevented us from accessing it easily.
 	// TODO: find a way to access that instead of making another GET call like this.
-	gotAKSMachine, err := p.getCreatedMachineAndHandleEarlyProvisioningError(ctx, aksMachineName, instanceType, zone, capacityType)
+	gotAKSMachine, err := p.getCreatedMachineAndHandleEarlyProvisioningError(ctx, aksMachineName, instanceType, zone, capacityType, metricLabels)
 	if err != nil {
 		return nil, err
 	}
@@ -491,19 +505,28 @@ func (p *DefaultAKSMachineProvider) beginCreateMachineBatch(
 		p,
 		aksMachineTemplate,
 		func() (pollingErr error) {
+			metricErrorCode := ""
 			defer func() {
 				if r := recover(); r != nil {
 					err := fmt.Errorf("%v", r)
 					pollingErr = fmt.Errorf("failed to create AKS machine %q during LRO, AKS API panicked: %w", aksMachineName, err)
 				}
+				if pollingErr != nil {
+					if metricErrorCode == "" {
+						metricErrorCode = ErrorCodeForMetrics(pollingErr)
+					}
+					recordAKSMachineCreateFailure(metricLabels, phaseAsyncFailure, metricErrorCode)
+				}
 			}()
 
 			provisioningErr, pollerErr := p.machineCache.PollUntilDone(ctx, aksMachineName)
 			if pollerErr != nil {
+				metricErrorCode = ErrorCodeForMetrics(pollerErr)
 				pollingErr = fmt.Errorf("failed to create AKS machine %q during LRO (GET poller), poller error: %w", aksMachineName, pollerErr)
 				return
 			}
 			if provisioningErr != nil {
+				metricErrorCode = aksMachineProvisioningErrorCodeForMetrics(provisioningErr)
 				pollingErr = p.handleMachineProvisioningError(ctx, "LRO (GET poller)", aksMachineName, instanceType, zone, capacityType, provisioningErr)
 				return
 			}
@@ -531,20 +554,23 @@ func (p *DefaultAKSMachineProvider) beginCreateMachineNonBatch(
 	instanceType *corecloudprovider.InstanceType,
 	capacityType string,
 	zone string,
+	metricLabels prometheus.Labels,
 ) (*AKSMachinePromise, error) {
 	poller, err := p.azClient.AKSMachinesClient().BeginCreateOrUpdate(ctx, p.clusterResourceGroup, p.clusterName, p.aksMachinesPoolName, aksMachineName, *aksMachineTemplate, nil)
 	if err != nil {
 		he := offerings.ErrorToHandlableError(err)
 		if he != nil {
+			recordAKSMachineCreateFailure(metricLabels, phaseSyncFailure, he.Code)
 			return nil, p.handleMachineBeginCreateError(ctx, aksMachineName, instanceType, zone, capacityType, he)
 		}
+		recordAKSMachineCreateFailure(metricLabels, phaseSyncFailure, ErrorCodeForMetrics(err))
 		return nil, fmt.Errorf("failed to begin create AKS machine %q, unhandled error: %w", aksMachineName, err)
 	}
 
 	// Get once after begin create to retrieve VMResourceID.
 	// In fact, the AKS machine object we want here is already returned with the PUT request above. However, the SDK have prevented us from accessing it easily.
 	// TODO: find a way to access that instead of making another GET call like this.
-	gotAKSMachine, err := p.getCreatedMachineAndHandleEarlyProvisioningError(ctx, aksMachineName, instanceType, zone, capacityType)
+	gotAKSMachine, err := p.getCreatedMachineAndHandleEarlyProvisioningError(ctx, aksMachineName, instanceType, zone, capacityType, metricLabels)
 	if err != nil {
 		return nil, err
 	}
@@ -554,10 +580,17 @@ func (p *DefaultAKSMachineProvider) beginCreateMachineNonBatch(
 		p,
 		aksMachineTemplate,
 		func() (pollingErr error) {
+			metricErrorCode := ""
 			defer func() {
 				if r := recover(); r != nil {
 					err := fmt.Errorf("%v", r)
 					pollingErr = fmt.Errorf("failed to create AKS machine %q during LRO, AKS API panicked: %w", aksMachineName, err)
+				}
+				if pollingErr != nil {
+					if metricErrorCode == "" {
+						metricErrorCode = ErrorCodeForMetrics(pollingErr)
+					}
+					recordAKSMachineCreateFailure(metricLabels, phaseAsyncFailure, metricErrorCode)
 				}
 			}()
 			// Use SDK poller (non-batch case)
@@ -568,10 +601,12 @@ func (p *DefaultAKSMachineProvider) beginCreateMachineNonBatch(
 				// Get once after begin create to retrieve error details. This is because if the poller returns error, the sdk doesn't let us look at the real results.
 				failedAKSMachine, _ := p.machineCache.GetWithFallback(ctx, aksMachineName, false)
 				if failedAKSMachine.Properties != nil && failedAKSMachine.Properties.Status != nil && failedAKSMachine.Properties.Status.ProvisioningError != nil {
+					metricErrorCode = aksMachineProvisioningErrorCodeForMetrics(failedAKSMachine.Properties.Status.ProvisioningError)
 					pollingErr = p.handleMachineProvisioningError(ctx, "LRO", aksMachineName, instanceType, zone, capacityType, failedAKSMachine.Properties.Status.ProvisioningError)
 					return
 				}
 				// This should not be expected.
+				metricErrorCode = ErrorCodeForMetrics(err)
 				pollingErr = fmt.Errorf("failed to create AKS machine %q during LRO, AKS API returned error: %w", aksMachineName, err)
 				return
 			}
@@ -704,20 +739,24 @@ func (p *DefaultAKSMachineProvider) reuseExistingMachine(ctx context.Context, ak
 	), nil
 }
 
-func (p *DefaultAKSMachineProvider) getCreatedMachineAndHandleEarlyProvisioningError(ctx context.Context, aksMachineName string, instanceType *corecloudprovider.InstanceType, zone string, capacityType string) (*armcontainerservice.Machine, error) {
+func (p *DefaultAKSMachineProvider) getCreatedMachineAndHandleEarlyProvisioningError(ctx context.Context, aksMachineName string, instanceType *corecloudprovider.InstanceType, zone string, capacityType string, metricLabels prometheus.Labels) (*armcontainerservice.Machine, error) {
 	gotAKSMachine, err := p.machineCache.GetWithFallback(ctx, aksMachineName, false)
 	if err != nil {
+		recordAKSMachineCreateFailure(metricLabels, phaseSyncFailure, ErrorCodeForMetrics(err))
 		return nil, fmt.Errorf("failed to get AKS machine %q once after begin creation: %w", aksMachineName, err)
 	}
 	if err := validateRetrievedAKSMachineBasicProperties(gotAKSMachine); err != nil {
+		recordAKSMachineCreateFailure(metricLabels, phaseSyncFailure, "UnknownError")
 		return nil, fmt.Errorf("failed to get AKS machine %q once after begin creation: %w", aksMachineName, err)
 	}
 	if lo.FromPtr(gotAKSMachine.Properties.ProvisioningState) == consts.ProvisioningStateFailed {
 		// We luckily catch failed state early (compared to during polling).
 		// ASSUMPTION: this is irrecoverable (i.e., polling would have failed).
 		if gotAKSMachine.Properties.Status == nil || gotAKSMachine.Properties.Status.ProvisioningError == nil {
+			recordAKSMachineCreateFailure(metricLabels, phaseSyncFailure, "UnknownError")
 			return nil, fmt.Errorf("failed to get AKS machine %q once after begin creation: AKS machine is in Failed state but ProvisioningError is nil", aksMachineName)
 		}
+		recordAKSMachineCreateFailure(metricLabels, phaseSyncFailure, aksMachineProvisioningErrorCodeForMetrics(gotAKSMachine.Properties.Status.ProvisioningError))
 		return nil, p.handleMachineProvisioningError(ctx, "get once after begin creation", aksMachineName, instanceType, zone, capacityType, gotAKSMachine.Properties.Status.ProvisioningError)
 	}
 	return gotAKSMachine, nil

--- a/pkg/providers/instance/aksmachineinstancehelpers.go
+++ b/pkg/providers/instance/aksmachineinstancehelpers.go
@@ -50,7 +50,7 @@ import (
 //     system knows to move it to the per-machine header.
 //   - If the field is the same for all NodeClaims in a NodePool+NodeClass (like VMSize),
 //     no action needed — it's automatically part of the shared template and batch grouping hash.
-func (p *DefaultAKSMachineProvider) buildAKSMachineTemplate(ctx context.Context, instanceType *corecloudprovider.InstanceType, capacityType string, placementScope string, zone string, ultraSSD bool, nodeClass *v1beta1.AKSNodeClass, nodeClaim *karpv1.NodeClaim) (*armcontainerservice.Machine, error) {
+func (p *DefaultAKSMachineProvider) buildAKSMachineTemplate(ctx context.Context, instanceType *corecloudprovider.InstanceType, vmImageID string, capacityType string, placementScope string, zone string, ultraSSD bool, nodeClass *v1beta1.AKSNodeClass, nodeClaim *karpv1.NodeClaim) (*armcontainerservice.Machine, error) {
 	if instanceType == nil {
 		return nil, fmt.Errorf("InstanceType is not set")
 	}
@@ -63,10 +63,6 @@ func (p *DefaultAKSMachineProvider) buildAKSMachineTemplate(ctx context.Context,
 
 	// NodeImageVersion
 	// E.g., "AKSUbuntu-2204gen2containerd-2023.11.15"
-	vmImageID, err := p.imageResolver.ResolveNodeImageFromNodeClass(nodeClass, instanceType)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve VM image ID: %w", err)
-	}
 	nodeImageVersion, err := utils.GetAKSMachineNodeImageVersionFromImageID(vmImageID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert VM image ID to NodeImageVersion: %w", err)

--- a/pkg/providers/instance/machinecache/machinecache.go
+++ b/pkg/providers/instance/machinecache/machinecache.go
@@ -249,7 +249,11 @@ func (c *MachineCache) InvalidateAll() {
 func (c *MachineCache) PollUntilDone(ctx context.Context, name string) (*armcontainerservice.ErrorDetail, error) {
 	log.FromContext(ctx).V(2).Info("starting cache poller for AKS machine", "aksMachineName", name)
 
-	if !c.checkMachineExists(ctx, name) {
+	machine, err := c.GetWithFallback(ctx, name, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check AKS machine %q before polling: %w", name, err)
+	}
+	if machine == nil {
 		return nil, fmt.Errorf("AKS machine %q does not exist", name)
 	}
 
@@ -272,11 +276,6 @@ func (c *MachineCache) PollUntilDone(ctx context.Context, name string) (*armcont
 			return nil, fmt.Errorf("timed out while polling for AKS machine %q after %s", name, c.options.pollTimeout)
 		}
 	}
-}
-
-func (c *MachineCache) checkMachineExists(ctx context.Context, name string) bool {
-	machine, err := c.GetWithFallback(ctx, name, true)
-	return machine != nil && err == nil
 }
 
 func (c *MachineCache) pollOnce(ctx context.Context, aksMachineName string) (*armcontainerservice.ErrorDetail, error, bool) {

--- a/pkg/providers/instance/metrics.go
+++ b/pkg/providers/instance/metrics.go
@@ -105,15 +105,26 @@ func recordAKSMachineCreateFailure(labels prometheus.Labels, phase, errorCode st
 	AKSMachineCreateFailureMetric.With(failureLabels).Inc()
 }
 
-func aksMachineProvisioningErrorCodeForMetrics(provisioningError *armcontainerservice.ErrorDetail) string {
+func aksMachineProvisioningErrorCode(provisioningError *armcontainerservice.ErrorDetail) (string, bool) {
 	if provisioningError == nil {
-		return "UnknownError"
+		return "", false
 	}
 	if len(provisioningError.Details) > 0 && provisioningError.Details[0] != nil && provisioningError.Details[0].Code != nil && *provisioningError.Details[0].Code != "" {
-		return *provisioningError.Details[0].Code
+		return *provisioningError.Details[0].Code, true
 	}
 	if provisioningError.Code != nil && *provisioningError.Code != "" {
-		return *provisioningError.Code
+		return *provisioningError.Code, true
 	}
-	return "UnknownError"
+	return "", false
+}
+
+func aksMachineProvisioningErrorCodeOrFallback(provisioningError *armcontainerservice.ErrorDetail, fallback string) string {
+	if errorCode, ok := aksMachineProvisioningErrorCode(provisioningError); ok {
+		return errorCode
+	}
+	return fallback
+}
+
+func aksMachineProvisioningErrorCodeForMetrics(provisioningError *armcontainerservice.ErrorDetail) string {
+	return aksMachineProvisioningErrorCodeOrFallback(provisioningError, "UnknownError")
 }

--- a/pkg/providers/instance/metrics.go
+++ b/pkg/providers/instance/metrics.go
@@ -17,6 +17,9 @@ limitations under the License.
 package instance
 
 import (
+	"maps"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
 	metrics "github.com/Azure/karpenter-provider-azure/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -55,11 +58,62 @@ var (
 		},
 		[]string{metrics.ImageLabel, metrics.SizeLabel, metrics.ZoneLabel, metrics.CapacityTypeLabel, metrics.NodePoolLabel, metrics.PhaseLabel, metrics.ErrorCodeLabel},
 	)
+
+	// AKSMachineCreateStartMetric tracks when AKS Machine creation starts.
+	//
+	// STABILITY: ALPHA - This metric may change or be removed without notice.
+	AKSMachineCreateStartMetric = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: instanceSubsystem,
+			Name:      "aks_machine_create_start_total",
+			Help:      "Total number of AKS Machine creation operations started.",
+		},
+		[]string{metrics.ImageLabel, metrics.SizeLabel, metrics.ZoneLabel, metrics.CapacityTypeLabel, metrics.NodePoolLabel},
+	)
+
+	// AKSMachineCreateFailureMetric tracks AKS Machine creation failures, regardless of phase.
+	//
+	// STABILITY: ALPHA - This metric may change or be removed without notice.
+	AKSMachineCreateFailureMetric = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: instanceSubsystem,
+			Name:      "aks_machine_create_failure_total",
+			Help:      "Total number of AKS Machine creation failures.",
+		},
+		[]string{metrics.ImageLabel, metrics.SizeLabel, metrics.ZoneLabel, metrics.CapacityTypeLabel, metrics.NodePoolLabel, metrics.PhaseLabel, metrics.ErrorCodeLabel},
+	)
 )
 
 func init() {
 	crmetrics.Registry.MustRegister(
 		VMCreateStartMetric,
 		VMCreateFailureMetric,
+		AKSMachineCreateStartMetric,
+		AKSMachineCreateFailureMetric,
 	)
+}
+
+func recordAKSMachineCreateFailure(labels prometheus.Labels, phase, errorCode string) {
+	failureLabels := maps.Clone(labels)
+	failureLabels[metrics.PhaseLabel] = phase
+	if errorCode == "" {
+		errorCode = "UnknownError"
+	}
+	failureLabels[metrics.ErrorCodeLabel] = errorCode
+	AKSMachineCreateFailureMetric.With(failureLabels).Inc()
+}
+
+func aksMachineProvisioningErrorCodeForMetrics(provisioningError *armcontainerservice.ErrorDetail) string {
+	if provisioningError == nil {
+		return "UnknownError"
+	}
+	if len(provisioningError.Details) > 0 && provisioningError.Details[0] != nil && provisioningError.Details[0].Code != nil && *provisioningError.Details[0].Code != "" {
+		return *provisioningError.Details[0].Code
+	}
+	if provisioningError.Code != nil && *provisioningError.Code != "" {
+		return *provisioningError.Code
+	}
+	return "UnknownError"
 }

--- a/pkg/providers/instance/metrics_test.go
+++ b/pkg/providers/instance/metrics_test.go
@@ -57,6 +57,21 @@ func TestAKSMachineProvisioningErrorCodeForMetrics(t *testing.T) {
 			want: "OperationPreempted",
 		},
 		{
+			name: "nil detail falls back to top-level code",
+			provisioningError: &armcontainerservice.ErrorDetail{
+				Code:    lo.ToPtr("AllocationFailed"),
+				Details: []*armcontainerservice.ErrorDetail{nil},
+			},
+			want: "AllocationFailed",
+		},
+		{
+			name: "detail without a code uses the bounded fallback",
+			provisioningError: &armcontainerservice.ErrorDetail{
+				Details: []*armcontainerservice.ErrorDetail{{}},
+			},
+			want: "UnknownError",
+		},
+		{
 			name:              "missing codes use the bounded fallback",
 			provisioningError: &armcontainerservice.ErrorDetail{},
 			want:              "UnknownError",

--- a/pkg/providers/instance/metrics_test.go
+++ b/pkg/providers/instance/metrics_test.go
@@ -1,0 +1,79 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instance
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
+	"github.com/samber/lo"
+)
+
+func TestAKSMachineProvisioningErrorCodeForMetrics(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		provisioningError *armcontainerservice.ErrorDetail
+		want              string
+	}{
+		{
+			name: "detail code takes precedence",
+			provisioningError: &armcontainerservice.ErrorDetail{
+				Code: lo.ToPtr("QuotaExceeded"),
+				Details: []*armcontainerservice.ErrorDetail{
+					{Code: lo.ToPtr("OperationNotAllowed")},
+				},
+			},
+			want: "OperationNotAllowed",
+		},
+		{
+			name:              "top-level code is the fallback",
+			provisioningError: &armcontainerservice.ErrorDetail{Code: lo.ToPtr("ZonalAllocationFailed")},
+			want:              "ZonalAllocationFailed",
+		},
+		{
+			name: "empty detail code falls back to top-level code",
+			provisioningError: &armcontainerservice.ErrorDetail{
+				Code: lo.ToPtr("OperationPreempted"),
+				Details: []*armcontainerservice.ErrorDetail{
+					{Code: lo.ToPtr("")},
+				},
+			},
+			want: "OperationPreempted",
+		},
+		{
+			name:              "missing codes use the bounded fallback",
+			provisioningError: &armcontainerservice.ErrorDetail{},
+			want:              "UnknownError",
+		},
+		{
+			name:              "nil error uses the bounded fallback",
+			provisioningError: nil,
+			want:              "UnknownError",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			if got := aksMachineProvisioningErrorCodeForMetrics(testCase.provisioningError); got != testCase.want {
+				t.Fatalf("aksMachineProvisioningErrorCodeForMetrics() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
(AI-generated)

**Description**

Adds AKS Machine API counterparts to the existing VM-create Prometheus metrics:

- `karpenter_instance_aks_machine_create_start_total`
- `karpenter_instance_aks_machine_create_failure_total`

Both direct and header-batched Machine API creates use the same logical-operation instrumentation. The counters preserve the VM metric label contract (`image`, `size`, `zone`, `capacity_type`, and `nodepool`), with failure phase and bounded error-code labels added to failures. Reused Machines, rejected preflight requests, updates, and deletes are excluded.

The implementation also makes standalone Machine promises wait exactly once and preserves the most specific available Azure error code when polling or diagnostic reads fail.

**How was this change tested?**

* `go test ./pkg/providers/instance/machinecache ./pkg/providers/instance ./pkg/cloudprovider -count=1`
* `go test -race ./pkg/cloudprovider -count=1 -ginkgo.focus='metrics integration'`
* `golangci-lint-custom run`
* `make verify`
* `make presubmit` (39 suites passed; composite coverage 69.5%)
* Real-cluster validation covers both `aksmachineapi` and `aksmachineapiheaderbatch`; this PR remains draft while those runs complete.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

**Release Note**

```release-note
Add Prometheus counters for AKS Machine API instance creation starts and failures.
```
