### PR TITLE
feat: support per-nodeclass pod subnet

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.azure.com_aksnodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.azure.com_aksnodeclasses.yaml
@@ -1668,6 +1668,14 @@ spec:
                 maximum: 2048
                 minimum: 30
                 type: integer
+              podSubnetID:
+                description: |-
+                  podSubnetID is the subnet pods on nodes provisioned with this nodeclass get their IPs from,
+                  overriding the cluster-level --pod-subnet-id, for clusters using Azure CNI with pod subnet.
+                  Must be in the same virtual network as the node subnet, and requires --pod-subnet-id to be set.
+                  If not specified, the cluster-level --pod-subnet-id is used.
+                pattern: (?i)^\/subscriptions\/[^\/]+\/resourceGroups\/[a-zA-Z0-9_\-().]{0,89}[a-zA-Z0-9_\-()]\/providers\/Microsoft\.Network\/virtualNetworks\/[^\/]+\/subnets\/[^\/]+$
+                type: string
               security:
                 description: security is a collection of security related karpenter
                   fields

--- a/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
@@ -1668,6 +1668,14 @@ spec:
                 maximum: 2048
                 minimum: 30
                 type: integer
+              podSubnetID:
+                description: |-
+                  podSubnetID is the subnet pods on nodes provisioned with this nodeclass get their IPs from,
+                  overriding the cluster-level --pod-subnet-id, for clusters using Azure CNI with pod subnet.
+                  Must be in the same virtual network as the node subnet, and requires --pod-subnet-id to be set.
+                  If not specified, the cluster-level --pod-subnet-id is used.
+                pattern: (?i)^\/subscriptions\/[^\/]+\/resourceGroups\/[a-zA-Z0-9_\-().]{0,89}[a-zA-Z0-9_\-()]\/providers\/Microsoft\.Network\/virtualNetworks\/[^\/]+\/subnets\/[^\/]+$
+                type: string
               security:
                 description: security is a collection of security related karpenter
                   fields

--- a/pkg/apis/v1beta1/aksnodeclass.go
+++ b/pkg/apis/v1beta1/aksnodeclass.go
@@ -70,6 +70,13 @@ type AKSNodeClassSpec struct {
 	// +kubebuilder:validation:Pattern=`(?i)^\/subscriptions\/[^\/]+\/resourceGroups\/[a-zA-Z0-9_\-().]{0,89}[a-zA-Z0-9_\-()]\/providers\/Microsoft\.Network\/virtualNetworks\/[^\/]+\/subnets\/[^\/]+$`
 	// +optional
 	VNETSubnetID *string `json:"vnetSubnetID,omitempty"`
+	// podSubnetID is the subnet pods on nodes provisioned with this nodeclass get their IPs from,
+	// overriding the cluster-level --pod-subnet-id, for clusters using Azure CNI with pod subnet.
+	// Must be in the same virtual network as the node subnet, and requires --pod-subnet-id to be set.
+	// If not specified, the cluster-level --pod-subnet-id is used.
+	// +kubebuilder:validation:Pattern=`(?i)^\/subscriptions\/[^\/]+\/resourceGroups\/[a-zA-Z0-9_\-().]{0,89}[a-zA-Z0-9_\-()]\/providers\/Microsoft\.Network\/virtualNetworks\/[^\/]+\/subnets\/[^\/]+$`
+	// +optional
+	PodSubnetID *string `json:"podSubnetID,omitempty"`
 	// osDiskSizeGB is the size of the OS disk in GB.
 	// +default=128
 	// +kubebuilder:validation:Minimum=30
@@ -723,6 +730,14 @@ type AKSNodeClassList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []AKSNodeClass `json:"items"`
+}
+
+// GetPodSubnetID returns the pod subnet for this node class, falling back to the cluster default.
+func (in *AKSNodeClass) GetPodSubnetID(defaultPodSubnetID string) string {
+	if in.Spec.PodSubnetID != nil {
+		return *in.Spec.PodSubnetID
+	}
+	return defaultPodSubnetID
 }
 
 // GetEncryptionAtHost returns whether encryption at host is enabled for the node class.

--- a/pkg/apis/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1beta1/zz_generated.deepcopy.go
@@ -93,6 +93,11 @@ func (in *AKSNodeClassSpec) DeepCopyInto(out *AKSNodeClassSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.PodSubnetID != nil {
+		in, out := &in.PodSubnetID, &out.PodSubnetID
+		*out = new(string)
+		**out = **in
+	}
 	if in.OSDiskSizeGB != nil {
 		in, out := &in.OSDiskSizeGB, &out.OSDiskSizeGB
 		*out = new(int32)

--- a/pkg/controllers/nodeclass/status/subnet.go
+++ b/pkg/controllers/nodeclass/status/subnet.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -28,6 +29,7 @@ import (
 
 	sdkerrors "github.com/Azure/azure-sdk-for-go-extensions/pkg/errors"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/providers/azclient/azapi"
 	"github.com/Azure/karpenter-provider-azure/pkg/utils"
@@ -58,8 +60,90 @@ const (
 )
 
 func (r *SubnetReconciler) Reconcile(ctx context.Context, nodeClass *v1beta1.AKSNodeClass) (reconcile.Result, error) {
-	// TODO: Handle podSubnetID readiness here as well
+	if result, err := r.validatePodSubnetID(ctx, nodeClass); err != nil || !nodeClass.StatusConditions().Get(v1beta1.ConditionTypeSubnetsReady).IsTrue() {
+		return result, err
+	}
 	return r.validateVNETSubnetID(ctx, nodeClass)
+}
+
+// validatePodSubnetID checks a nodeclass-level pod subnet against the same rules the cluster-wide
+// --pod-subnet-id option is validated against at startup
+func (r *SubnetReconciler) validatePodSubnetID(ctx context.Context, nodeClass *v1beta1.AKSNodeClass) (reconcile.Result, error) {
+	if nodeClass.Spec.PodSubnetID == nil {
+		nodeClass.StatusConditions().SetTrue(v1beta1.ConditionTypeSubnetsReady)
+		return reconcile.Result{}, nil
+	}
+	opts := options.FromContext(ctx)
+	podSubnetID := lo.FromPtr(nodeClass.Spec.PodSubnetID)
+	logger := log.FromContext(ctx).WithName(subnetReconcilerName).WithValues("podSubnetID", podSubnetID)
+
+	podSubnetComponents, err := utils.GetVnetSubnetIDComponents(podSubnetID)
+	if err != nil {
+		logger.Error(err, "failed to parse podSubnetID")
+		nodeClass.StatusConditions().SetFalse(
+			v1beta1.ConditionTypeSubnetsReady,
+			SubnetUnreadyReasonIDInvalid,
+			fmt.Sprintf("Failed to parse podSubnetID %s", podSubnetID),
+		)
+		return reconcile.Result{}, nil
+	}
+	if msg := podSubnetConfigError(opts, nodeClass, podSubnetID, podSubnetComponents); msg != "" {
+		nodeClass.StatusConditions().SetFalse(v1beta1.ConditionTypeSubnetsReady, SubnetUnreadyReasonIDInvalid, msg)
+		return reconcile.Result{}, nil
+	}
+
+	_, err = r.subnetClient.Get(ctx, podSubnetComponents.ResourceGroupName, podSubnetComponents.VNetName, podSubnetComponents.SubnetName, nil)
+	if err != nil {
+		azErr := sdkerrors.IsResponseError(err)
+		if azErr != nil && (azErr.StatusCode == http.StatusNotFound) {
+			nodeClass.StatusConditions().SetFalse(
+				v1beta1.ConditionTypeSubnetsReady,
+				SubnetUnreadyReasonNotFound,
+				fmt.Sprintf("resource not found: %s", podSubnetID),
+			)
+			return reconcile.Result{RequeueAfter: time.Minute}, err
+		}
+		nodeClass.StatusConditions().SetFalse(
+			v1beta1.ConditionTypeSubnetsReady,
+			SubnetUnreadyReasonUnknownError,
+			fmt.Sprintf("unknown error getting pod subnet: %s", err.Error()),
+		)
+		logger.Error(err, "getting pod subnet failed during reconciliation with unknown error")
+		return reconcile.Result{}, err
+	}
+
+	nodeClass.StatusConditions().SetTrue(v1beta1.ConditionTypeSubnetsReady)
+	return reconcile.Result{}, nil
+}
+
+// podSubnetConfigError returns why a nodeclass pod subnet cannot be used with the current cluster
+// configuration, or an empty string when it is valid
+func podSubnetConfigError(opts *options.Options, nodeClass *v1beta1.AKSNodeClass, podSubnetID string, podSubnet utils.VnetSubnetResource) string {
+	// The cluster-level pod subnet drives startup wiring like the VNet GUID the pod network labels
+	// carry, so a nodeclass may only override it, not turn pod subnet on by itself
+	if opts.PodSubnetID == "" {
+		return "podSubnetID requires the cluster-level --pod-subnet-id to be set"
+	}
+	if opts.NetworkPluginMode == consts.NetworkPluginModeOverlay || opts.NetworkPlugin != consts.NetworkPluginAzure {
+		return "podSubnetID is only supported with Azure CNI without overlay"
+	}
+	// AKS machine nodes do not carry the bootstrap pod network labels, and the AKS API rejects PodSubnetID
+	if opts.IsAKSMachineAPIMode() {
+		return fmt.Sprintf("podSubnetID is not supported with provision-mode %s", opts.ProvisionMode)
+	}
+	// Skip the cross-check when the node subnet does not parse; validateVNETSubnetID reports that
+	nodeSubnetID := lo.Ternary(nodeClass.Spec.VNETSubnetID != nil, lo.FromPtr(nodeClass.Spec.VNETSubnetID), opts.SubnetID)
+	nodeSubnet, err := utils.GetVnetSubnetIDComponents(nodeSubnetID)
+	if err != nil {
+		return ""
+	}
+	if !nodeSubnet.IsSameVNETFold(podSubnet) {
+		return fmt.Sprintf("podSubnetID must be in the same virtual network as the node subnet: %s", podSubnetID)
+	}
+	if strings.EqualFold(podSubnetID, nodeSubnetID) {
+		return "podSubnetID must be different from the node subnet"
+	}
+	return ""
 }
 
 func (r *SubnetReconciler) validateVNETSubnetID(ctx context.Context, nodeClass *v1beta1.AKSNodeClass) (reconcile.Result, error) {

--- a/pkg/controllers/nodeclass/status/subnet_test.go
+++ b/pkg/controllers/nodeclass/status/subnet_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
+	"github.com/Azure/karpenter-provider-azure/pkg/consts"
 	"github.com/Azure/karpenter-provider-azure/pkg/controllers/nodeclass/status"
 	"github.com/Azure/karpenter-provider-azure/pkg/operator/options"
 	"github.com/Azure/karpenter-provider-azure/pkg/test"
@@ -34,6 +35,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )
@@ -219,6 +221,151 @@ var _ = Describe("SubnetStatus", func() {
 			Expect(cond.IsFalse()).To(BeTrue())
 			Expect(cond.Reason).To(Equal("SubnetUnknownError"))
 			Expect(cond.Message).To(ContainSubstring(errString))
+		})
+	})
+
+	Context("PodSubnetID", func() {
+		const (
+			nodeSubnetID     = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-resourceGroup/providers/Microsoft.Network/virtualNetworks/byo-vnet/subnets/nodesubnet"
+			podSubnetID      = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-resourceGroup/providers/Microsoft.Network/virtualNetworks/byo-vnet/subnets/podsubnet"
+			otherVNetSubnet  = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-resourceGroup/providers/Microsoft.Network/virtualNetworks/other-vnet/subnets/podsubnet"
+			clusterPodSubnet = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-resourceGroup/providers/Microsoft.Network/virtualNetworks/byo-vnet/subnets/clusterpodsubnet"
+		)
+
+		var (
+			reconciler   *status.SubnetReconciler
+			podSubnetCtx context.Context
+		)
+
+		BeforeEach(func() {
+			reconciler = status.NewSubnetReconciler(azureEnv.SubnetsAPI)
+			nodeClass = test.AKSNodeClass()
+			nodeClass.Spec.VNETSubnetID = lo.ToPtr(nodeSubnetID)
+			podSubnetCtx = options.ToContext(ctx, test.Options(test.OptionsFields{
+				SubnetID:          lo.ToPtr(nodeSubnetID),
+				PodSubnetID:       lo.ToPtr(clusterPodSubnet),
+				NetworkPluginMode: lo.ToPtr(consts.NetworkPluginModeNone),
+			}))
+			azureEnv.SubnetsAPI.GetFunc = func(_ context.Context, _ string, _ string, _ string, _ *armnetwork.SubnetsClientGetOptions) (armnetwork.SubnetsClientGetResponse, error) {
+				return armnetwork.SubnetsClientGetResponse{
+					Subnet: armnetwork.Subnet{
+						Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: lo.ToPtr("10.0.0.0/16")},
+					},
+				}, nil
+			}
+		})
+
+		It("should mark nodeclass as ready and look up the pod subnet when podSubnetID is valid", func() {
+			nodeClass.Spec.PodSubnetID = lo.ToPtr(podSubnetID)
+			lookedUp := sets.New[string]()
+			azureEnv.SubnetsAPI.GetFunc = func(_ context.Context, _ string, virtualNetworkName string, subnetName string, _ *armnetwork.SubnetsClientGetOptions) (armnetwork.SubnetsClientGetResponse, error) {
+				Expect(virtualNetworkName).To(Equal("byo-vnet"))
+				lookedUp.Insert(subnetName)
+				return armnetwork.SubnetsClientGetResponse{
+					Subnet: armnetwork.Subnet{
+						Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: lo.ToPtr("10.0.0.0/16")},
+					},
+				}, nil
+			}
+
+			_, err := reconciler.Reconcile(podSubnetCtx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Both the pod subnet and the node subnet must be validated, not just the node subnet
+			Expect(lookedUp.UnsortedList()).To(ConsistOf("podsubnet", "nodesubnet"))
+			Expect(nodeClass.StatusConditions().Get(v1beta1.ConditionTypeSubnetsReady).IsTrue()).To(BeTrue())
+		})
+
+		It("should mark nodeclass as not ready when podSubnetID is in a different VNet than the node subnet", func() {
+			nodeClass.Spec.PodSubnetID = lo.ToPtr(otherVNetSubnet)
+
+			result, err := reconciler.Reconcile(podSubnetCtx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			cond := nodeClass.StatusConditions().Get(v1beta1.ConditionTypeSubnetsReady)
+			Expect(cond.IsFalse()).To(BeTrue())
+			Expect(cond.Reason).To(Equal("SubnetIDInvalid"))
+			Expect(cond.Message).To(ContainSubstring("same virtual network as the node subnet"))
+		})
+
+		It("should mark nodeclass as not ready when podSubnetID matches the node subnet", func() {
+			nodeClass.Spec.PodSubnetID = lo.ToPtr(nodeSubnetID)
+
+			result, err := reconciler.Reconcile(podSubnetCtx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			cond := nodeClass.StatusConditions().Get(v1beta1.ConditionTypeSubnetsReady)
+			Expect(cond.IsFalse()).To(BeTrue())
+			Expect(cond.Message).To(ContainSubstring("must be different from the node subnet"))
+		})
+
+		It("should mark nodeclass as not ready when podSubnetID is set with overlay", func() {
+			nodeClass.Spec.PodSubnetID = lo.ToPtr(podSubnetID)
+			overlayCtx := options.ToContext(ctx, test.Options(test.OptionsFields{
+				SubnetID:          lo.ToPtr(nodeSubnetID),
+				PodSubnetID:       lo.ToPtr(clusterPodSubnet),
+				NetworkPluginMode: lo.ToPtr(consts.NetworkPluginModeOverlay),
+			}))
+
+			result, err := reconciler.Reconcile(overlayCtx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			cond := nodeClass.StatusConditions().Get(v1beta1.ConditionTypeSubnetsReady)
+			Expect(cond.IsFalse()).To(BeTrue())
+			Expect(cond.Message).To(ContainSubstring("only supported with Azure CNI without overlay"))
+		})
+
+		// AKS machine nodes never get the pod network labels, so maxPods must not jump to the pod subnet default
+		It("should mark nodeclass as not ready when podSubnetID is set in an AKS machine API mode", func() {
+			nodeClass.Spec.PodSubnetID = lo.ToPtr(podSubnetID)
+			machineAPICtx := options.ToContext(ctx, test.Options(test.OptionsFields{
+				SubnetID:          lo.ToPtr(nodeSubnetID),
+				PodSubnetID:       lo.ToPtr(clusterPodSubnet),
+				NetworkPluginMode: lo.ToPtr(consts.NetworkPluginModeNone),
+				ProvisionMode:     lo.ToPtr(consts.ProvisionModeAKSMachineAPI),
+			}))
+
+			result, err := reconciler.Reconcile(machineAPICtx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			cond := nodeClass.StatusConditions().Get(v1beta1.ConditionTypeSubnetsReady)
+			Expect(cond.IsFalse()).To(BeTrue())
+			Expect(cond.Message).To(ContainSubstring(consts.ProvisionModeAKSMachineAPI))
+		})
+
+		It("should mark nodeclass as not ready when podSubnetID is set without a cluster-level pod subnet", func() {
+			nodeClass.Spec.PodSubnetID = lo.ToPtr(podSubnetID)
+			noClusterDefaultCtx := options.ToContext(ctx, test.Options(test.OptionsFields{
+				SubnetID:          lo.ToPtr(nodeSubnetID),
+				NetworkPluginMode: lo.ToPtr(consts.NetworkPluginModeNone),
+			}))
+
+			result, err := reconciler.Reconcile(noClusterDefaultCtx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			cond := nodeClass.StatusConditions().Get(v1beta1.ConditionTypeSubnetsReady)
+			Expect(cond.IsFalse()).To(BeTrue())
+			Expect(cond.Message).To(ContainSubstring("requires the cluster-level --pod-subnet-id"))
+		})
+
+		It("should not require a pod subnet lookup when podSubnetID is unset", func() {
+			azureEnv.SubnetsAPI.GetFunc = func(_ context.Context, _ string, _ string, subnetName string, _ *armnetwork.SubnetsClientGetOptions) (armnetwork.SubnetsClientGetResponse, error) {
+				Expect(subnetName).To(Equal("nodesubnet"))
+				return armnetwork.SubnetsClientGetResponse{
+					Subnet: armnetwork.Subnet{
+						Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: lo.ToPtr("10.0.0.0/16")},
+					},
+				}, nil
+			}
+
+			_, err := reconciler.Reconcile(podSubnetCtx, nodeClass)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodeClass.StatusConditions().Get(v1beta1.ConditionTypeSubnetsReady).IsTrue()).To(BeTrue())
 		})
 	})
 })

--- a/pkg/operator/options/options_extensions.go
+++ b/pkg/operator/options/options_extensions.go
@@ -35,3 +35,9 @@ func (o *Options) IsNetworkPluginNone() bool {
 func (o *Options) IsAzureCNIPodSubnet() bool {
 	return o.NetworkPlugin == consts.NetworkPluginAzure && o.PodSubnetID != ""
 }
+
+// IsAzureCNIPodSubnetFor reports pod subnet mode for a specific effective pod subnet, which may come
+// from an AKSNodeClass rather than the cluster default
+func (o *Options) IsAzureCNIPodSubnetFor(podSubnetID string) bool {
+	return o.NetworkPlugin == consts.NetworkPluginAzure && podSubnetID != ""
+}

--- a/pkg/operator/options/options_validation.go
+++ b/pkg/operator/options/options_validation.go
@@ -121,7 +121,7 @@ func (o *Options) validatePodSubnetID() error {
 	}
 	// Skip the cross-check when the node subnet does not parse; validateVnetSubnetID reports that
 	if nodeSubnet, nodeSubnetErr := utils.GetVnetSubnetIDComponents(o.SubnetID); nodeSubnetErr == nil {
-		if !isSameVNETFold(nodeSubnet, podSubnet) {
+		if !nodeSubnet.IsSameVNETFold(podSubnet) {
 			return fmt.Errorf("pod-subnet-id must be in the same virtual network as vnet-subnet-id")
 		}
 	}
@@ -129,13 +129,6 @@ func (o *Options) validatePodSubnetID() error {
 		return fmt.Errorf("pod-subnet-id must be different from vnet-subnet-id")
 	}
 	return nil
-}
-
-// isSameVNETFold compares the VNet of two subnets, case-insensitively as ARM resource IDs are
-func isSameVNETFold(a, b utils.VnetSubnetResource) bool {
-	return strings.EqualFold(a.SubscriptionID, b.SubscriptionID) &&
-		strings.EqualFold(a.ResourceGroupName, b.ResourceGroupName) &&
-		strings.EqualFold(a.VNetName, b.VNetName)
 }
 
 func (o *Options) validateEndpoint() error {

--- a/pkg/providers/imagefamily/resolver.go
+++ b/pkg/providers/imagefamily/resolver.go
@@ -232,7 +232,7 @@ func prepareKubeletConfiguration(ctx context.Context, instanceType *cloudprovide
 		kubeletConfig.KubeletConfiguration = *nodeClass.Spec.Kubelet
 	}
 
-	kubeletConfig.MaxPods = utils.GetMaxPods(nodeClass, options.FromContext(ctx).NetworkPlugin, options.FromContext(ctx).NetworkPluginMode, options.FromContext(ctx).PodSubnetID)
+	kubeletConfig.MaxPods = utils.GetMaxPods(nodeClass, options.FromContext(ctx).NetworkPlugin, options.FromContext(ctx).NetworkPluginMode, nodeClass.GetPodSubnetID(options.FromContext(ctx).PodSubnetID))
 	kubeletConfig.ClusterDNSServiceIP = options.FromContext(ctx).DNSServiceIP
 
 	// TODO: revisit computeResources implementation

--- a/pkg/providers/instance/vminstance.go
+++ b/pkg/providers/instance/vminstance.go
@@ -816,7 +816,7 @@ func (p *DefaultVMProvider) beginLaunchInstance(
 	}
 	networkPlugin := options.FromContext(ctx).NetworkPlugin
 	networkPluginMode := options.FromContext(ctx).NetworkPluginMode
-	podSubnetID := options.FromContext(ctx).PodSubnetID
+	podSubnetID := nodeClass.GetPodSubnetID(options.FromContext(ctx).PodSubnetID)
 
 	isAKSManagedVNET, err := utils.IsAKSManagedVNET(options.FromContext(ctx).NodeResourceGroup, launchTemplate.SubnetID)
 	if err != nil {

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -147,7 +147,7 @@ func (p *DefaultProvider) List(
 	instanceTypeParams := &instanceTypeParameters{
 		ImageFamily:              lo.FromPtr(nodeClass.Spec.ImageFamily),
 		OSDiskSizeGB:             lo.FromPtr(nodeClass.Spec.OSDiskSizeGB),
-		MaxPods:                  utils.GetMaxPods(nodeClass, options.FromContext(ctx).NetworkPlugin, options.FromContext(ctx).NetworkPluginMode, options.FromContext(ctx).PodSubnetID),
+		MaxPods:                  utils.GetMaxPods(nodeClass, options.FromContext(ctx).NetworkPlugin, options.FromContext(ctx).NetworkPluginMode, nodeClass.GetPodSubnetID(options.FromContext(ctx).PodSubnetID)),
 		EncryptionAtHost:         nodeClass.GetEncryptionAtHost(),
 		TrustedLaunch:            nodeClass.IsTrustedLaunchEnabled(),
 		GPUMode:                  nodeClass.GetGPUMode(),

--- a/pkg/providers/labels/labels.go
+++ b/pkg/providers/labels/labels.go
@@ -132,7 +132,7 @@ func Get(
 	imageFamily := imagefamily.GetImageFamily(nodeClass.Spec.ImageFamily, nodeClass.Spec.FIPSMode, nodeClass.IsTrustedLaunchEnabled(), kubernetesVersion, nil)
 	labels[v1beta1.AKSLabelOSSKUEffective] = imageFamily.Name()
 
-	if err := setNetworkLabels(ctx, labels, subnetID, kubernetesVersion); err != nil {
+	if err := setNetworkLabels(ctx, labels, nodeClass, subnetID, kubernetesVersion); err != nil {
 		return nil, err
 	}
 	if opts.NetworkDataplane == consts.NetworkDataplaneCilium {
@@ -162,9 +162,10 @@ func Get(
 }
 
 // setNetworkLabels adds the labels describing the node and pod networks, for the CNI modes that need them
-func setNetworkLabels(ctx context.Context, labels map[string]string, subnetID, kubernetesVersion string) error {
+func setNetworkLabels(ctx context.Context, labels map[string]string, nodeClass *v1beta1.AKSNodeClass, subnetID, kubernetesVersion string) error {
 	opts := options.FromContext(ctx)
-	if !opts.IsAzureCNIOverlay() && !opts.IsAzureCNIPodSubnet() {
+	podSubnetID := nodeClass.GetPodSubnetID(opts.PodSubnetID)
+	if !opts.IsAzureCNIOverlay() && !opts.IsAzureCNIPodSubnetFor(podSubnetID) {
 		return nil
 	}
 
@@ -187,7 +188,7 @@ func setNetworkLabels(ctx context.Context, labels map[string]string, subnetID, k
 	}
 
 	// The Delegated Network Controller keys off these labels to allocate pod subnet IPs for the node
-	podSubnetComponents, err := utils.GetVnetSubnetIDComponents(opts.PodSubnetID)
+	podSubnetComponents, err := utils.GetVnetSubnetIDComponents(podSubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/labels/labels_test.go
+++ b/pkg/providers/labels/labels_test.go
@@ -588,13 +588,14 @@ func TestNetworkLabels(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name              string
-		networkPlugin     string
-		networkPluginMode string
-		podSubnetID       string
-		kubernetesVersion string
-		expectedLabels    map[string]string
-		unexpectedLabels  []string
+		name               string
+		networkPlugin      string
+		networkPluginMode  string
+		podSubnetID        string
+		nodeClassPodSubnet string
+		kubernetesVersion  string
+		expectedLabels     map[string]string
+		unexpectedLabels   []string
 	}{
 		{
 			name:              "Azure CNI pod subnet emits the podnetwork labels DNC keys off",
@@ -664,6 +665,19 @@ func TestNetworkLabels(t *testing.T) {
 			},
 		},
 		{
+			name:               "NodeClass podSubnetID overrides the cluster default",
+			networkPlugin:      consts.NetworkPluginAzure,
+			networkPluginMode:  consts.NetworkPluginModeNone,
+			podSubnetID:        podSubnetID,
+			nodeClassPodSubnet: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/other-podsubnet",
+			kubernetesVersion:  "1.35.0",
+			expectedLabels: map[string]string{
+				labels.AKSLabelPodNetworkSubnet: "other-podsubnet",
+				labels.AKSLabelPodNetworkType:   consts.PodNetworkTypeVNet,
+				labels.AKSLabelSubnetName:       "nodesubnet",
+			},
+		},
+		{
 			name:              "network plugin none ignores a stray pod subnet",
 			networkPlugin:     consts.NetworkPluginNone,
 			networkPluginMode: consts.NetworkPluginModeNone,
@@ -702,6 +716,9 @@ func TestNetworkLabels(t *testing.T) {
 						},
 					},
 				},
+			}
+			if tc.nodeClassPodSubnet != "" {
+				nodeClass.Spec.PodSubnetID = lo.ToPtr(tc.nodeClassPodSubnet)
 			}
 
 			labelMap, err := labels.Get(ctx, nodeClass, "amd64")

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -194,16 +194,17 @@ func (p *Provider) getStaticParameters(
 		RouteTableName:                 routeTableName,
 		APIServerName:                  options.FromContext(ctx).GetAPIServerName(),
 		KubeletClientTLSBootstrapToken: options.FromContext(ctx).KubeletClientTLSBootstrapToken,
-		NetworkPlugin:                  getAgentbakerNetworkPlugin(ctx),
+		NetworkPlugin:                  getAgentbakerNetworkPlugin(ctx, nodeClass),
 		NetworkPolicy:                  options.FromContext(ctx).NetworkPolicy,
 		SubnetID:                       subnetID,
 		ClusterResourceGroup:           p.clusterResourceGroup,
 	}, nil
 }
 
-func getAgentbakerNetworkPlugin(ctx context.Context) string {
+func getAgentbakerNetworkPlugin(ctx context.Context, nodeClass *v1beta1.AKSNodeClass) string {
 	opts := options.FromContext(ctx)
-	if opts.IsAzureCNIOverlay() || opts.IsCiliumNodeSubnet() || opts.IsNetworkPluginNone() || opts.IsAzureCNIPodSubnet() {
+	podSubnetID := nodeClass.GetPodSubnetID(opts.PodSubnetID)
+	if opts.IsAzureCNIOverlay() || opts.IsCiliumNodeSubnet() || opts.IsNetworkPluginNone() || opts.IsAzureCNIPodSubnetFor(podSubnetID) {
 		return consts.NetworkPluginNone
 	}
 	return consts.NetworkPluginAzure

--- a/pkg/utils/subnet_parser.go
+++ b/pkg/utils/subnet_parser.go
@@ -42,6 +42,13 @@ func (v VnetSubnetResource) IsSameVNET(cmp VnetSubnetResource) bool {
 	return true
 }
 
+// IsSameVNETFold compares the virtual networks of two subnets, case-insensitively as ARM resource IDs are
+func (v VnetSubnetResource) IsSameVNETFold(cmp VnetSubnetResource) bool {
+	return strings.EqualFold(v.SubscriptionID, cmp.SubscriptionID) &&
+		strings.EqualFold(v.ResourceGroupName, cmp.ResourceGroupName) &&
+		strings.EqualFold(v.VNetName, cmp.VNetName)
+}
+
 // GetSubnetResourceID constructs the subnet resource id
 func GetSubnetResourceID(subscriptionID, resourceGroupName, virtualNetworkName, subnetName string) string {
 	// an example subnet resource: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}


### PR DESCRIPTION
**Stacked on #1855.** Base is the upstream mirror of that PR's head (`willie-yao/pod-subnet-support` @ `b6c7dec`), so the diff here is only the new commit. Retarget to `main` once #1855 merges.

Fixes # 

**Description**

#1855 added Azure CNI pod subnet support as a single cluster-scoped `--pod-subnet-id`. That covers one pod subnet per cluster, but AKS itself allows a different pod subnet per agent pool, and users hitting IP exhaustion need to segment pod address space across node pools. I confirmed the AKS side empirically: a second pod subnet at `10.243.0.0/16` and a second pool run alongside the original in one cluster. The only thing preventing it in Karpenter was that the pod subnet was a single string.

This adds an optional `podSubnetID` to `AKSNodeClass`, mirroring the existing `vnetSubnetID`, that overrides the cluster-scoped default for nodes provisioned from that nodeclass. Every consumer now resolves through `nodeClass.GetPodSubnetID(options.PodSubnetID)` instead of reading the option directly, so labels, the agentbaker network plugin, max pods, and the NIC ipConfig decision all agree on one value for a given node.

It is an override, not an independent enabler: a nodeclass `podSubnetID` requires the cluster-scoped `--pod-subnet-id` to be set. That guarantee matters, because `VnetGUID` is derived once at startup gated on the cluster-scoped value, and it feeds the `nodenetwork-vnetguid` and `podnetwork-delegationguid` labels the Delegated Network Controller keys off. Letting a nodeclass turn pod subnet on by itself would emit those labels with an empty GUID, which is the same silent failure mode (pods `Running` on node subnet IPs) that #1855 exists to prevent. Requiring the cluster default keeps that derivation correct without touching startup, and it matches the AKS constraint that all or none of the agent pools set a pod subnet.

The subnet status reconciler now validates `podSubnetID` and reports it through `SubnetsReady`, replacing the `// TODO: Handle podSubnetID readiness here as well` left in #1855. It applies the same rules the cluster-scoped option is validated against at startup: Azure CNI without overlay, not an AKS Machine API mode, same virtual network as the node subnet, different from the node subnet, and the subnet actually exists. The AKS Machine API guard is load-bearing rather than cosmetic. Machine nodes never carry the bootstrap pod network labels, so without it a nodeclass `podSubnetID` would silently push max pods from 30 to 250 on nodes that never receive a pod subnet.

Also folds two byte-identical case-insensitive VNet comparison helpers into `utils.VnetSubnetResource.IsSameVNETFold`, next to the existing `IsSameVNET`, since that file already warns about duplicated subnet-parsing helpers drifting.

No `AKSNodeClassHashVersion` bump. Verified an existing stored object with no `podSubnetID` hashes identically to an explicit nil, so existing nodeclasses do not drift on upgrade, while setting the field does change the hash and drift as intended.

**How was this change tested?**

Unit and acceptance tests extend the existing suites: nodeclass pod subnet resolution in the existing network labels table (`labels_test.go`), and seven cases added to the existing `SubnetStatus` suite (`subnet_test.go`) covering a valid override, a different VNet, the node subnet, overlay, an AKS Machine API mode, a missing cluster default, and the unset case. The valid case asserts both the pod subnet and the node subnet are looked up; the unset case asserts no pod subnet lookup happens at all.

Mutation tested rather than assumed: breaking `GetPodSubnetID` fails the label tests, disabling the AKS Machine API guard fails exactly its own case, and skipping pod subnet validation entirely fails five.

Also built this branch's image and installed it self-hosted on an AKS 1.35.6 pod subnet cluster with two pod subnets, `podsubnet` (`10.241.0.0/16`, the cluster default) and `podsubnet2` (`10.243.0.0/16`), and two nodepools whose nodeclasses differ only in `podSubnetID`.

Verified:

- pods on the default nodeclass got `10.241.0.112`, `.120`, `.121`; pods on the overriding nodeclass got `10.243.0.29`, `.31`, `.34`
- each node carries its own `podnetwork-subnet` label (`podsubnet` vs `podsubnet2`) while the delegation GUID is non-empty and identical on both, as expected for one VNet
- max pods 250 on both, same as AKS
- cross-VNet, same-as-node-subnet, and nonexistent pod subnets are all rejected with `SubnetsReady=False` and propagate to `Ready=False`, so no node is provisioned

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # 
- [x] No

**Release Note**

```release-note
Support per-AKSNodeClass pod subnet via podSubnetID
```
