### PR TITLE
feat: add capacity recommendation client and options

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -179,6 +179,10 @@ spec:
             - name: DISABLE_CLUSTER_STATE_OBSERVABILITY
               value: "{{ . }}"
           {{- end }}
+          {{- with .Values.settings.computeRecommendationMode }}
+            - name: COMPUTE_RECOMMENDATION_MODE
+              value: "{{ . }}"
+          {{- end }}
           {{- with .Values.controller.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -206,6 +206,12 @@ settings:
   # -- Disable cluster state metrics and events.
   disableClusterStateObservability: false
 
+  # -- Controls compute recommendation API behavior.
+  # "disabled" (default): No API calls are made to the compute recommendation API.
+  # "log": API is called and results are logged, but local ranking is used for allocation.
+  # "enabled": API results actively influence allocation decisions.
+  computeRecommendationMode: "disabled"
+
   # -- Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates
   # in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features
   featureGates:

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -208,7 +208,7 @@ settings:
 
   # -- Controls compute recommendation API behavior.
   # "disabled" (default): No API calls are made to the compute recommendation API.
-  # "log": API is called and results are logged, but local ranking is used for allocation.
+  # "log-only": API is called and results are logged, but local ranking is used for allocation.
   # "enabled": API results actively influence allocation decisions.
   computeRecommendationMode: "disabled"
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7 v7.3.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armrecommender v0.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9 v9.5.0-beta.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthoriza
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0/go.mod h1:/pz8dyNQe+Ey3yBp/XuYz7oqX8YDNWVpPB0hH3XWfbc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7 v7.3.0 h1:nyxugFxG2uhbMeJVCFFuD2j9wu+6KgeabITdINraQsE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7 v7.3.0/go.mod h1:e4RAYykLIz73CF52KhSooo4whZGXvXrD09m0jkgnWiU=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armrecommender v0.2.0 h1:lhFsjuztGY8igy+O5K3EWC9JPXcD2jEVzPM6NR6dcG4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armrecommender v0.2.0/go.mod h1:BDTIkAa0GCbRLikhuI1siCch6Unn01eyi1J0sEi29T0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0 h1:DWlwvVV5r/Wy1561nZ3wrpI1/vDIBRY/Wd1HWaRBZWA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0/go.mod h1:E7ltexgRDmeJ0fJWv0D/HLwY2xbDdN+uv+X2uZtOx3w=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5 v5.0.0 h1:5n7dPVqsWfVKw+ZiEKSd3Kzu7gwBkbEBkeXb8rgaE9Q=

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -50,7 +50,7 @@ const (
 
 	// Compute recommendation mode values.
 	ComputeRecommendationModeDisabled = "disabled"
-	ComputeRecommendationModeLog      = "log"
+	ComputeRecommendationModeLog      = "log-only"
 	ComputeRecommendationModeEnabled  = "enabled"
 
 	// Provisioning states for AKS Machine objects.

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -48,6 +48,11 @@ const (
 
 	AKSMachineAPIHeaderBatchMaxSize = 50
 
+	// Compute recommendation mode values.
+	ComputeRecommendationModeDisabled = "disabled"
+	ComputeRecommendationModeLog      = "log"
+	ComputeRecommendationModeEnabled  = "enabled"
+
 	// Provisioning states for AKS Machine objects.
 	// The SDK's Machine.Properties.ProvisioningState is typed as *string (no typed constants).
 	// Suggestion: find a constant from azure-sdk-for-go if one becomes available.

--- a/pkg/fake/skumixplacementscoresapi.go
+++ b/pkg/fake/skumixplacementscoresapi.go
@@ -1,0 +1,56 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	armrecommender "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armrecommender"
+
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/capacityrecommendation"
+)
+
+type SKUMixPlacementScoresPostInput struct {
+	Location string
+	Request  armrecommender.SKUMixPlacementRequest
+	Options  *armrecommender.SKUMixPlacementScoresClientPostOptions
+}
+
+type SKUMixPlacementScoresBehavior struct {
+	PostBehavior MockedFunction[SKUMixPlacementScoresPostInput, armrecommender.SKUMixPlacementScoresClientPostResponse]
+}
+
+var _ capacityrecommendation.SKUMixPlacementScoresAPI = &SKUMixPlacementScoresAPI{}
+
+type SKUMixPlacementScoresAPI struct {
+	SKUMixPlacementScoresBehavior
+}
+
+func (f *SKUMixPlacementScoresAPI) Post(_ context.Context, location string, request armrecommender.SKUMixPlacementRequest, options *armrecommender.SKUMixPlacementScoresClientPostOptions) (armrecommender.SKUMixPlacementScoresClientPostResponse, error) {
+	input := &SKUMixPlacementScoresPostInput{
+		Location: location,
+		Request:  request,
+		Options:  options,
+	}
+	return f.PostBehavior.Invoke(input, func(*SKUMixPlacementScoresPostInput) (armrecommender.SKUMixPlacementScoresClientPostResponse, error) {
+		return armrecommender.SKUMixPlacementScoresClientPostResponse{}, nil
+	})
+}
+
+func (f *SKUMixPlacementScoresAPI) Reset() {
+	f.PostBehavior.Reset()
+}

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -107,6 +107,8 @@ type Options struct {
 	ProviderBatchMaxDuration  time.Duration `json:"providerBatchMaxDuration,omitempty"`  // Maximum duration for provider batch accumulation (default 5s). Only used on provision mode aksmachineapiheaderbatch.
 	ProviderBatchMaxSize      int           `json:"providerBatchMaxSize,omitempty"`      // Maximum number of machines per provider batch (default 50, AKS API limit). Only used on provision mode aksmachineapiheaderbatch.
 
+	ComputeRecommendationMode string `json:"computeRecommendationMode,omitempty"` // Controls compute recommendation API behavior: "disabled" (default), "log", or "enabled".
+
 	// computed options; do not set.
 	ParsedDiskEncryptionSetID *arm.ResourceID `json:"-"`
 }
@@ -140,6 +142,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.DurationVar(&o.ProviderBatchIdleDuration, "provider-batch-idle-duration", env.WithDefaultDuration("PROVIDER_BATCH_IDLE_DURATION", time.Second), "Idle duration for provider batch accumulation. Use Go duration format such as `1s`. Only used on provision mode aksmachineapiheaderbatch.")
 	fs.DurationVar(&o.ProviderBatchMaxDuration, "provider-batch-max-duration", env.WithDefaultDuration("PROVIDER_BATCH_MAX_DURATION", 5*time.Second), "Maximum duration for provider batch accumulation. Use Go duration format such as `1s`. Only used on provision mode aksmachineapiheaderbatch.")
 	fs.IntVar(&o.ProviderBatchMaxSize, "provider-batch-max-size", env.WithDefaultInt("PROVIDER_BATCH_MAX_SIZE", consts.AKSMachineAPIHeaderBatchMaxSize), fmt.Sprintf("Maximum number of machines per provider batch (AKS API limit is %d). Only used on provision mode aksmachineapiheaderbatch.", consts.AKSMachineAPIHeaderBatchMaxSize))
+	fs.StringVar(&o.ComputeRecommendationMode, "compute-recommendation-mode", env.WithDefaultString("COMPUTE_RECOMMENDATION_MODE", consts.ComputeRecommendationModeDisabled), "Controls compute recommendation API behavior: 'disabled' (no API calls), 'log' (call and log only), or 'enabled' (use for allocation).")
 
 	additionalTagsFlag := k8sflag.NewMapStringString(&o.AdditionalTags)
 	if err := additionalTagsFlag.Set(env.WithDefaultString("ADDITIONAL_TAGS", "")); err != nil {

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -107,7 +107,7 @@ type Options struct {
 	ProviderBatchMaxDuration  time.Duration `json:"providerBatchMaxDuration,omitempty"`  // Maximum duration for provider batch accumulation (default 5s). Only used on provision mode aksmachineapiheaderbatch.
 	ProviderBatchMaxSize      int           `json:"providerBatchMaxSize,omitempty"`      // Maximum number of machines per provider batch (default 50, AKS API limit). Only used on provision mode aksmachineapiheaderbatch.
 
-	ComputeRecommendationMode string `json:"computeRecommendationMode,omitempty"` // Controls compute recommendation API behavior: "disabled" (default), "log", or "enabled".
+	ComputeRecommendationMode string `json:"computeRecommendationMode,omitempty"` // Controls compute recommendation API behavior: "disabled" (default), "log-only", or "enabled".
 
 	// computed options; do not set.
 	ParsedDiskEncryptionSetID *arm.ResourceID `json:"-"`
@@ -142,7 +142,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.DurationVar(&o.ProviderBatchIdleDuration, "provider-batch-idle-duration", env.WithDefaultDuration("PROVIDER_BATCH_IDLE_DURATION", time.Second), "Idle duration for provider batch accumulation. Use Go duration format such as `1s`. Only used on provision mode aksmachineapiheaderbatch.")
 	fs.DurationVar(&o.ProviderBatchMaxDuration, "provider-batch-max-duration", env.WithDefaultDuration("PROVIDER_BATCH_MAX_DURATION", 5*time.Second), "Maximum duration for provider batch accumulation. Use Go duration format such as `1s`. Only used on provision mode aksmachineapiheaderbatch.")
 	fs.IntVar(&o.ProviderBatchMaxSize, "provider-batch-max-size", env.WithDefaultInt("PROVIDER_BATCH_MAX_SIZE", consts.AKSMachineAPIHeaderBatchMaxSize), fmt.Sprintf("Maximum number of machines per provider batch (AKS API limit is %d). Only used on provision mode aksmachineapiheaderbatch.", consts.AKSMachineAPIHeaderBatchMaxSize))
-	fs.StringVar(&o.ComputeRecommendationMode, "compute-recommendation-mode", env.WithDefaultString("COMPUTE_RECOMMENDATION_MODE", consts.ComputeRecommendationModeDisabled), "Controls compute recommendation API behavior: 'disabled' (no API calls), 'log' (call and log only), or 'enabled' (use for allocation).")
+	fs.StringVar(&o.ComputeRecommendationMode, "compute-recommendation-mode", env.WithDefaultString("COMPUTE_RECOMMENDATION_MODE", consts.ComputeRecommendationModeDisabled), "Controls compute recommendation API behavior: 'disabled' (no API calls), 'log-only' (call and log only), or 'enabled' (use for allocation).")
 
 	additionalTagsFlag := k8sflag.NewMapStringString(&o.AdditionalTags)
 	if err := additionalTagsFlag.Set(env.WithDefaultString("ADDITIONAL_TAGS", "")); err != nil {

--- a/pkg/operator/options/options_validation.go
+++ b/pkg/operator/options/options_validation.go
@@ -295,6 +295,6 @@ func (o *Options) validateComputeRecommendationMode() error {
 		consts.ComputeRecommendationModeEnabled:
 		return nil
 	default:
-		return fmt.Errorf("compute-recommendation-mode %q is invalid, must be one of 'disabled', 'log', or 'enabled'", o.ComputeRecommendationMode)
+		return fmt.Errorf("compute-recommendation-mode %q is invalid, must be one of 'disabled', 'log-only', or 'enabled'", o.ComputeRecommendationMode)
 	}
 }

--- a/pkg/operator/options/options_validation.go
+++ b/pkg/operator/options/options_validation.go
@@ -48,6 +48,7 @@ func (o *Options) Validate() error {
 		o.validateAdditionalTags(),
 		o.validateDiskEncryptionSetID(),
 		o.validateClusterDNSIP(),
+		o.validateComputeRecommendationMode(),
 		validate.Struct(o),
 	)
 }
@@ -280,4 +281,20 @@ func (o *Options) validateDiskEncryptionSetID() error {
 
 	o.ParsedDiskEncryptionSetID = parsedID
 	return nil
+}
+
+func (o *Options) validateComputeRecommendationMode() error {
+	// TODO: We currently only accept disabled. Will expand to accept the other documented values later
+	if o.ComputeRecommendationMode != consts.ComputeRecommendationModeDisabled {
+		return fmt.Errorf("compute-recommendation-mode %q is invalid, must be one of 'disabled'", o.ComputeRecommendationMode)
+	}
+
+	switch o.ComputeRecommendationMode {
+	case consts.ComputeRecommendationModeDisabled,
+		consts.ComputeRecommendationModeLog,
+		consts.ComputeRecommendationModeEnabled:
+		return nil
+	default:
+		return fmt.Errorf("compute-recommendation-mode %q is invalid, must be one of 'disabled', 'log', or 'enabled'", o.ComputeRecommendationMode)
+	}
 }

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -242,7 +242,7 @@ var _ = Describe("Options", func() {
 			Expect(err).To(MatchError(ContainSubstring("compute-recommendation-mode \"invalid-mode\" is invalid")))
 		})
 		It("should accept valid compute-recommendation-mode values", func() {
-			for _, mode := range []string{"disabled"} { // TODO: Add other modes in the future , "log", "enabled"
+			for _, mode := range []string{"disabled"} { // TODO: Add other modes in the future, "log-only", "enabled"
 				err := opts.Parse(
 					fs,
 					"--cluster-name", "my-name",

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -78,6 +78,7 @@ var _ = Describe("Options", func() {
 		"PROVIDER_BATCH_IDLE_DURATION",
 		"PROVIDER_BATCH_MAX_DURATION",
 		"PROVIDER_BATCH_MAX_SIZE",
+		"COMPUTE_RECOMMENDATION_MODE",
 	}
 
 	var fs *coreoptions.FlagSet
@@ -226,6 +227,34 @@ var _ = Describe("Options", func() {
 				"--kubelet-identity-client-id", "not-a-uuid",
 			)
 			Expect(err).To(MatchError(ContainSubstring(errMsg)))
+		})
+		It("should fail when compute-recommendation-mode is invalid", func() {
+			err := opts.Parse(
+				fs,
+				"--cluster-name", "my-name",
+				"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+				"--kubelet-bootstrap-token", "flag-bootstrap-token",
+				"--ssh-public-key", "flag-ssh-public-key",
+				"--vnet-subnet-id", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub",
+				"--node-resource-group", "my-node-rg",
+				"--compute-recommendation-mode", "invalid-mode",
+			)
+			Expect(err).To(MatchError(ContainSubstring("compute-recommendation-mode \"invalid-mode\" is invalid")))
+		})
+		It("should accept valid compute-recommendation-mode values", func() {
+			for _, mode := range []string{"disabled"} { // TODO: Add other modes in the future , "log", "enabled"
+				err := opts.Parse(
+					fs,
+					"--cluster-name", "my-name",
+					"--cluster-endpoint", "https://karpenter-000000000000.hcp.westus2.staging.azmk8s.io",
+					"--kubelet-bootstrap-token", "flag-bootstrap-token",
+					"--ssh-public-key", "flag-ssh-public-key",
+					"--vnet-subnet-id", "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/sillygeese/providers/Microsoft.Network/virtualNetworks/karpentervnet/subnets/karpentersub",
+					"--node-resource-group", "my-node-rg",
+					"--compute-recommendation-mode", mode,
+				)
+				Expect(err).ToNot(HaveOccurred(), "mode %q should be valid", mode)
+			}
 		})
 		It("should fail when vnet guid is not a uuid", func() {
 			errMsg := "vnet-guid null is malformed"

--- a/pkg/providers/azclient/azclient.go
+++ b/pkg/providers/azclient/azclient.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+	armrecommender "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armrecommender"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
@@ -32,6 +33,7 @@ import (
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient/aksmachinesheaderbatch"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient/azapi"
+	"github.com/Azure/karpenter-provider-azure/pkg/providers/capacityrecommendation"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily"
 	imagefamilytypes "github.com/Azure/karpenter-provider-azure/pkg/providers/imagefamily/types"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/instance/skuclient"
@@ -65,6 +67,7 @@ type AZClient struct {
 	NetworkSecurityGroupsClient networksecuritygroup.API
 	SubscriptionsClient         zone.SubscriptionsAPI
 	UsageClient                 quota.UsageAPI
+	SkuMixPlacementClient       capacityrecommendation.SKUMixPlacementScoresAPI
 }
 
 func (c *AZClient) SubnetsClient() azapi.SubnetsAPI {
@@ -121,6 +124,7 @@ func NewAZClientFromAPI(
 	skuClient skewer.ResourceClient,
 	subscriptionsClient zone.SubscriptionsAPI,
 	usageClient quota.UsageAPI,
+	skuMixPlacementClient capacityrecommendation.SKUMixPlacementScoresAPI,
 ) *AZClient {
 	return &AZClient{
 		virtualMachinesClient:          virtualMachinesClient,
@@ -140,6 +144,7 @@ func NewAZClientFromAPI(
 		NetworkSecurityGroupsClient:    networkSecurityGroupsClient,
 		SubscriptionsClient:            subscriptionsClient,
 		UsageClient:                    usageClient,
+		SkuMixPlacementClient:          skuMixPlacementClient,
 	}
 }
 
@@ -218,6 +223,11 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *auth.Environment, c
 	//   * It is functionally identical to the Microsoft.Quota API.
 	// See designs/0012-quota-fungibility-reactivity-improvements.md for more details.
 	usageClient, err := armcompute.NewUsageClient(cfg.SubscriptionID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	skuMixPlacementClient, err := armrecommender.NewSKUMixPlacementScoresClient(cfg.SubscriptionID, cred, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -308,5 +318,6 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *auth.Environment, c
 		skuClient,
 		subscriptionsClient,
 		usageClient,
+		skuMixPlacementClient,
 	), nil
 }

--- a/pkg/providers/azclient/azclient.go
+++ b/pkg/providers/azclient/azclient.go
@@ -67,7 +67,7 @@ type AZClient struct {
 	NetworkSecurityGroupsClient networksecuritygroup.API
 	SubscriptionsClient         zone.SubscriptionsAPI
 	UsageClient                 quota.UsageAPI
-	SkuMixPlacementClient       capacityrecommendation.SKUMixPlacementScoresAPI
+	SKUMixPlacementClient       capacityrecommendation.SKUMixPlacementScoresAPI
 }
 
 func (c *AZClient) SubnetsClient() azapi.SubnetsAPI {
@@ -144,7 +144,7 @@ func NewAZClientFromAPI(
 		NetworkSecurityGroupsClient:    networkSecurityGroupsClient,
 		SubscriptionsClient:            subscriptionsClient,
 		UsageClient:                    usageClient,
-		SkuMixPlacementClient:          skuMixPlacementClient,
+		SKUMixPlacementClient:          skuMixPlacementClient,
 	}
 }
 

--- a/pkg/providers/capacityrecommendation/interfaces.go
+++ b/pkg/providers/capacityrecommendation/interfaces.go
@@ -1,0 +1,27 @@
+/*
+Portions Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacityrecommendation
+
+import (
+	"context"
+
+	armrecommender "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armrecommender"
+)
+
+type SKUMixPlacementScoresAPI interface {
+	Post(ctx context.Context, location string, skuMixPlacementRequest armrecommender.SKUMixPlacementRequest, options *armrecommender.SKUMixPlacementScoresClientPostOptions) (armrecommender.SKUMixPlacementScoresClientPostResponse, error)
+}

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -85,6 +85,7 @@ type Environment struct {
 	AKSMachinesAPI              *fake.AKSMachinesAPI
 	AKSAgentPoolsAPI            *fake.AKSAgentPoolsAPI
 	UsageAPI                    *fake.UsageAPI
+	SKUMixPlacementScoresAPI    *fake.SKUMixPlacementScoresAPI
 	DynamicInterface            dynamic.Interface
 
 	// Fake data stores for the APIs
@@ -154,6 +155,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 	nodeBootstrappingAPI := &fake.NodeBootstrappingAPI{}
 	subscriptionAPI := &fake.SubscriptionsAPI{}
 	usageAPI := &fake.UsageAPI{}
+	skuMixPlacementScoresAPI := &fake.SKUMixPlacementScoresAPI{}
 
 	aksDataStorage := fake.NewAKSDataStorage()
 	aksAgentPoolsAPI := fake.NewAKSAgentPoolsAPI(aksDataStorage)
@@ -235,6 +237,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		skusAPI,
 		subscriptionAPI,
 		usageAPI,
+		skuMixPlacementScoresAPI,
 	)
 	allocationStrategyProvider := allocationstrategy.NewProvider()
 	vmInstanceProvider := instance.NewDefaultVMProvider(
@@ -322,6 +325,7 @@ func NewRegionalEnvironment(ctx context.Context, env *coretest.Environment, regi
 		AKSMachinesAPI:              aksMachinesAPI,
 		AKSAgentPoolsAPI:            aksAgentPoolsAPI,
 		UsageAPI:                    usageAPI,
+		SKUMixPlacementScoresAPI:    skuMixPlacementScoresAPI,
 		DynamicInterface:            dynamic.NewForConfigOrDie(env.Config),
 
 		AKSDataStorage: aksDataStorage,

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -54,6 +54,7 @@ type OptionsFields struct {
 	ProviderBatchIdleDuration      *time.Duration
 	ProviderBatchMaxDuration       *time.Duration
 	ProviderBatchMaxSize           *int
+	ComputeRecommendationMode      *string
 
 	// SIG Flags not required by the self hosted offering
 	UseSIG                  *bool
@@ -99,5 +100,6 @@ func Options(overrides ...OptionsFields) *azoptions.Options {
 		ProviderBatchIdleDuration:      lo.FromPtrOr(options.ProviderBatchIdleDuration, time.Second),
 		ProviderBatchMaxDuration:       lo.FromPtrOr(options.ProviderBatchMaxDuration, 5*time.Second),
 		ProviderBatchMaxSize:           lo.FromPtrOr(options.ProviderBatchMaxSize, 50),
+		ComputeRecommendationMode:      lo.FromPtrOr(options.ComputeRecommendationMode, "disabled"),
 	}
 }


### PR DESCRIPTION
Note: The options currently default to disabled and no other option is allowed. A future PR will add support for the other options.

**Description**

**How was this change tested?**

* Unit tests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
