### PR TITLE
feat: limit core instancetypes count to 60

### DIFF
--- a/pkg/cloudprovider/suite_aksmachineapi_offerings_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_offerings_test.go
@@ -19,6 +19,7 @@ package cloudprovider
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/awslabs/operatorpkg/object"
 	corestatus "github.com/awslabs/operatorpkg/status"
@@ -33,10 +34,12 @@ import (
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
+	nodeclaimlifecycle "sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/lifecycle"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/state/nodepoolhealth"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 
@@ -965,5 +968,152 @@ var _ = Describe("CloudProvider", func() {
 			})
 		})
 
+	})
+
+	Context("ProvisionMode = AKSMachineAPIHeaderBatch with short accumulation windows", func() {
+		BeforeEach(func() {
+			testOptions = test.Options(test.OptionsFields{
+				ProvisionMode:             lo.ToPtr(consts.ProvisionModeAKSMachineAPIHeaderBatch),
+				UseSIG:                    lo.ToPtr(true),
+				ProviderBatchIdleDuration: lo.ToPtr(time.Millisecond),
+				ProviderBatchMaxDuration:  lo.ToPtr(time.Millisecond),
+			})
+
+			ctx = coreoptions.ToContext(ctx, coretest.Options())
+			ctx = options.ToContext(ctx, testOptions)
+
+			azureEnv = test.NewEnvironment(ctx, env)
+			test.ApplyDefaultStatus(nodeClass, env, testOptions.UseSIG)
+			cloudProvider = New(azureEnv.InstanceTypesProvider, azureEnv.VMInstanceProvider, azureEnv.AKSMachineProvider, recorder, env.Client, azureEnv.ImageProvider, azureEnv.InstanceTypeStore)
+			cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
+			coreProvisioner = provisioning.NewProvisioner(env.Client, recorder, cloudProvider, cluster, fakeClock, deviceallocation.NewController(env.Client))
+		})
+
+		AfterEach(func() {
+			cloudProvider.WaitForInstancePromises()
+			cluster.Reset()
+			azureEnv.Reset(ctx)
+		})
+
+		Context("NodeClaim instance type limits", func() {
+			It("should create a new NodeClaim with different instance types after exhausting the capped set", func() {
+				// Construct a synthetic set of SKUs as the default test instance type provider doesn't return enough SKUs for our purposes
+				baseSKU, found := lo.Find(fake.ResourceSkus[fake.Region], func(sku compute.ResourceSku) bool {
+					return lo.FromPtr(sku.Name) == "Standard_D2_v3"
+				})
+				Expect(found).To(BeTrue())
+				syntheticSKUNames := make([]string, 0, 2*consts.MaxInstanceTypes+1)
+				for i := range 2*consts.MaxInstanceTypes + 1 {
+					family := string(rune('A' + i/9))
+					version := i%9 + 1
+					syntheticSKU := baseSKU
+					syntheticSKU.Name = lo.ToPtr(fmt.Sprintf("Standard_X%s2s_v%d", family, version))
+					syntheticSKU.Size = lo.ToPtr(fmt.Sprintf("X%s2s_v%d", family, version))
+					syntheticSKU.Family = lo.ToPtr(fmt.Sprintf("standardX%ssv%dFamily", family, version))
+					azureEnv.SKUsAPI.AdditionalSKUs = append(azureEnv.SKUsAPI.AdditionalSKUs, syntheticSKU)
+					syntheticSKUNames = append(syntheticSKUNames, lo.FromPtr(syntheticSKU.Name))
+				}
+				Expect(azureEnv.InstanceTypesProvider.UpdateInstanceTypes(ctx)).To(Succeed())
+
+				coretest.ReplaceRequirements(nodePool,
+					karpv1.NodeSelectorRequirementWithMinValues{
+						Key:      v1.LabelInstanceTypeStable,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   syntheticSKUNames,
+					},
+					karpv1.NodeSelectorRequirementWithMinValues{
+						Key:      karpv1.CapacityTypeLabelKey,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{karpv1.CapacityTypeOnDemand},
+					},
+				)
+				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+
+				allInstanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(allInstanceTypes)).To(BeNumerically(">", 2*consts.MaxInstanceTypes))
+
+				pod := coretest.UnschedulablePod()
+				ExpectApplied(ctx, env.Client, pod)
+
+				results, err := coreProvisioner.Schedule(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(results.NewNodeClaims).To(HaveLen(1))
+				nodeClaims := ExpectScheduledNodeClaimsCreated(ctx, env.Client, coreProvisioner, results.NewNodeClaims...)
+				Expect(nodeClaims).To(HaveLen(1))
+				firstNodeClaim := nodeClaims[0]
+
+				instanceTypesFor := func(nodeClaim *karpv1.NodeClaim) sets.Set[string] {
+					requirement, found := lo.Find(nodeClaim.Spec.Requirements, func(requirement karpv1.NodeSelectorRequirementWithMinValues) bool {
+						return requirement.Key == v1.LabelInstanceTypeStable
+					})
+					Expect(found).To(BeTrue())
+					return sets.New(requirement.Values...)
+				}
+
+				firstInstanceTypes := instanceTypesFor(firstNodeClaim)
+				Expect(firstInstanceTypes.Len()).To(Equal(consts.MaxInstanceTypes))
+
+				batchAttempts := 0
+				azureEnv.AKSMachinesAPI.BatchMachineErrorFunc = func(string) (string, string) {
+					batchAttempts++
+					return "VMSizeNotSupported", "synthetic VM size is not supported for subscription"
+				}
+				lifecycleController := nodeclaimlifecycle.NewController(
+					fakeClock,
+					env.Client,
+					cloudProvider,
+					events.NewRecorder(&record.FakeRecorder{}),
+					nodepoolhealth.NewState(),
+					nil,
+				)
+
+				attemptedInstanceTypes := sets.New[string]()
+				for range consts.MaxInstanceTypes {
+					// Batch errors don't expose the per-machine template through CalledWithInput,
+					// so infer the attempted instance type from the offering removed by this retry.
+					remainingBefore, err := cloudProvider.resolveInstanceTypes(ctx, firstNodeClaim, nodeClass)
+					Expect(err).ToNot(HaveOccurred())
+					remainingBeforeNames := sets.New(lo.Map(remainingBefore, func(instanceType *corecloudprovider.InstanceType, _ int) string {
+						return instanceType.Name
+					})...)
+
+					err = ExpectObjectReconcileFailed(ctx, env.Client, lifecycleController, firstNodeClaim)
+					Expect(err).To(HaveOccurred())
+
+					remainingAfter, err := cloudProvider.resolveInstanceTypes(ctx, firstNodeClaim, nodeClass)
+					Expect(err).ToNot(HaveOccurred())
+					remainingAfterNames := sets.New(lo.Map(remainingAfter, func(instanceType *corecloudprovider.InstanceType, _ int) string {
+						return instanceType.Name
+					})...)
+					removedInstanceTypes := remainingBeforeNames.Difference(remainingAfterNames)
+					Expect(removedInstanceTypes).To(HaveLen(1))
+					attemptedInstanceType := removedInstanceTypes.UnsortedList()[0]
+					Expect(firstInstanceTypes.Has(attemptedInstanceType)).To(BeTrue())
+					Expect(attemptedInstanceTypes.Has(attemptedInstanceType)).To(BeFalse())
+					attemptedInstanceTypes.Insert(attemptedInstanceType)
+				}
+				Expect(attemptedInstanceTypes.Equal(firstInstanceTypes)).To(BeTrue())
+				Expect(batchAttempts).To(Equal(consts.MaxInstanceTypes))
+
+				// All candidates attached to the NodeClaim are now unavailable.
+				// ICE marks the NodeClaim for deletion without another Azure request.
+				ExpectObjectReconciled(ctx, env.Client, lifecycleController, firstNodeClaim)
+				Expect(batchAttempts).To(Equal(consts.MaxInstanceTypes))
+				// A second reconcile removes the termination finalizer.
+				ExpectObjectReconciled(ctx, env.Client, lifecycleController, firstNodeClaim)
+				ExpectNotFound(ctx, env.Client, firstNodeClaim)
+
+				results, err = coreProvisioner.Schedule(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(results.NewNodeClaims).To(HaveLen(1))
+				nodeClaims = ExpectScheduledNodeClaimsCreated(ctx, env.Client, coreProvisioner, results.NewNodeClaims...)
+				Expect(nodeClaims).To(HaveLen(1))
+				secondInstanceTypes := instanceTypesFor(nodeClaims[0])
+				// We should have another 60 instance types and they should be disjoint from the first 60.
+				Expect(secondInstanceTypes.Len()).To(Equal(consts.MaxInstanceTypes))
+				Expect(secondInstanceTypes.Intersection(firstInstanceTypes)).To(BeEmpty())
+			})
+		})
 	})
 })

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -40,6 +40,7 @@ const (
 	DefaultOverlayMaxPods       = 250
 	DefaultNodeSubnetMaxPods    = 30
 	DefaultKubernetesMaxPods    = 110
+	MaxInstanceTypes            = 60
 
 	ProvisionModeAKSScriptless            = "aksscriptless"
 	ProvisionModeBootstrappingClient      = "bootstrappingclient"

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	karpapis "sigs.k8s.io/karpenter/pkg/apis"
+	corescheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 
 	"sigs.k8s.io/karpenter/pkg/operator"
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
@@ -75,6 +76,7 @@ import (
 
 func init() {
 	zones.RegisterCSIZoneNormalization()
+	corescheduling.MaxInstanceTypes = consts.MaxInstanceTypes
 }
 
 type Operator struct {

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -33,20 +33,25 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
+	nodeclaimlifecycle "sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/lifecycle"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/state/nodepoolhealth"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	"sigs.k8s.io/karpenter/pkg/test/v1alpha1"
 	. "sigs.k8s.io/karpenter/pkg/utils/testing"
 
+	sdkerrors "github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
@@ -1329,6 +1334,120 @@ var _ = Describe("VMInstanceProvider", func() {
 			secondPools := secondNIC.Interface.Properties.IPConfigurations[0].Properties.LoadBalancerBackendAddressPools
 			secondPoolIDs := lo.Map(secondPools, func(p *armnetwork.BackendAddressPool, _ int) string { return lo.FromPtr(p.ID) })
 			Expect(secondPoolIDs).ToNot(ContainElement(deletedPoolID))
+		})
+	})
+
+	Context("NodeClaim instance type limits", func() {
+		It("should create a new NodeClaim with different instance types after exhausting the capped set", func() {
+			// Construct a synthetic set of SKUs as the default test instance type provider doesn't return enough SKUs for our purposes
+			baseSKU, found := lo.Find(fake.ResourceSkus[fake.Region], func(sku compute.ResourceSku) bool {
+				return lo.FromPtr(sku.Name) == "Standard_D2_v3"
+			})
+			Expect(found).To(BeTrue())
+			syntheticSKUNames := make([]string, 0, 2*consts.MaxInstanceTypes+1)
+			for i := range 2*consts.MaxInstanceTypes + 1 {
+				family := string(rune('A' + i/9))
+				version := i%9 + 1
+				syntheticSKU := baseSKU
+				syntheticSKU.Name = lo.ToPtr(fmt.Sprintf("Standard_X%s2s_v%d", family, version))
+				syntheticSKU.Size = lo.ToPtr(fmt.Sprintf("X%s2s_v%d", family, version))
+				syntheticSKU.Family = lo.ToPtr(fmt.Sprintf("standardX%ssv%dFamily", family, version))
+				azureEnv.SKUsAPI.AdditionalSKUs = append(azureEnv.SKUsAPI.AdditionalSKUs, syntheticSKU)
+				syntheticSKUNames = append(syntheticSKUNames, lo.FromPtr(syntheticSKU.Name))
+			}
+			Expect(azureEnv.InstanceTypesProvider.UpdateInstanceTypes(ctx)).To(Succeed())
+
+			coretest.ReplaceRequirements(nodePool,
+				karpv1.NodeSelectorRequirementWithMinValues{
+					Key:      v1.LabelInstanceTypeStable,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   syntheticSKUNames,
+				},
+				karpv1.NodeSelectorRequirementWithMinValues{
+					Key:      karpv1.CapacityTypeLabelKey,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{karpv1.CapacityTypeOnDemand},
+				},
+			)
+			ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+
+			allInstanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(allInstanceTypes)).To(BeNumerically(">", 2*consts.MaxInstanceTypes))
+
+			pod := coretest.UnschedulablePod()
+			ExpectApplied(ctx, env.Client, pod)
+
+			results, err := coreProvisioner.Schedule(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results.NewNodeClaims).To(HaveLen(1))
+			nodeClaims := ExpectScheduledNodeClaimsCreated(ctx, env.Client, coreProvisioner, results.NewNodeClaims...)
+			Expect(nodeClaims).To(HaveLen(1))
+			firstNodeClaim := nodeClaims[0]
+
+			instanceTypesFor := func(nodeClaim *karpv1.NodeClaim) sets.Set[string] {
+				requirement, found := lo.Find(nodeClaim.Spec.Requirements, func(requirement karpv1.NodeSelectorRequirementWithMinValues) bool {
+					return requirement.Key == v1.LabelInstanceTypeStable
+				})
+				Expect(found).To(BeTrue())
+				return sets.New(requirement.Values...)
+			}
+
+			firstInstanceTypes := instanceTypesFor(firstNodeClaim)
+			Expect(firstInstanceTypes.Len()).To(Equal(consts.MaxInstanceTypes))
+
+			azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.BeginError.Set(
+				&azcore.ResponseError{
+					ErrorCode: sdkerrors.OperationNotAllowed,
+					RawResponse: &http.Response{
+						Body: fake.CreateSDKErrorBody(
+							sdkerrors.OperationNotAllowed,
+							"Operation could not be completed as it results in exceeding approved Synthetic Family Cores quota. Additional details - Current Limit: 0, Current Usage: 0, Additional Required: 2.",
+						),
+					},
+				},
+				fake.MaxCalls(0), // Fails forever
+			)
+			fakeClock.SetTime(time.Now())
+			lifecycleController := nodeclaimlifecycle.NewController(
+				fakeClock,
+				env.Client,
+				cloudProvider,
+				events.NewRecorder(&record.FakeRecorder{}),
+				nodepoolhealth.NewState(),
+				nil,
+			)
+
+			attemptedInstanceTypes := sets.New[string]()
+			for range consts.MaxInstanceTypes {
+				err := ExpectObjectReconcileFailed(ctx, env.Client, lifecycleController, firstNodeClaim)
+				Expect(err).To(HaveOccurred())
+				createInput := azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Pop()
+				attemptedInstanceType := string(lo.FromPtr(createInput.VM.Properties.HardwareProfile.VMSize))
+				Expect(firstInstanceTypes.Has(attemptedInstanceType)).To(BeTrue())
+				Expect(attemptedInstanceTypes.Has(attemptedInstanceType)).To(BeFalse())
+				attemptedInstanceTypes.Insert(attemptedInstanceType)
+			}
+			Expect(attemptedInstanceTypes.Equal(firstInstanceTypes)).To(BeTrue())
+
+			// All candidates attached to the NodeClaim are now unavailable.
+			// ICE marks the NodeClaim for deletion without another Azure request.
+			Expect(azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(BeZero())
+			ExpectObjectReconciled(ctx, env.Client, lifecycleController, firstNodeClaim)
+			// A second reconcile removes the termination finalizer.
+			Expect(azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Len()).To(BeZero())
+			ExpectObjectReconciled(ctx, env.Client, lifecycleController, firstNodeClaim)
+			ExpectNotFound(ctx, env.Client, firstNodeClaim)
+
+			results, err = coreProvisioner.Schedule(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results.NewNodeClaims).To(HaveLen(1))
+			nodeClaims = ExpectScheduledNodeClaimsCreated(ctx, env.Client, coreProvisioner, results.NewNodeClaims...)
+			Expect(nodeClaims).To(HaveLen(1))
+			secondInstanceTypes := instanceTypesFor(nodeClaims[0])
+			// We should have another 60 instance types and they should be disjoint from the first 60.
+			Expect(secondInstanceTypes.Len()).To(Equal(consts.MaxInstanceTypes))
+			Expect(secondInstanceTypes.Intersection(firstInstanceTypes)).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -27,6 +27,7 @@ import (
 	"github.com/patrickmn/go-cache"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	corescheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
@@ -54,6 +55,7 @@ import (
 
 func init() {
 	zones.RegisterCSIZoneNormalization()
+	corescheduling.MaxInstanceTypes = consts.MaxInstanceTypes
 
 	// Configuring this here because it's commonly imported and has an init already
 	gomegaformat.CharactersAroundMismatchToInclude = 40

--- a/test/pkg/environment/azure/environment.go
+++ b/test/pkg/environment/azure/environment.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	corescheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	coretest "sigs.k8s.io/karpenter/pkg/test"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -51,6 +52,7 @@ import (
 
 func init() {
 	zones.RegisterCSIZoneNormalization()
+	corescheduling.MaxInstanceTypes = consts.MaxInstanceTypes
 	coretest.DefaultImage = "mcr.microsoft.com/oss/kubernetes/pause:3.6"
 }
 


### PR DESCRIPTION
* Reduces load on kube-apiserver as well as internal Karpenter CPI load processing a large number of instance types which we will in all likelihood never use. Instead just use the cheapest 60 that meet the requirements.
* Added tests that ensure provisioning logic works as expected when claim has only 60 instance types set.

**How was this change tested?**

* Unit tests (see two newly added unit tests)
* E2E tests (regression mainly): <TODO link>
* Manually

**Two concerns**

1. Core clearly exposed this value primarily to be set for tests, not actually overridden in production.
2. Limiting to 60 instance types could possibly cause some things which were satisfying `minValues` before to fail to satisfy `minValues` - for example if users ask for 10 different families but after limiting to 60 we only have 8 families, so there is some small risk in making this change that we break some scheduling behavior.

By limiting the number of instances we consider, we could technically start to violate `MiNValues`

I manually created a NodeClaim both before/after this change.

Prior to this being set, a basic NodeClaim from our default pool was:
```
    Key:       node.kubernetes.io/instance-type
    Operator:  In
    Values:
      Standard_D13
      Standard_D13_v2
      Standard_D14
      Standard_D14_v2
      Standard_D15_v2
      Standard_D16_v3
      Standard_D16_v4
      Standard_D16_v5
      Standard_D16a_v4
      Standard_D16ads_v5
      Standard_D16ads_v6
      Standard_D16ads_v7
      Standard_D16alds_v6
      Standard_D16alds_v7
      Standard_D16als_v6
      Standard_D16als_v7
      Standard_D16as_v4
      Standard_D16as_v5
      Standard_D16as_v6
      Standard_D16as_v7
      Standard_D16d_v4
      Standard_D16d_v5
      Standard_D16ds_v4
      Standard_D16ds_v5
      Standard_D16ds_v7
      Standard_D16lds_v5
      Standard_D16lds_v6
      Standard_D16lds_v7
      Standard_D16ls_v5
      Standard_D16ls_v6
      Standard_D16ls_v7
      Standard_D16s_v4
      Standard_D16s_v5
      Standard_D16s_v6
      Standard_D16s_v7
      Standard_D32_v3
      Standard_D32_v4
      Standard_D32_v5
      Standard_D32a_v4
      Standard_D32ads_v5
      Standard_D32ads_v6
      Standard_D32ads_v7
      Standard_D32alds_v6
      Standard_D32alds_v7
      Standard_D32als_v6
      Standard_D32als_v7
      Standard_D32as_v4
      Standard_D32as_v5
      Standard_D32as_v6
      Standard_D32as_v7
      Standard_D32d_v4
      Standard_D32d_v5
      Standard_D32ds_v4
      Standard_D32ds_v5
      Standard_D32ds_v7
      Standard_D32lds_v5
      Standard_D32lds_v6
      Standard_D32lds_v7
      Standard_D32ls_v5
      Standard_D32ls_v6
      Standard_D32ls_v7
      Standard_D32s_v4
      Standard_D32s_v5
      Standard_D32s_v6
      Standard_D32s_v7
      Standard_D4
      Standard_D48_v3
      Standard_D48_v4
      Standard_D48_v5
      Standard_D48a_v4
      Standard_D48ads_v5
      Standard_D48ads_v6
      Standard_D48ads_v7
      Standard_D48alds_v6
      Standard_D48alds_v7
      Standard_D48als_v6
      Standard_D48als_v7
      Standard_D48as_v4
      Standard_D48as_v5
      Standard_D48as_v6
      Standard_D48as_v7
      Standard_D48d_v4
      Standard_D48d_v5
      Standard_D48ds_v4
      Standard_D48ds_v5
      Standard_D48ds_v7
      Standard_D48lds_v5
      Standard_D48lds_v6
      Standard_D48lds_v7
      Standard_D48ls_v5
      Standard_D48ls_v6
      Standard_D48ls_v7
      Standard_D48s_v4
      Standard_D48s_v5
      Standard_D48s_v6
      Standard_D48s_v7
      Standard_D4_v2
      Standard_D5_v2
      Standard_D64_v3
      Standard_D64_v4
      Standard_D64_v5
      Standard_D64a_v4
      Standard_D64ads_v5
      Standard_D64ads_v6
      Standard_D64ads_v7
      Standard_D64alds_v6
      Standard_D64alds_v7
      Standard_D64als_v6
      Standard_D64als_v7
      Standard_D64as_v5
      Standard_D64as_v6
      Standard_D64as_v7
      Standard_D64d_v4
      Standard_D64d_v5
      Standard_D64ds_v4
      Standard_D64ds_v7
      Standard_D64lds_v5
      Standard_D64lds_v6
      Standard_D64lds_v7
      Standard_D64ls_v5
      Standard_D64ls_v6
      Standard_D64ls_v7
      Standard_D64s_v4
      Standard_D64s_v5
      Standard_D64s_v6
      Standard_D64s_v7
      Standard_D8_v3
      Standard_D8_v4
      Standard_D8_v5
      Standard_D8a_v4
      Standard_D8ads_v5
      Standard_D8ads_v6
      Standard_D8ads_v7
      Standard_D8alds_v6
      Standard_D8alds_v7
      Standard_D8als_v6
      Standard_D8als_v7
      Standard_D8as_v4
      Standard_D8as_v5
      Standard_D8as_v6
      Standard_D8as_v7
      Standard_D8d_v4
      Standard_D8d_v5
      Standard_D8ds_v4
      Standard_D8ds_v5
      Standard_D8ds_v7
      Standard_D8lds_v5
      Standard_D8lds_v6
      Standard_D8lds_v7
      Standard_D8ls_v5
      Standard_D8ls_v6
      Standard_D8ls_v7
      Standard_D8s_v4
      Standard_D8s_v5
      Standard_D8s_v6
      Standard_D8s_v7
      Standard_D96ads_v6
      Standard_D96ads_v7
      Standard_D96alds_v6
      Standard_D96alds_v7
      Standard_D96als_v6
      Standard_D96als_v7
      Standard_D96as_v5
      Standard_D96as_v6
      Standard_D96as_v7
      Standard_D96ds_v7
      Standard_D96lds_v6
      Standard_D96lds_v7
      Standard_D96ls_v5
      Standard_D96ls_v6
      Standard_D96ls_v7
      Standard_D96s_v5
      Standard_D96s_v6
      Standard_D96s_v7
      Standard_DS13
      Standard_DS13_v2
      Standard_DS14
      Standard_DS14_v2
      Standard_DS15_v2
      Standard_DS4
      Standard_DS4_v2
      Standard_DS5_v2
```

(roughly 180 values). Note that the values are alphabetical here but in (using set `in` operator) but are processed in price order. This means in practice considering something like `Standard_D96s_v5` is a bit farfetched even if it's _technically_ possible.

After setting `corescheduling.MaxInstanceTypes = 60` we get
```
    Key:       node.kubernetes.io/instance-type
    Operator:  In
    Values:
      Standard_D13_v2
      Standard_D16_v3
      Standard_D16_v4
      Standard_D16_v5
      Standard_D16a_v4
      Standard_D16ads_v5
      Standard_D16ads_v6
      Standard_D16ads_v7
      Standard_D16alds_v6
      Standard_D16alds_v7
      Standard_D16als_v6
      Standard_D16als_v7
      Standard_D16as_v4
      Standard_D16as_v5
      Standard_D16as_v6
      Standard_D16as_v7
      Standard_D16d_v4
      Standard_D16d_v5
      Standard_D16ds_v4
      Standard_D16ds_v5
      Standard_D16lds_v5
      Standard_D16lds_v6
      Standard_D16ls_v5
      Standard_D16ls_v6
      Standard_D16s_v4
      Standard_D16s_v5
      Standard_D16s_v6
      Standard_D4_v2
      Standard_D8_v3
      Standard_D8_v4
      Standard_D8_v5
      Standard_D8a_v4
      Standard_D8ads_v5
      Standard_D8ads_v6
      Standard_D8ads_v7
      Standard_D8alds_v6
      Standard_D8alds_v7
      Standard_D8als_v6
      Standard_D8als_v7
      Standard_D8as_v4
      Standard_D8as_v5
      Standard_D8as_v6
      Standard_D8as_v7
      Standard_D8d_v4
      Standard_D8d_v5
      Standard_D8ds_v4
      Standard_D8ds_v5
      Standard_D8ds_v7
      Standard_D8lds_v5
      Standard_D8lds_v6
      Standard_D8lds_v7
      Standard_D8ls_v5
      Standard_D8ls_v6
      Standard_D8ls_v7
      Standard_D8s_v4
      Standard_D8s_v5
      Standard_D8s_v6
      Standard_D8s_v7
      Standard_DS13_v2
      Standard_DS4_v2
```


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
