### PR TITLE
feat: Use bounded context for all polling Azure operations

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -74,6 +74,8 @@ const (
 	InstanceTypeResolutionFailedReason = "InstanceTypeResolutionFailed"
 	CreateInstanceFailedReason         = "CreateInstanceFailed"
 	SpotConditionPreemptionScheduled   = "PreemptionScheduled"
+	// Match Karpenter's maximum NodeClaim registration duration.
+	instancePromiseTimeout = 15 * time.Minute
 )
 
 var _ cloudprovider.CloudProvider = (*CloudProvider)(nil)
@@ -255,7 +257,7 @@ func (c *CloudProvider) handleInstancePromise(ctx context.Context, instancePromi
 		// so we delete them synchronously. After marking Launched=true,
 		// their status can't be reverted to false once the delete completes due to how core caches nodeclaims in
 		// the launch controller. This ensures we retry continuously until we hit the registration TTL
-		err := instancePromise.Wait()
+		err := waitForInstancePromise(ctx, instancePromise)
 		if err != nil {
 			c.handleInstancePromiseWaitError(ctx, instancePromise, nodeClaim, err)
 			return toCreateError(err, "creating standalone instance failed")
@@ -280,7 +282,7 @@ func (c *CloudProvider) handleInstancePromise(ctx context.Context, instancePromi
 			}
 		}()
 
-		err := instancePromise.Wait()
+		err := waitForInstancePromise(ctx, instancePromise)
 
 		// Wait until the claim is Launched, to avoid racing with creation.
 		// This isn't strictly required, but without this, failure test scenarios are harder
@@ -313,6 +315,12 @@ func (c *CloudProvider) handleInstancePromise(ctx context.Context, instancePromi
 		}
 	}()
 	return nil
+}
+
+func waitForInstancePromise(ctx context.Context, promise instance.Promise) error {
+	waitCtx, cancel := context.WithTimeout(ctx, instancePromiseTimeout)
+	defer cancel()
+	return promise.Wait(waitCtx)
 }
 
 func (c *CloudProvider) handleInstancePromiseWaitError(ctx context.Context, instancePromise instance.Promise, nodeClaim *karpv1.NodeClaim, waitErr error) {

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -30,6 +30,38 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type testInstancePromise struct {
+	waitFunc func(context.Context) error
+}
+
+func (p *testInstancePromise) Cleanup(context.Context) error {
+	return nil
+}
+
+func (p *testInstancePromise) Wait(ctx context.Context) error {
+	return p.waitFunc(ctx)
+}
+
+func (p *testInstancePromise) GetInstanceName() string {
+	return "test-instance"
+}
+
+func TestWaitForInstancePromiseAddsDeadline(t *testing.T) {
+	g := NewWithT(t)
+	start := time.Now()
+	promise := &testInstancePromise{
+		waitFunc: func(ctx context.Context) error {
+			deadline, ok := ctx.Deadline()
+			g.Expect(ok).To(BeTrue())
+			g.Expect(deadline).To(BeTemporally(">=", start.Add(instancePromiseTimeout-time.Second)))
+			g.Expect(deadline).To(BeTemporally("<=", start.Add(instancePromiseTimeout+time.Second)))
+			return nil
+		},
+	}
+
+	g.Expect(waitForInstancePromise(context.Background(), promise)).To(Succeed())
+}
+
 func TestGenerateNodeClaimName(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -59,7 +59,7 @@ func TestWaitForInstancePromiseAddsDeadline(t *testing.T) {
 		},
 	}
 
-	g.Expect(waitForInstancePromise(context.Background(), promise)).To(Succeed())
+	g.Expect(waitForInstancePromise(t.Context(), promise)).To(Succeed())
 }
 
 func TestGenerateNodeClaimName(t *testing.T) {

--- a/pkg/providers/instance/aksmachineinstance.go
+++ b/pkg/providers/instance/aksmachineinstance.go
@@ -54,7 +54,7 @@ import (
 // the promise fields and functions like BuildNodeClaimFromAKSMachineTemplate, as well as reduce the number of loose arguments passed around.
 // More discussion: https://github.com/Azure/karpenter-provider-azure/pull/1197#discussion_r2482957255
 type AKSMachinePromise struct {
-	waitFunc    func() error
+	waitFunc    func(context.Context) error
 	providerRef AKSMachineProvider
 
 	AKSMachineTemplate *armcontainerservice.Machine
@@ -72,7 +72,7 @@ type AKSMachinePromise struct {
 func NewAKSMachinePromise(
 	providerRef AKSMachineProvider,
 	aksMachineTemplate *armcontainerservice.Machine,
-	waitFunc func() error,
+	waitFunc func(context.Context) error,
 	aksMachineName string,
 	instanceType *corecloudprovider.InstanceType,
 	capacityType string,
@@ -101,8 +101,8 @@ func (p *AKSMachinePromise) Cleanup(ctx context.Context) error {
 	return p.providerRef.Delete(ctx, p.AKSMachineName)
 }
 
-func (p *AKSMachinePromise) Wait() error {
-	return p.waitFunc()
+func (p *AKSMachinePromise) Wait(ctx context.Context) error {
+	return p.waitFunc(ctx)
 }
 func (p *AKSMachinePromise) GetInstanceName() string {
 	return p.AKSMachineName
@@ -490,7 +490,7 @@ func (p *DefaultAKSMachineProvider) beginCreateMachineBatch(
 	return NewAKSMachinePromise(
 		p,
 		aksMachineTemplate,
-		func() (pollingErr error) {
+		func(waitCtx context.Context) (pollingErr error) {
 			defer func() {
 				if r := recover(); r != nil {
 					err := fmt.Errorf("%v", r)
@@ -498,16 +498,16 @@ func (p *DefaultAKSMachineProvider) beginCreateMachineBatch(
 				}
 			}()
 
-			provisioningErr, pollerErr := p.machineCache.PollUntilDone(ctx, aksMachineName)
+			provisioningErr, pollerErr := p.machineCache.PollUntilDone(waitCtx, aksMachineName)
 			if pollerErr != nil {
 				pollingErr = fmt.Errorf("failed to create AKS machine %q during LRO (GET poller), poller error: %w", aksMachineName, pollerErr)
 				return
 			}
 			if provisioningErr != nil {
-				pollingErr = p.handleMachineProvisioningError(ctx, "LRO (GET poller)", aksMachineName, instanceType, zone, capacityType, provisioningErr)
+				pollingErr = p.handleMachineProvisioningError(waitCtx, "LRO (GET poller)", aksMachineName, instanceType, zone, capacityType, provisioningErr)
 				return
 			}
-			log.FromContext(ctx).V(1).Info("successfully created AKS machine",
+			log.FromContext(waitCtx).V(1).Info("successfully created AKS machine",
 				"aksMachineName", aksMachineName,
 				"aksMachineID", gotAKSMachine.ID)
 			return
@@ -553,7 +553,7 @@ func (p *DefaultAKSMachineProvider) beginCreateMachineNonBatch(
 	return NewAKSMachinePromise(
 		p,
 		aksMachineTemplate,
-		func() (pollingErr error) {
+		func(waitCtx context.Context) (pollingErr error) {
 			defer func() {
 				if r := recover(); r != nil {
 					err := fmt.Errorf("%v", r)
@@ -561,14 +561,14 @@ func (p *DefaultAKSMachineProvider) beginCreateMachineNonBatch(
 				}
 			}()
 			// Use SDK poller (non-batch case)
-			_, err := poller.PollUntilDone(ctx, defaultPollerOptions()) // This may panic if it is deleted mid-way.
+			_, err := poller.PollUntilDone(waitCtx, defaultPollerOptions()) // This may panic if it is deleted mid-way.
 			if err != nil {
 				// Could be quota error; will be handled with custom logic below
 
 				// Get once after begin create to retrieve error details. This is because if the poller returns error, the sdk doesn't let us look at the real results.
-				failedAKSMachine, _ := p.machineCache.GetWithFallback(ctx, aksMachineName, false)
-				if failedAKSMachine.Properties != nil && failedAKSMachine.Properties.Status != nil && failedAKSMachine.Properties.Status.ProvisioningError != nil {
-					pollingErr = p.handleMachineProvisioningError(ctx, "LRO", aksMachineName, instanceType, zone, capacityType, failedAKSMachine.Properties.Status.ProvisioningError)
+				failedAKSMachine, _ := p.machineCache.GetWithFallback(waitCtx, aksMachineName, false)
+				if failedAKSMachine != nil && failedAKSMachine.Properties != nil && failedAKSMachine.Properties.Status != nil && failedAKSMachine.Properties.Status.ProvisioningError != nil {
+					pollingErr = p.handleMachineProvisioningError(waitCtx, "LRO", aksMachineName, instanceType, zone, capacityType, failedAKSMachine.Properties.Status.ProvisioningError)
 					return
 				}
 				// This should not be expected.
@@ -576,7 +576,7 @@ func (p *DefaultAKSMachineProvider) beginCreateMachineNonBatch(
 				return
 			}
 
-			log.FromContext(ctx).V(1).Info("successfully created AKS machine",
+			log.FromContext(waitCtx).V(1).Info("successfully created AKS machine",
 				"aksMachineName", aksMachineName,
 				"aksMachineID", gotAKSMachine.ID)
 			return
@@ -688,7 +688,7 @@ func (p *DefaultAKSMachineProvider) reuseExistingMachine(ctx context.Context, ak
 	return NewAKSMachinePromise(
 		p,
 		existingAKSMachine,
-		func() error {
+		func(context.Context) error {
 			// We hope the AKS machine completed provisioning at this point. Otherwise, if fails, it would not be handled until registration TTL.
 			// Suggestion: create a new poller just to handle it the same way as new machines. That will improve performance for such cases.
 			return nil

--- a/pkg/providers/instance/instancepromise.go
+++ b/pkg/providers/instance/instancepromise.go
@@ -24,8 +24,8 @@ import (
 type Promise interface {
 	// Cleanup removes the instance from the cloud provider.
 	Cleanup(ctx context.Context) error
-	// Wait blocks until the instance is ready.
-	Wait() error
+	// Wait blocks until the instance is ready or the context ends.
+	Wait(ctx context.Context) error
 	// GetInstanceName returns the name of the instance. Recommended to be used for logging only due to generic nature.
 	GetInstanceName() string
 }

--- a/pkg/providers/instance/vminstance.go
+++ b/pkg/providers/instance/vminstance.go
@@ -129,7 +129,7 @@ type Resource = map[string]interface{}
 
 type VirtualMachinePromise struct {
 	VM       *armcompute.VirtualMachine
-	WaitFunc func() error
+	WaitFunc func(context.Context) error
 
 	providerRef VMProvider
 }
@@ -141,8 +141,8 @@ func (p *VirtualMachinePromise) Cleanup(ctx context.Context) error {
 	return p.providerRef.Delete(ctx, lo.FromPtr(p.VM.Name))
 }
 
-func (p *VirtualMachinePromise) Wait() error {
-	return p.WaitFunc()
+func (p *VirtualMachinePromise) Wait(ctx context.Context) error {
+	return p.WaitFunc(ctx)
 }
 func (p *VirtualMachinePromise) GetInstanceName() string {
 	return lo.FromPtr(p.VM.Name)
@@ -902,7 +902,7 @@ func (p *DefaultVMProvider) beginLaunchInstance(
 
 	return &VirtualMachinePromise{
 		providerRef: p,
-		WaitFunc: func() error {
+		WaitFunc: func(waitCtx context.Context) error {
 			if result.Poller == nil {
 				// Poller is nil means the VM existed already and we're done.
 				// TODO: if the VM doesn't have extensions this will still happen and we will have to
@@ -911,7 +911,7 @@ func (p *DefaultVMProvider) beginLaunchInstance(
 				return nil
 			}
 
-			_, err = result.Poller.PollUntilDone(ctx, defaultPollerOptions())
+			_, err = result.Poller.PollUntilDone(waitCtx, defaultPollerOptions())
 			if err != nil {
 				VMCreateFailureMetric.With(map[string]string{
 					metrics.ImageLabel:        launchTemplate.ImageID,
@@ -923,11 +923,11 @@ func (p *DefaultVMProvider) beginLaunchInstance(
 					metrics.ErrorCodeLabel:    ErrorCodeForMetrics(err),
 				}).Inc()
 
-				sku, skuErr := p.instanceTypeProvider.Get(ctx, instanceType.Name)
+				sku, skuErr := p.instanceTypeProvider.Get(waitCtx, instanceType.Name)
 				if skuErr != nil {
 					return fmt.Errorf("failed to get instance type %q: %w", instanceType.Name, err)
 				}
-				handledError := p.errorHandling.Handle(ctx, sku, instanceType, zone, capacityType, err)
+				handledError := p.errorHandling.Handle(waitCtx, sku, instanceType, zone, capacityType, err)
 				if handledError != nil {
 					// At this point, the error is handled in provider layer (e.g., unavailable offerings cache), but not yet Karpenter core.
 					// Thus the error needs to be returned.
@@ -938,14 +938,14 @@ func (p *DefaultVMProvider) beginLaunchInstance(
 			}
 
 			if p.provisionMode == consts.ProvisionModeBootstrappingClient {
-				err = p.createCSExtension(ctx, resourceName, launchTemplate.CustomScriptsCSE, launchTemplate.IsWindows, launchTemplate.Tags)
+				err = p.createCSExtension(waitCtx, resourceName, launchTemplate.CustomScriptsCSE, launchTemplate.IsWindows, launchTemplate.Tags)
 				if err != nil {
 					// An error here is handled by CloudProvider create and calls vmInstanceProvider.Delete (which cleans up the azure resources)
 					return err
 				}
 			}
 			if isAKSIdentifyingExtensionEnabled(p.env) {
-				err = p.createAKSIdentifyingExtension(ctx, resourceName, launchTemplate.Tags)
+				err = p.createAKSIdentifyingExtension(waitCtx, resourceName, launchTemplate.Tags)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION

Fixes #1860 

**Description**

As TheUnrepentantRobot discusses in #1860, any Azure long-running-operation (LRO) that stalls for a long time has a significant memory footprint. 

If we ended up in a retry loop starting many such operations, we could end up with many such operations cluttering the heap.

Even without a retry loop, any such stall that locks permanently results in a fixed increment of memory use, that over time may start to impact on operation of KPA.

This PR ensures that all operations have access to a context, and that they have an upper bound of 15 minutes before being cancelled.

**How was this change tested?**

Local run of `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note
NONE
```
