### PR TITLE
fix: account for Trusted Launch storage in Ephemeral OS fit

### DIFF
--- a/pkg/cloudprovider/suite_aksmachineapi_features_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_features_test.go
@@ -404,6 +404,34 @@ var _ = Describe("CloudProvider", func() {
 				Expect(*machine.Properties.Security.EnableSecureBoot).To(BeTrue())
 			})
 
+			It("should use ephemeral disk when Trusted Launch has one GiB of headroom", func() {
+				nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](1599)
+				nodeClass.Spec.Security = &v1beta1.Security{
+					TrustedLaunch: &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true), SecureBoot: lo.ToPtr(true)},
+				}
+				nodePool.Spec.Template.Spec.Requirements = append(nodePool.Spec.Template.Spec.Requirements, karpv1.NodeSelectorRequirementWithMinValues{
+					Key:      v1.LabelInstanceTypeStable,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"Standard_D64s_v3"},
+				})
+
+				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+				ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
+				pod := coretest.UnschedulablePod()
+				ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
+				ExpectScheduled(ctx, env.Client, pod)
+
+				machine := azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Pop().AKSMachine
+				Expect(machine.Properties.OperatingSystem.OSDiskSizeGB).ToNot(BeNil())
+				Expect(*machine.Properties.OperatingSystem.OSDiskSizeGB).To(Equal(int32(1599)))
+				Expect(machine.Properties.OperatingSystem.OSDiskType).ToNot(BeNil())
+				Expect(*machine.Properties.OperatingSystem.OSDiskType).To(Equal(armcontainerservice.OSDiskTypeEphemeral))
+				Expect(machine.Properties.Security.EnableVTPM).ToNot(BeNil())
+				Expect(*machine.Properties.Security.EnableVTPM).To(BeTrue())
+				Expect(machine.Properties.Security.EnableSecureBoot).ToNot(BeNil())
+				Expect(*machine.Properties.Security.EnableSecureBoot).To(BeTrue())
+			})
+
 			// Ported from VM test: "should fail to provision if ephemeral disk ask for is too large"
 			It("should fail to provision if ephemeral disk ask for is too large", func() {
 				nodePool.Spec.Template.Spec.Requirements = append(nodePool.Spec.Template.Spec.Requirements, karpv1.NodeSelectorRequirementWithMinValues{

--- a/pkg/cloudprovider/suite_aksmachineapi_features_test.go
+++ b/pkg/cloudprovider/suite_aksmachineapi_features_test.go
@@ -378,6 +378,32 @@ var _ = Describe("CloudProvider", func() {
 				Expect(*aksMachine.Properties.OperatingSystem.OSDiskType).To(Equal(armcontainerservice.OSDiskTypeEphemeral))
 			})
 
+			It("should use managed disk when Trusted Launch consumes an exact-fit cache boundary", func() {
+				nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](1600)
+				nodeClass.Spec.Security = &v1beta1.Security{
+					TrustedLaunch: &v1beta1.TrustedLaunch{SecureBoot: lo.ToPtr(true)},
+				}
+				nodePool.Spec.Template.Spec.Requirements = append(nodePool.Spec.Template.Spec.Requirements, karpv1.NodeSelectorRequirementWithMinValues{
+					Key:      v1.LabelInstanceTypeStable,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"Standard_D64s_v3"},
+				})
+
+				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+				ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
+				pod := coretest.UnschedulablePod()
+				ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
+				ExpectScheduled(ctx, env.Client, pod)
+
+				machine := azureEnv.AKSMachinesAPI.AKSMachineCreateOrUpdateBehavior.CalledWithInput.Pop().AKSMachine
+				Expect(machine.Properties.OperatingSystem.OSDiskSizeGB).ToNot(BeNil())
+				Expect(*machine.Properties.OperatingSystem.OSDiskSizeGB).To(Equal(int32(1600)))
+				Expect(machine.Properties.OperatingSystem.OSDiskType).ToNot(BeNil())
+				Expect(*machine.Properties.OperatingSystem.OSDiskType).To(Equal(armcontainerservice.OSDiskTypeManaged))
+				Expect(machine.Properties.Security.EnableSecureBoot).ToNot(BeNil())
+				Expect(*machine.Properties.Security.EnableSecureBoot).To(BeTrue())
+			})
+
 			// Ported from VM test: "should fail to provision if ephemeral disk ask for is too large"
 			It("should fail to provision if ephemeral disk ask for is too large", func() {
 				nodePool.Spec.Template.Spec.Requirements = append(nodePool.Spec.Template.Spec.Requirements, karpv1.NodeSelectorRequirementWithMinValues{

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -596,9 +596,33 @@ func supportsNVMeEphemeralOSDisk(sku *skewer.SKU) bool {
 	return sku.HasCapabilityWithSeparator(ephemeralOSDiskPlacementCapability, nvme)
 }
 
+func ephemeralOSDiskPlacementSizeBytes(sku *skewer.SKU, placement armcompute.DiffDiskPlacement) int64 {
+	switch placement {
+	case armcompute.DiffDiskPlacementCacheDisk:
+		sizeBytes, _ := sku.MaxCachedDiskBytes()
+		return max(sizeBytes, 0)
+	case armcompute.DiffDiskPlacementResourceDisk:
+		sizeMiB, _ := sku.MaxResourceVolumeMB()
+		return max(sizeMiB, 0) * int64(units.MiB)
+	case armcompute.DiffDiskPlacementNvmeDisk:
+		sizeMiB, _ := nvmeDiskSizeInMiB(sku)
+		return max(sizeMiB, 0) * int64(units.MiB)
+	default:
+		return 0
+	}
+}
+
 func UseEphemeralDisk(sku *skewer.SKU, nodeClass *v1beta1.AKSNodeClass) bool {
-	sizeGB, _ := FindMaxEphemeralSizeGBAndPlacement(sku)
-	return int64(*nodeClass.Spec.OSDiskSizeGB) <= sizeGB // use ephemeral disk if it is large enough
+	_, placement := FindMaxEphemeralSizeGBAndPlacement(sku)
+	if placement == nil {
+		return false
+	}
+
+	requiredBytes := int64(*nodeClass.Spec.OSDiskSizeGB) * int64(units.GiB)
+	if nodeClass.IsTrustedLaunchEnabled() {
+		requiredBytes += int64(units.GiB)
+	}
+	return requiredBytes <= ephemeralOSDiskPlacementSizeBytes(sku, *placement)
 }
 
 func nvmeDiskSizeInMiB(s *skewer.SKU) (int64, error) {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1089,6 +1089,17 @@ var _ = Describe("InstanceType Provider", func() {
 				Entry("NVMe exact fit with Secure Boot", withSKUCapability(fake.MakeSKU("Standard_D128ds_v6"), "NvmeDiskSizeInMiB", "131072"), int32(128), &v1beta1.TrustedLaunch{SecureBoot: lo.ToPtr(true)}, false),
 				Entry("NVMe one-GiB headroom with Secure Boot", withSKUCapability(fake.MakeSKU("Standard_D128ds_v6"), "NvmeDiskSizeInMiB", "131072"), int32(127), &v1beta1.TrustedLaunch{SecureBoot: lo.ToPtr(true)}, true),
 			)
+			It("should continue to resource disk when Trusted Launch consumes an exact-fit cache boundary", func() {
+				testNodeClass := test.AKSNodeClass()
+				testNodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](30)
+				testNodeClass.Spec.Security = &v1beta1.Security{
+					TrustedLaunch: &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true)},
+				}
+
+				placement := instancetype.FindEphemeralOSDiskPlacement(fake.MakeSKU("Standard_B20ms"), testNodeClass)
+				Expect(placement).ToNot(BeNil())
+				Expect(*placement).To(Equal(armcompute.DiffDiskPlacementResourceDisk))
+			})
 			Context("Placement", func() {
 				It("should prefer NVMe disk if supported for ephemeral", func() {
 					nodePool.Spec.Template.Spec.Requirements = append(nodePool.Spec.Template.Spec.Requirements, karpv1.NodeSelectorRequirementWithMinValues{

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1105,6 +1105,19 @@ var _ = Describe("InstanceType Provider", func() {
 				Entry("NVMe exact fit with Secure Boot", withSKUCapability(fake.MakeSKU("Standard_D128ds_v6"), "NvmeDiskSizeInMiB", "131072"), int32(128), &v1beta1.TrustedLaunch{SecureBoot: lo.ToPtr(true)}, false),
 				Entry("NVMe one-GiB headroom with Secure Boot", withSKUCapability(fake.MakeSKU("Standard_D128ds_v6"), "NvmeDiskSizeInMiB", "131072"), int32(127), &v1beta1.TrustedLaunch{SecureBoot: lo.ToPtr(true)}, true),
 			)
+			It("should allow a 2040-GiB disk when the placement has one GiB of Trusted Launch headroom", func() {
+				sku := withSKUCapability(fake.MakeSKU("Standard_D64s_v3"), "SupportedEphemeralOSDiskPlacements", "ResourceDisk")
+				sku = withSKUCapability(sku, "MaxResourceVolumeMB", strconv.FormatInt(2041*int64(units.GiB)/int64(units.MiB), 10))
+				testNodeClass := test.AKSNodeClass()
+				testNodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](2040)
+				testNodeClass.Spec.Security = &v1beta1.Security{
+					TrustedLaunch: &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true)},
+				}
+
+				placement := instancetype.FindEphemeralOSDiskPlacement(sku, testNodeClass)
+				Expect(placement).ToNot(BeNil())
+				Expect(*placement).To(Equal(armcompute.DiffDiskPlacementResourceDisk))
+			})
 			It("should continue to resource disk when Trusted Launch consumes an exact-fit cache boundary", func() {
 				testNodeClass := test.AKSNodeClass()
 				testNodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](30)

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -1009,6 +1009,20 @@ var _ = Describe("InstanceType Provider", func() {
 					Entry("Nil SKU", nil, int64(0), nil),
 				)
 			})
+			DescribeTable("should reserve one GiB of local storage for Trusted Launch",
+				func(trustedLaunch *v1beta1.TrustedLaunch, expected bool) {
+					testNodeClass := test.AKSNodeClass()
+					testNodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](1600)
+					testNodeClass.Spec.Security = &v1beta1.Security{TrustedLaunch: trustedLaunch}
+
+					Expect(instancetype.UseEphemeralDisk(fake.MakeSKU("Standard_D64s_v3"), testNodeClass)).To(Equal(expected))
+				},
+				Entry("without Trusted Launch", nil, true),
+				Entry("with vTPM", &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true)}, false),
+				Entry("with Secure Boot", &v1beta1.TrustedLaunch{SecureBoot: lo.ToPtr(true)}, false),
+				Entry("with vTPM and Secure Boot", &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true), SecureBoot: lo.ToPtr(true)}, false),
+				Entry("with both features explicitly disabled", &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(false), SecureBoot: lo.ToPtr(false)}, true),
+			)
 			Context("Placement", func() {
 				It("should prefer NVMe disk if supported for ephemeral", func() {
 					nodePool.Spec.Template.Spec.Requirements = append(nodePool.Spec.Template.Spec.Requirements, karpv1.NodeSelectorRequirementWithMinValues{
@@ -1059,6 +1073,31 @@ var _ = Describe("InstanceType Provider", func() {
 					Expect(vm).NotTo(BeNil())
 					Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings).NotTo(BeNil())
 					Expect(lo.FromPtr(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Placement)).To(Equal(armcompute.DiffDiskPlacementCacheDisk))
+				})
+				It("should use managed disk when Trusted Launch consumes an exact-fit cache boundary", func() {
+					nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](1600)
+					nodeClass.Spec.Security = &v1beta1.Security{
+						TrustedLaunch: &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true)},
+					}
+					nodePool.Spec.Template.Spec.Requirements = append(nodePool.Spec.Template.Spec.Requirements, karpv1.NodeSelectorRequirementWithMinValues{
+						Key:      v1.LabelInstanceTypeStable,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{"Standard_D64s_v3"},
+					})
+
+					ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+					statusController := status.NewController(env.Client, azureEnv.KubernetesVersionProvider, azureEnv.ImageProvider, env.KubernetesInterface, env.KubernetesInterface, azureEnv.DynamicInterface, azureEnv.SubnetsAPI, azureEnv.DiskEncryptionSetsAPI, testOptions.ParsedDiskEncryptionSetID, options.FromContext(ctx).NetworkPolicy, options.FromContext(ctx).NetworkPlugin)
+					ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
+					pod := coretest.UnschedulablePod()
+					ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
+					ExpectScheduled(ctx, env.Client, pod)
+
+					vm := azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Pop().VM
+					Expect(vm.Properties.StorageProfile.OSDisk.DiskSizeGB).ToNot(BeNil())
+					Expect(*vm.Properties.StorageProfile.OSDisk.DiskSizeGB).To(Equal(int32(1600)))
+					Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings).To(BeNil())
+					Expect(vm.Properties.SecurityProfile.SecurityType).ToNot(BeNil())
+					Expect(*vm.Properties.SecurityProfile.SecurityType).To(Equal(armcompute.SecurityTypesTrustedLaunch))
 				})
 				It("should select managed disk if cache disk is too small but temp disk supports ephemeral and fits osDiskSizeGB to have parity with the AKS Nodepool API", func() {
 					nodePool.Spec.Template.Spec.Requirements = append(nodePool.Spec.Template.Spec.Requirements, karpv1.NodeSelectorRequirementWithMinValues{

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -97,6 +97,26 @@ var fakeZone1 = zones.MakeAKSLabelZoneFromARMZone(fake.Region, "1")
 
 var defaultTestSKU = fake.MakeSKU("Standard_D2_v3")
 
+func withEphemeralDiskCapability(sku *skewer.SKU, name, value string) *skewer.SKU {
+	clone := *sku
+	capabilities := append([]compute.ResourceSkuCapabilities(nil), (*sku.Capabilities)...)
+	for i := range capabilities {
+		if lo.FromPtr(capabilities[i].Name) == name {
+			capability := capabilities[i]
+			capability.Value = lo.ToPtr(value)
+			capabilities[i] = capability
+			clone.Capabilities = &capabilities
+			return &clone
+		}
+	}
+	capabilities = append(capabilities, compute.ResourceSkuCapabilities{
+		Name:  lo.ToPtr(name),
+		Value: lo.ToPtr(value),
+	})
+	clone.Capabilities = &capabilities
+	return &clone
+}
+
 func TestAzure(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)
@@ -1009,19 +1029,23 @@ var _ = Describe("InstanceType Provider", func() {
 					Entry("Nil SKU", nil, int64(0), nil),
 				)
 			})
-			DescribeTable("should reserve one GiB of local storage for Trusted Launch",
-				func(trustedLaunch *v1beta1.TrustedLaunch, expected bool) {
+			DescribeTable("should reserve exactly one GiB of local storage for Trusted Launch",
+				func(sku *skewer.SKU, sizeGiB int32, trustedLaunch *v1beta1.TrustedLaunch, expected bool) {
 					testNodeClass := test.AKSNodeClass()
-					testNodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](1600)
+					testNodeClass.Spec.OSDiskSizeGB = lo.ToPtr(sizeGiB)
 					testNodeClass.Spec.Security = &v1beta1.Security{TrustedLaunch: trustedLaunch}
 
-					Expect(instancetype.UseEphemeralDisk(fake.MakeSKU("Standard_D64s_v3"), testNodeClass)).To(Equal(expected))
+					Expect(instancetype.UseEphemeralDisk(sku, testNodeClass)).To(Equal(expected))
 				},
-				Entry("without Trusted Launch", nil, true),
-				Entry("with vTPM", &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true)}, false),
-				Entry("with Secure Boot", &v1beta1.TrustedLaunch{SecureBoot: lo.ToPtr(true)}, false),
-				Entry("with vTPM and Secure Boot", &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true), SecureBoot: lo.ToPtr(true)}, false),
-				Entry("with both features explicitly disabled", &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(false), SecureBoot: lo.ToPtr(false)}, true),
+				Entry("cache exact fit without Trusted Launch", fake.MakeSKU("Standard_D64s_v3"), int32(1600), nil, true),
+				Entry("cache exact fit with vTPM", fake.MakeSKU("Standard_D64s_v3"), int32(1600), &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true)}, false),
+				Entry("cache one-GiB headroom with Secure Boot", fake.MakeSKU("Standard_D64s_v3"), int32(1599), &v1beta1.TrustedLaunch{SecureBoot: lo.ToPtr(true)}, true),
+				Entry("cache one-GiB headroom with both features", fake.MakeSKU("Standard_D64s_v3"), int32(1599), &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true), SecureBoot: lo.ToPtr(true)}, true),
+				Entry("cache exact fit with both features disabled", fake.MakeSKU("Standard_D64s_v3"), int32(1600), &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(false), SecureBoot: lo.ToPtr(false)}, true),
+				Entry("resource exact fit with vTPM", withEphemeralDiskCapability(fake.MakeSKU("Standard_D64s_v3"), "CachedDiskBytes", "0"), int32(512), &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true)}, false),
+				Entry("resource one-GiB headroom with vTPM", withEphemeralDiskCapability(fake.MakeSKU("Standard_D64s_v3"), "CachedDiskBytes", "0"), int32(511), &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true)}, true),
+				Entry("NVMe exact fit with Secure Boot", withEphemeralDiskCapability(fake.MakeSKU("Standard_D128ds_v6"), "NvmeDiskSizeInMiB", "131072"), int32(128), &v1beta1.TrustedLaunch{SecureBoot: lo.ToPtr(true)}, false),
+				Entry("NVMe one-GiB headroom with Secure Boot", withEphemeralDiskCapability(fake.MakeSKU("Standard_D128ds_v6"), "NvmeDiskSizeInMiB", "131072"), int32(127), &v1beta1.TrustedLaunch{SecureBoot: lo.ToPtr(true)}, true),
 			)
 			Context("Placement", func() {
 				It("should prefer NVMe disk if supported for ephemeral", func() {
@@ -1096,6 +1120,31 @@ var _ = Describe("InstanceType Provider", func() {
 					Expect(vm.Properties.StorageProfile.OSDisk.DiskSizeGB).ToNot(BeNil())
 					Expect(*vm.Properties.StorageProfile.OSDisk.DiskSizeGB).To(Equal(int32(1600)))
 					Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings).To(BeNil())
+					Expect(vm.Properties.SecurityProfile.SecurityType).ToNot(BeNil())
+					Expect(*vm.Properties.SecurityProfile.SecurityType).To(Equal(armcompute.SecurityTypesTrustedLaunch))
+				})
+				It("should use ephemeral cache disk when Trusted Launch has one GiB of headroom", func() {
+					nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](1599)
+					nodeClass.Spec.Security = &v1beta1.Security{
+						TrustedLaunch: &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true), SecureBoot: lo.ToPtr(true)},
+					}
+					nodePool.Spec.Template.Spec.Requirements = append(nodePool.Spec.Template.Spec.Requirements, karpv1.NodeSelectorRequirementWithMinValues{
+						Key:      v1.LabelInstanceTypeStable,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{"Standard_D64s_v3"},
+					})
+
+					ExpectApplied(ctx, env.Client, nodePool, nodeClass)
+					statusController := status.NewController(env.Client, azureEnv.KubernetesVersionProvider, azureEnv.ImageProvider, env.KubernetesInterface, env.KubernetesInterface, azureEnv.DynamicInterface, azureEnv.SubnetsAPI, azureEnv.DiskEncryptionSetsAPI, testOptions.ParsedDiskEncryptionSetID, options.FromContext(ctx).NetworkPolicy, options.FromContext(ctx).NetworkPlugin)
+					ExpectObjectReconciled(ctx, env.Client, statusController, nodeClass)
+					pod := coretest.UnschedulablePod()
+					ExpectProvisionedAndWaitForPromises(ctx, env.Client, cluster, cloudProvider, coreProvisioner, azureEnv, pod)
+					ExpectScheduled(ctx, env.Client, pod)
+
+					vm := azureEnv.VirtualMachinesAPI.VirtualMachineCreateOrUpdateBehavior.CalledWithInput.Pop().VM
+					Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings).ToNot(BeNil())
+					Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Placement).ToNot(BeNil())
+					Expect(*vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Placement).To(Equal(armcompute.DiffDiskPlacementCacheDisk))
 					Expect(vm.Properties.SecurityProfile.SecurityType).ToNot(BeNil())
 					Expect(*vm.Properties.SecurityProfile.SecurityType).To(Equal(armcompute.SecurityTypesTrustedLaunch))
 				})

--- a/test/suites/nodeclaim/eph_osdisk_test.go
+++ b/test/suites/nodeclaim/eph_osdisk_test.go
@@ -75,6 +75,29 @@ var _ = Describe("Ephemeral OS Disk", func() {
 		Expect(vm.Properties.SecurityProfile.SecurityType).ToNot(BeNil())
 		Expect(*vm.Properties.SecurityProfile.SecurityType).To(Equal(armcompute.SecurityTypesTrustedLaunch))
 	})
+	It("should use ephemeral cache disk when Trusted Launch has one GiB of headroom", func() {
+		test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
+			Key:      corev1.LabelInstanceTypeStable,
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{"Standard_D2s_v3"},
+		})
+		nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](49)
+		nodeClass.Spec.Security = &v1beta1.Security{
+			TrustedLaunch: &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true), SecureBoot: lo.ToPtr(true)},
+		}
+
+		deployment := test.Deployment(test.DeploymentOptions{Replicas: 1})
+		env.ExpectCreated(nodeClass, nodePool, deployment)
+		pods := env.EventuallyExpectHealthyDeployment(deployment)
+		vm := env.GetVM(pods[0].Spec.NodeName)
+
+		Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings).ToNot(BeNil())
+		Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Placement).ToNot(BeNil())
+		Expect(*vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Placement).To(Equal(armcompute.DiffDiskPlacementCacheDisk))
+		Expect(vm.Properties.SecurityProfile).ToNot(BeNil())
+		Expect(vm.Properties.SecurityProfile.SecurityType).ToNot(BeNil())
+		Expect(*vm.Properties.SecurityProfile.SecurityType).To(Equal(armcompute.SecurityTypesTrustedLaunch))
+	})
 	It("should provision VM with SKU that does not support ephemeral OS disk", func() {
 		test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 			Key:      v1beta1.LabelSKUStorageEphemeralOSMaxSize,

--- a/test/suites/nodeclaim/eph_osdisk_test.go
+++ b/test/suites/nodeclaim/eph_osdisk_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package nodeclaim_test
 
 import (
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+
 	"github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -49,6 +51,29 @@ var _ = Describe("Ephemeral OS Disk", func() {
 		// We should be specifying os disk placement now
 		Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Placement).ToNot(BeNil())
 		Expect(string(lo.FromPtr(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Option))).To(Equal("Local"))
+	})
+	It("should use managed disk when Trusted Launch consumes exact-fit local storage", func() {
+		test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
+			Key:      corev1.LabelInstanceTypeStable,
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{"Standard_D2s_v3"},
+		})
+		nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](50)
+		nodeClass.Spec.Security = &v1beta1.Security{
+			TrustedLaunch: &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true)},
+		}
+
+		deployment := test.Deployment(test.DeploymentOptions{Replicas: 1})
+		env.ExpectCreated(nodeClass, nodePool, deployment)
+		pods := env.EventuallyExpectHealthyDeployment(deployment)
+		vm := env.GetVM(pods[0].Spec.NodeName)
+
+		Expect(vm.Properties.StorageProfile.OSDisk.DiskSizeGB).ToNot(BeNil())
+		Expect(*vm.Properties.StorageProfile.OSDisk.DiskSizeGB).To(Equal(int32(50)))
+		Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings).To(BeNil())
+		Expect(vm.Properties.SecurityProfile).ToNot(BeNil())
+		Expect(vm.Properties.SecurityProfile.SecurityType).ToNot(BeNil())
+		Expect(*vm.Properties.SecurityProfile.SecurityType).To(Equal(armcompute.SecurityTypesTrustedLaunch))
 	})
 	It("should provision VM with SKU that does not support ephemeral OS disk", func() {
 		test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{

--- a/test/suites/nodeclaim/eph_osdisk_test.go
+++ b/test/suites/nodeclaim/eph_osdisk_test.go
@@ -28,6 +28,13 @@ import (
 	"sigs.k8s.io/karpenter/pkg/test"
 )
 
+// Both SKUs expose a 50-GiB cache and a 16-GiB resource disk, preserving
+// the exact Trusted Launch boundary while tolerating subscription availability.
+var trustedLaunchBoundaryInstanceTypes = []string{
+	"Standard_D2s_v3",
+	"Standard_D2as_v4",
+}
+
 var _ = Describe("Ephemeral OS Disk", func() {
 	It("should use a node with an ephemeral os disk", func() {
 		test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
@@ -56,7 +63,7 @@ var _ = Describe("Ephemeral OS Disk", func() {
 		test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 			Key:      corev1.LabelInstanceTypeStable,
 			Operator: corev1.NodeSelectorOpIn,
-			Values:   []string{"Standard_D2s_v3"},
+			Values:   trustedLaunchBoundaryInstanceTypes,
 		})
 		nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](50)
 		nodeClass.Spec.Security = &v1beta1.Security{
@@ -79,7 +86,7 @@ var _ = Describe("Ephemeral OS Disk", func() {
 		test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
 			Key:      corev1.LabelInstanceTypeStable,
 			Operator: corev1.NodeSelectorOpIn,
-			Values:   []string{"Standard_D2s_v3"},
+			Values:   trustedLaunchBoundaryInstanceTypes,
 		})
 		nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](49)
 		nodeClass.Spec.Security = &v1beta1.Security{

--- a/test/suites/nodeclaim/eph_osdisk_test.go
+++ b/test/suites/nodeclaim/eph_osdisk_test.go
@@ -28,11 +28,21 @@ import (
 	"sigs.k8s.io/karpenter/pkg/test"
 )
 
-// Both SKUs expose a 50-GiB cache and a 16-GiB resource disk, preserving
-// the exact Trusted Launch boundary while tolerating subscription availability.
-var trustedLaunchBoundaryInstanceTypes = []string{
-	"Standard_D2s_v3",
-	"Standard_D2as_v4",
+func requireTrustedLaunchBoundaryInstanceType() {
+	GinkgoHelper()
+	// The maximum eligible Ephemeral OS placement is 50 GiB. Trusted Launch
+	// therefore makes a 50-GiB disk too large and leaves exactly enough room for 49 GiB.
+	test.ReplaceRequirements(nodePool,
+		karpv1.NodeSelectorRequirementWithMinValues{
+			Key:      v1beta1.LabelSKUFamily,
+			Operator: corev1.NodeSelectorOpExists,
+		},
+		karpv1.NodeSelectorRequirementWithMinValues{
+			Key:      v1beta1.LabelSKUStorageEphemeralOSMaxSize,
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{"50"},
+		},
+	)
 }
 
 var _ = Describe("Ephemeral OS Disk", func() {
@@ -60,11 +70,7 @@ var _ = Describe("Ephemeral OS Disk", func() {
 		Expect(string(lo.FromPtr(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Option))).To(Equal("Local"))
 	})
 	It("should use managed disk when Trusted Launch consumes exact-fit local storage", func() {
-		test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
-			Key:      corev1.LabelInstanceTypeStable,
-			Operator: corev1.NodeSelectorOpIn,
-			Values:   trustedLaunchBoundaryInstanceTypes,
-		})
+		requireTrustedLaunchBoundaryInstanceType()
 		nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](50)
 		nodeClass.Spec.Security = &v1beta1.Security{
 			TrustedLaunch: &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true)},
@@ -82,12 +88,8 @@ var _ = Describe("Ephemeral OS Disk", func() {
 		Expect(vm.Properties.SecurityProfile.SecurityType).ToNot(BeNil())
 		Expect(*vm.Properties.SecurityProfile.SecurityType).To(Equal(armcompute.SecurityTypesTrustedLaunch))
 	})
-	It("should use ephemeral cache disk when Trusted Launch has one GiB of headroom", func() {
-		test.ReplaceRequirements(nodePool, karpv1.NodeSelectorRequirementWithMinValues{
-			Key:      corev1.LabelInstanceTypeStable,
-			Operator: corev1.NodeSelectorOpIn,
-			Values:   trustedLaunchBoundaryInstanceTypes,
-		})
+	It("should use an ephemeral disk when Trusted Launch has one GiB of headroom", func() {
+		requireTrustedLaunchBoundaryInstanceType()
 		nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](49)
 		nodeClass.Spec.Security = &v1beta1.Security{
 			TrustedLaunch: &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true), SecureBoot: lo.ToPtr(true)},
@@ -98,9 +100,10 @@ var _ = Describe("Ephemeral OS Disk", func() {
 		pods := env.EventuallyExpectHealthyDeployment(deployment)
 		vm := env.GetVM(pods[0].Spec.NodeName)
 
+		Expect(vm.Properties.StorageProfile.OSDisk.DiskSizeGB).ToNot(BeNil())
+		Expect(*vm.Properties.StorageProfile.OSDisk.DiskSizeGB).To(Equal(int32(49)))
 		Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings).ToNot(BeNil())
 		Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Placement).ToNot(BeNil())
-		Expect(*vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Placement).To(Equal(armcompute.DiffDiskPlacementCacheDisk))
 		Expect(vm.Properties.SecurityProfile).ToNot(BeNil())
 		Expect(vm.Properties.SecurityProfile.SecurityType).ToNot(BeNil())
 		Expect(*vm.Properties.SecurityProfile.SecurityType).To(Equal(armcompute.SecurityTypesTrustedLaunch))

--- a/test/suites/nodeclaim/eph_osdisk_test.go
+++ b/test/suites/nodeclaim/eph_osdisk_test.go
@@ -29,17 +29,17 @@ import (
 
 func requireTrustedLaunchBoundaryInstanceType() {
 	GinkgoHelper()
-	// The maximum eligible Ephemeral OS placement is 50 GiB. Trusted Launch
-	// makes a 50-GiB disk too large and leaves exactly enough room for 49 GiB.
+	// Both SKUs expose a 50-GiB cache and a 16-GiB resource disk, preserving
+	// the exact Trusted Launch boundary while tolerating subscription availability.
 	test.ReplaceRequirements(nodePool,
 		karpv1.NodeSelectorRequirementWithMinValues{
 			Key:      v1beta1.LabelSKUFamily,
 			Operator: corev1.NodeSelectorOpExists,
 		},
 		karpv1.NodeSelectorRequirementWithMinValues{
-			Key:      v1beta1.LabelSKUStorageEphemeralOSMaxSize,
+			Key:      corev1.LabelInstanceTypeStable,
 			Operator: corev1.NodeSelectorOpIn,
-			Values:   []string{"50"},
+			Values:   []string{"Standard_D2s_v3", "Standard_D2as_v4"},
 		},
 	)
 }

--- a/test/suites/nodeclaim/eph_osdisk_test.go
+++ b/test/suites/nodeclaim/eph_osdisk_test.go
@@ -121,6 +121,38 @@ var _ = Describe("Ephemeral OS Disk", func() {
 		Expect(vm.Properties.SecurityProfile.SecurityType).ToNot(BeNil())
 		Expect(*vm.Properties.SecurityProfile.SecurityType).To(Equal(armcompute.SecurityTypesTrustedLaunch))
 	})
+	It("should select resource disk when Trusted Launch consumes an exact-fit cache boundary", func() {
+		test.ReplaceRequirements(nodePool,
+			karpv1.NodeSelectorRequirementWithMinValues{
+				Key:      v1beta1.LabelSKUFamily,
+				Operator: corev1.NodeSelectorOpExists,
+			},
+			karpv1.NodeSelectorRequirementWithMinValues{
+				Key:      corev1.LabelInstanceTypeStable,
+				Operator: corev1.NodeSelectorOpIn,
+				// Each candidate has a 50-GiB CacheDisk and 75-GiB ResourceDisk.
+				Values: []string{"Standard_D2ds_v4", "Standard_DC1ds_v3", "Standard_E2ds_v4"},
+			},
+		)
+		nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](50)
+		nodeClass.Spec.Security = &v1beta1.Security{
+			TrustedLaunch: &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true)},
+		}
+
+		deployment := test.Deployment(test.DeploymentOptions{Replicas: 1})
+		env.ExpectCreated(nodeClass, nodePool, deployment)
+		pods := env.EventuallyExpectHealthyDeployment(deployment)
+		vm := env.GetVM(pods[0].Spec.NodeName)
+
+		Expect(vm.Properties.StorageProfile.OSDisk.DiskSizeGB).ToNot(BeNil())
+		Expect(*vm.Properties.StorageProfile.OSDisk.DiskSizeGB).To(Equal(int32(50)))
+		Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings).ToNot(BeNil())
+		Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Placement).ToNot(BeNil())
+		Expect(*vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Placement).To(Equal(armcompute.DiffDiskPlacementResourceDisk))
+		Expect(vm.Properties.SecurityProfile).ToNot(BeNil())
+		Expect(vm.Properties.SecurityProfile.SecurityType).ToNot(BeNil())
+		Expect(*vm.Properties.SecurityProfile.SecurityType).To(Equal(armcompute.SecurityTypesTrustedLaunch))
+	})
 	It("should use an ephemeral disk when Trusted Launch has one GiB of headroom", func() {
 		requireTrustedLaunchBoundaryInstanceType()
 		nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](49)

--- a/test/suites/nodeclaim/eph_osdisk_test.go
+++ b/test/suites/nodeclaim/eph_osdisk_test.go
@@ -130,11 +130,11 @@ var _ = Describe("Ephemeral OS Disk", func() {
 			karpv1.NodeSelectorRequirementWithMinValues{
 				Key:      corev1.LabelInstanceTypeStable,
 				Operator: corev1.NodeSelectorOpIn,
-				// Each candidate has a 50-GiB CacheDisk and 75-GiB ResourceDisk.
-				Values: []string{"Standard_D2ds_v4", "Standard_DC1ds_v3", "Standard_E2ds_v4"},
+				// Each candidate has a 30-GiB CacheDisk and a larger ResourceDisk.
+				Values: []string{"Standard_B4ms", "Standard_B8ms", "Standard_B12ms"},
 			},
 		)
-		nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](50)
+		nodeClass.Spec.OSDiskSizeGB = lo.ToPtr[int32](30)
 		nodeClass.Spec.Security = &v1beta1.Security{
 			TrustedLaunch: &v1beta1.TrustedLaunch{VTPM: lo.ToPtr(true)},
 		}
@@ -145,7 +145,7 @@ var _ = Describe("Ephemeral OS Disk", func() {
 		vm := env.GetVM(pods[0].Spec.NodeName)
 
 		Expect(vm.Properties.StorageProfile.OSDisk.DiskSizeGB).ToNot(BeNil())
-		Expect(*vm.Properties.StorageProfile.OSDisk.DiskSizeGB).To(Equal(int32(50)))
+		Expect(*vm.Properties.StorageProfile.OSDisk.DiskSizeGB).To(Equal(int32(30)))
 		Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings).ToNot(BeNil())
 		Expect(vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Placement).ToNot(BeNil())
 		Expect(*vm.Properties.StorageProfile.OSDisk.DiffDiskSettings.Placement).To(Equal(armcompute.DiffDiskPlacementResourceDisk))

--- a/test/suites/nodeclaim/eph_osdisk_test.go
+++ b/test/suites/nodeclaim/eph_osdisk_test.go
@@ -30,8 +30,9 @@ import (
 
 func requireTrustedLaunchBoundaryInstanceType() {
 	GinkgoHelper()
-	// The maximum eligible Ephemeral OS placement is 50 GiB. Trusted Launch
-	// therefore makes a 50-GiB disk too large and leaves exactly enough room for 49 GiB.
+	// The maximum eligible Ephemeral OS placement is 50 GiB. The compatibility
+	// label reports that binary capacity as 53 decimal GB. Trusted Launch therefore
+	// makes a 50-GiB disk too large and leaves exactly enough room for 49 GiB.
 	test.ReplaceRequirements(nodePool,
 		karpv1.NodeSelectorRequirementWithMinValues{
 			Key:      v1beta1.LabelSKUFamily,
@@ -40,7 +41,7 @@ func requireTrustedLaunchBoundaryInstanceType() {
 		karpv1.NodeSelectorRequirementWithMinValues{
 			Key:      v1beta1.LabelSKUStorageEphemeralOSMaxSize,
 			Operator: corev1.NodeSelectorOpIn,
-			Values:   []string{"50"},
+			Values:   []string{"53"},
 		},
 	)
 }

--- a/test/suites/nodeclaim/eph_osdisk_test.go
+++ b/test/suites/nodeclaim/eph_osdisk_test.go
@@ -29,8 +29,7 @@ import (
 
 func requireTrustedLaunchBoundaryInstanceType() {
 	GinkgoHelper()
-	// The maximum eligible Ephemeral OS placement is 50 GiB. The compatibility
-	// label reports that binary capacity as 53 decimal GB. Trusted Launch therefore
+	// The maximum eligible Ephemeral OS placement is 50 GiB. Trusted Launch
 	// makes a 50-GiB disk too large and leaves exactly enough room for 49 GiB.
 	test.ReplaceRequirements(nodePool,
 		karpv1.NodeSelectorRequirementWithMinValues{
@@ -40,7 +39,7 @@ func requireTrustedLaunchBoundaryInstanceType() {
 		karpv1.NodeSelectorRequirementWithMinValues{
 			Key:      v1beta1.LabelSKUStorageEphemeralOSMaxSize,
 			Operator: corev1.NodeSelectorOpIn,
-			Values:   []string{"53"},
+			Values:   []string{"50"},
 		},
 	)
 }


### PR DESCRIPTION
**Depends on:** https://github.com/Azure/karpenter-provider-azure/pull/1870

**Description**

Trusted Launch stores VM guest state on the selected local Ephemeral OS disk placement, reducing usable capacity by 1 GiB. The provider previously compared the requested OS disk with unreserved capacity and could send an invalid exact-boundary Ephemeral request.

This change adds one GiB to the required local capacity when either vTPM or Secure Boot is enabled, then continues through the eligible CacheDisk, ResourceDisk, and NVMe candidates. It does not blanket-disable Ephemeral disks: if an exact-fit Cache becomes too small but Resource has headroom, Resource remains eligible. Requested disk size and security settings are unchanged.

The requested disk and its fit requirement remain distinct:

```text
Machine/Compute disk size = requested D
required local capacity   = D + 1 GiB when Trusted Launch is enabled
```

Direct VM provisioning sends the selected placement. AKS Machine provisioning sends the resulting disk type because its public request model has no placement field; the service-side placement decision must apply the same usable-capacity rule.

The base PR preserves raw candidate capacity independently from its public label cap. This allows a 2,040-GiB disk to remain eligible when a placement has the required 2,041 GiB of raw capacity, while the requested disk remains within Compute's 2,040-GiB limit.

**How was this change tested?**

* New E2E failing in unfixed main: [aksscriptless](https://github.com/Azure/karpenter-provider-azure/actions/runs/33111354048/job/98654795067), [aksmachineapi](https://teams.microsoft.com/l/message/19:b94e67ab23e44a6c940de9b6ee149c95@thread.skype/1788223584897?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=e121dbfd-0ec1-40ea-8af5-26075f6a731b&parentMessageId=1787606392710&teamName=Azure%20Container%20Compute&channelName=Auto%20SIG%20-%20Karpenter&createdTime=1788223584897). Passing with the fix: [aksscriptless](https://github.com/Azure/karpenter-provider-azure/actions/runs/33254573822). [aksmachineapi](https://github.com/Azure/karpenter-provider-azure/actions/runs/33254580717/job/99145749240) is still failing as AKS-side fix is pending. Full-stack fix is tested internally and passing.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

**Release Note**

```release-note
Reserve Trusted Launch VM guest state before selecting an Ephemeral OS disk placement.
```
