### PR TITLE
fix: prevent Ginkgo CLI and library version drift

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -16,14 +16,26 @@ runs:
     # Root path permission workaround for caching https://github.com/actions/cache/issues/845#issuecomment-1252594999
     - run: sudo chown "$USER" /usr/local
       shell: bash
+    - id: tool-versions
+      shell: bash
+      run: |
+        set -euo pipefail
+        ginkgo_version="$(GOWORK=off go -C "$GITHUB_WORKSPACE" list -m -f '{{ .Version }}' github.com/onsi/ginkgo/v2)"
+        if [[ -z "$ginkgo_version" ]]; then
+          echo "resolved an empty Ginkgo version from $GITHUB_WORKSPACE/go.mod" >&2
+          exit 1
+        fi
+        go_bin="$("$GITHUB_WORKSPACE/hack/go-tool-path.sh")"
+        printf 'ginkgo=%s\n' "$ginkgo_version" >> "$GITHUB_OUTPUT"
+        printf 'go_bin=%s\n' "$go_bin" >> "$GITHUB_OUTPUT"
     - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: cache-toolchain
       with:
         path: |
           /usr/local/kubebuilder/bin
-          ~/go/bin
-        # Include runner.environment in key because ~/go/bin expands differently on github-hosted vs self-hosted runners
-        key: ${{ runner.os }}-${{ runner.environment }}-${{ inputs.k8sVersion }}-go-${{ steps.setup-go.outputs.go-version }}-toolchain-cache-${{ hashFiles('hack/toolchain.sh') }}
+          ${{ steps.tool-versions.outputs.go_bin }}
+        # Include runner.environment because the effective Go bin path differs across runner types.
+        key: ${{ runner.os }}-${{ runner.environment }}-${{ inputs.k8sVersion }}-go-${{ steps.setup-go.outputs.go-version }}-ginkgo-${{ steps.tool-versions.outputs.ginkgo }}-toolchain-cache-${{ hashFiles('hack/toolchain.sh', 'hack/go-tool-path.sh') }}
     - if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
       shell: bash
       env:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ include Makefile-az.mk
 LDFLAGS ?= -ldflags=-X=sigs.k8s.io/karpenter/pkg/operator.Version=$(shell git describe --tags --always | cut -d"v" -f2)
 
 GOFLAGS ?= $(LDFLAGS)
+GINKGO := $(shell ./hack/go-tool-path.sh ginkgo)
 
 # # CR for local builds of Karpenter
 KARPENTER_NAMESPACE ?= kube-system
@@ -34,7 +35,7 @@ ci-test: test coverage ## Runs tests and submits coverage
 ci-non-test: verify licenses vulncheck ## Runs checks other than tests
 
 test: ## Run tests
-	ginkgo -vv \
+	"$(GINKGO)" -vv \
 		-cover -coverprofile=coverage.out -output-dir=. -coverpkg=./pkg/... \
 		--focus="${FOCUS}" \
 		--randomize-all \
@@ -44,7 +45,7 @@ deflake: ## Run randomized, racing, code-covered tests to deflake failures
 	for i in $(shell seq 1 5); do make test || exit 1; done
 
 deflake-until-it-fails: ## Run randomized, racing tests until the test fails to catch flakes
-	ginkgo \
+	"$(GINKGO)" \
 		--race \
 		--focus="${FOCUS}" \
 		--randomize-all \
@@ -92,6 +93,7 @@ coverage:
 
 verify: tidy download ## Verify code. Includes dependencies, linting, formatting, etc
 	SKIP_INSTALLED=true make toolchain
+	hack/toolchain_test.sh
 	make az-swagger-generate-clients-raw
 	go generate ./...
 	hack/boilerplate.sh

--- a/hack/go-tool-path.sh
+++ b/hack/go-tool-path.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# > 1 )); then
+    echo "usage: $0 [tool-name]" >&2
+    exit 2
+fi
+
+tool_name="${1:-}"
+if [[ "$tool_name" == */* ]]; then
+    echo "tool name must not contain '/': $tool_name" >&2
+    exit 2
+fi
+
+go_bin=$(go env GOBIN)
+if [[ -z "$go_bin" ]]; then
+    go_path=$(go env GOPATH)
+    go_path=${go_path%%:*}
+    if [[ -z "$go_path" ]]; then
+        echo "go env GOPATH returned no paths" >&2
+        exit 1
+    fi
+    go_bin="$go_path/bin"
+fi
+
+if [[ -n "$tool_name" ]]; then
+    printf '%s/%s\n' "$go_bin" "$tool_name"
+else
+    printf '%s\n' "$go_bin"
+fi

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -7,18 +7,14 @@ KUBEBUILDER_ASSETS="/usr/local/kubebuilder/bin"
 # Default SKIP_INSTALLED to false if not set
 SKIP_INSTALLED="${SKIP_INSTALLED:=false}"
 
-# Find the path where this script is found
+# Find the repository and the effective directory used by go install.
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
-
-# Define go install will put things
-TOOL_DEST="$(go env GOPATH)/bin"
+REPO_ROOT=$(dirname "$SCRIPT_DIR")
+TOOL_DEST=$("$SCRIPT_DIR/go-tool-path.sh")
 
 if [ "$SKIP_INSTALLED" == true ]; then
     echo "[INF] Skipping tools already installed."
 fi
-
-# This is where go install will put things
-TOOL_DEST="$(go env GOPATH)/bin"
 
 main() {
     crosscompilers
@@ -54,6 +50,34 @@ go-install() {
     go install "$2"
 }
 
+# Ginkgo's CLI must match the library imported by this repository. Unlike other
+# tools, an existing binary is skipped only when its version matches go.mod.
+install-ginkgo() {
+    local module="github.com/onsi/ginkgo/v2"
+    local expected_version
+    if ! expected_version=$(GOWORK=off go -C "$REPO_ROOT" list -m -f '{{ .Version }}' "$module"); then
+        echo "failed to resolve Ginkgo version from $REPO_ROOT/go.mod" >&2
+        return 1
+    fi
+    if [[ -z "$expected_version" ]]; then
+        echo "resolved an empty Ginkgo version from $REPO_ROOT/go.mod" >&2
+        return 1
+    fi
+
+    if should-skip ginkgo; then
+        local installed_version
+        if ! installed_version=$("$TOOL_DEST/ginkgo" version 2>/dev/null | awk '$1 == "Ginkgo" && $2 == "Version" { print "v" $3; exit }'); then
+            installed_version=""
+        fi
+        if [[ "$installed_version" == "$expected_version" ]]; then
+            return
+        fi
+    fi
+
+    echo "[INF] Installing ginkgo $expected_version"
+    go install "$module/ginkgo@$expected_version"
+}
+
 crosscompilers() {
     # Install CGO cross-compilation toolchains for multi-arch builds
     if ! command -v aarch64-linux-gnu-gcc &> /dev/null || ! command -v x86_64-linux-gnu-gcc &> /dev/null; then
@@ -71,7 +95,7 @@ tools() {
     go-install cosign github.com/sigstore/cosign/v2/cmd/cosign@v2.4.1
 #   go install -tags extended github.com/gohugoio/hugo@v0.110.0
     go-install govulncheck golang.org/x/vuln/cmd/govulncheck@v1.1.4
-    go-install ginkgo github.com/onsi/ginkgo/v2/ginkgo@latest
+    install-ginkgo
     go-install actionlint github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
     go-install goveralls github.com/mattn/goveralls@v0.0.12
     go-install crane github.com/google/go-containerregistry/cmd/crane@v0.20.2

--- a/hack/toolchain_test.sh
+++ b/hack/toolchain_test.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+REPO_ROOT=$(dirname "$SCRIPT_DIR")
+TOOLCHAIN_SCRIPT="$SCRIPT_DIR/toolchain.sh"
+GO_TOOL_PATH_SCRIPT="$SCRIPT_DIR/go-tool-path.sh"
+ACTION_FILE="$REPO_ROOT/.github/actions/install-deps/action.yaml"
+MAKEFILE="$REPO_ROOT/Makefile"
+EXPECTED_GINKGO_VERSION="v9.8.7"
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+assert_call_count() {
+    local expected="$1"
+    local call="$2"
+    local calls_file="$3"
+    local actual
+    actual=$(grep -Fxc -- "$call" "$calls_file" || true)
+    [[ "$actual" == "$expected" ]] || fail "expected $expected calls to '$call', got $actual"
+}
+
+[[ -x "$GO_TOOL_PATH_SCRIPT" ]] || fail "missing executable $GO_TOOL_PATH_SCRIPT"
+
+write_fake_go() {
+    local path="$1"
+    cat > "$path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "$1" >> "$GO_CALLS"
+printf ' %s' "${@:2}" >> "$GO_CALLS"
+printf '\n' >> "$GO_CALLS"
+
+if [[ "$#" == 2 && "$1" == "env" && "$2" == "GOBIN" ]]; then
+    printf '%s\n' "$FAKE_GOBIN"
+elif [[ "$#" == 2 && "$1" == "env" && "$2" == "GOPATH" ]]; then
+    printf '%s\n' "$FAKE_GOPATH"
+elif [[ "$#" == 7 && "$1" == "-C" && "$2" == "$EXPECTED_REPO_ROOT" && "$3" == "list" && "$4" == "-m" && "$5" == "-f" && "$6" == "{{ .Version }}" && "$7" == "github.com/onsi/ginkgo/v2" ]]; then
+    [[ "${GOWORK:-}" == "off" ]] || exit 89
+    case "$LOOKUP_MODE" in
+        value) printf '%s\n' "$EXPECTED_GINKGO_VERSION" ;;
+        value-fail) printf '%s\n' "$EXPECTED_GINKGO_VERSION"; exit 42 ;;
+        empty) ;;
+        fail) exit 42 ;;
+        *) exit 90 ;;
+    esac
+elif [[ "$#" == 2 && "$1" == "install" && "$2" == "github.com/onsi/ginkgo/v2/ginkgo@$EXPECTED_GINKGO_VERSION" ]]; then
+    :
+else
+    printf 'unexpected go command: %q ' "$@" >&2
+    printf '\n' >&2
+    exit 88
+fi
+EOF
+    chmod +x "$path"
+}
+
+write_fake_ginkgo() {
+    local path="$1"
+    local installed_version="$2"
+    local exit_code="${3:-0}"
+    cat > "$path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "\$#" == 1 && "\$1" == "version" ]] || exit 87
+printf 'probe\n' >> "\$GINKGO_PROBES"
+printf 'Ginkgo Version ${installed_version}\n'
+exit ${exit_code}
+EOF
+    chmod +x "$path"
+}
+
+run_case() {
+    local name="$1"
+    local installed_version="$2"
+    local expected_install="$3"
+    local use_gobin="$4"
+    local resolved_version="${5:-$EXPECTED_GINKGO_VERSION}"
+    local case_dir="$TEMP_DIR/$name"
+    local gopath_one="$case_dir/gopath-one"
+    local gopath_two="$case_dir/gopath-two"
+    local fake_gobin=""
+    local tool_dir="$gopath_one/bin"
+    local go_calls="$case_dir/go-calls"
+    local ginkgo_probes="$case_dir/ginkgo-probes"
+
+    if [[ "$use_gobin" == "yes" ]]; then
+        fake_gobin="$case_dir/gobin"
+        tool_dir="$fake_gobin"
+    fi
+    mkdir -p "$case_dir/bin" "$tool_dir" "$gopath_one/bin" "$gopath_two/bin"
+    : > "$go_calls"
+    : > "$ginkgo_probes"
+    write_fake_go "$case_dir/bin/go"
+
+    # A PATH-shadowing binary must never be probed or executed by the toolchain.
+    cat > "$case_dir/bin/ginkgo" <<'EOF'
+#!/usr/bin/env bash
+exit 86
+EOF
+    chmod +x "$case_dir/bin/ginkgo"
+
+    if [[ "$installed_version" == "broken" ]]; then
+        write_fake_ginkgo "$tool_dir/ginkgo" "${resolved_version#v}" 1
+    elif [[ "$installed_version" != "missing" ]]; then
+        write_fake_ginkgo "$tool_dir/ginkgo" "$installed_version" 0
+    fi
+    if [[ "$use_gobin" == "yes" ]]; then
+        write_fake_ginkgo "$gopath_one/bin/ginkgo" "0.0.1"
+    fi
+
+    cp "$GO_TOOL_PATH_SCRIPT" "$case_dir/go-tool-path.sh"
+    grep -v '^main "\$@"$' "$TOOLCHAIN_SCRIPT" > "$case_dir/toolchain-library.sh"
+    (
+        export EXPECTED_GINKGO_VERSION="$resolved_version" EXPECTED_REPO_ROOT="$REPO_ROOT"
+        export FAKE_GOBIN="$fake_gobin" FAKE_GOPATH="$gopath_one:$gopath_two"
+        export GO_CALLS="$go_calls" GINKGO_PROBES="$ginkgo_probes" LOOKUP_MODE=value
+        export PATH="$case_dir/bin:$PATH" SKIP_INSTALLED=true
+        # shellcheck source=/dev/null
+        source "$case_dir/toolchain-library.sh"
+        [[ "$TOOL_DEST" == "$tool_dir" ]]
+        install-ginkgo
+    )
+
+    local expected_calls="env GOBIN"
+    if [[ "$use_gobin" != "yes" ]]; then
+        expected_calls+=$'\n'"env GOPATH"
+    fi
+    expected_calls+=$'\n'"-C $REPO_ROOT list -m -f {{ .Version }} github.com/onsi/ginkgo/v2"
+    if [[ "$expected_install" == "yes" ]]; then
+        expected_calls+=$'\n'"install github.com/onsi/ginkgo/v2/ginkgo@$resolved_version"
+    fi
+    [[ "$(<"$go_calls")" == "$expected_calls" ]] || fail "$name produced an unexpected or out-of-order Go call transcript"
+    if [[ "$installed_version" == "missing" ]]; then
+        [[ ! -s "$ginkgo_probes" ]] || fail "$name unexpectedly probed a missing binary"
+    else
+        [[ "$(wc -l < "$ginkgo_probes")" == 1 ]] || fail "$name did not probe exactly once"
+    fi
+
+    local install_call="install github.com/onsi/ginkgo/v2/ginkgo@$resolved_version"
+    if [[ "$expected_install" == "yes" ]]; then
+        assert_call_count 1 "$install_call" "$go_calls"
+    else
+        assert_call_count 0 "$install_call" "$go_calls"
+    fi
+}
+
+run_lookup_failure_case() {
+    local mode="$1"
+    local case_dir="$TEMP_DIR/lookup-$mode"
+    local gopath="$case_dir/gopath"
+    local go_calls="$case_dir/go-calls"
+    mkdir -p "$case_dir/bin" "$gopath/bin"
+    : > "$go_calls"
+    write_fake_go "$case_dir/bin/go"
+    cp "$GO_TOOL_PATH_SCRIPT" "$case_dir/go-tool-path.sh"
+    grep -v '^main "\$@"$' "$TOOLCHAIN_SCRIPT" > "$case_dir/toolchain-library.sh"
+
+    if (
+        export EXPECTED_GINKGO_VERSION EXPECTED_REPO_ROOT="$REPO_ROOT"
+        export FAKE_GOBIN="" FAKE_GOPATH="$gopath:$case_dir/other-gopath"
+        export GO_CALLS="$go_calls" GINKGO_PROBES="$case_dir/probes" LOOKUP_MODE="$mode"
+        export PATH="$case_dir/bin:$PATH" SKIP_INSTALLED=true
+        # shellcheck source=/dev/null
+        source "$case_dir/toolchain-library.sh"
+        install-ginkgo
+    ); then
+        fail "$mode Ginkgo module lookup unexpectedly succeeded"
+    fi
+    if grep -Fq 'install github.com/onsi/ginkgo/v2/ginkgo@' "$go_calls"; then
+        fail "$mode lookup attempted to install Ginkgo"
+    fi
+    local expected_calls=$'env GOBIN\nenv GOPATH\n'"-C $REPO_ROOT list -m -f {{ .Version }} github.com/onsi/ginkgo/v2"
+    [[ "$(<"$go_calls")" == "$expected_calls" ]] || fail "$mode lookup produced an unexpected Go call transcript"
+}
+
+run_case matching 9.8.7 no no v9.8.7
+run_case matching-alt 1.2.3 no no v1.2.3
+run_case mismatched 9.8.8 yes no v9.8.7
+run_case broken broken yes no v9.8.7
+run_case missing missing yes no v9.8.7
+run_case gobin-matching 9.8.7 no yes v9.8.7
+run_lookup_failure_case empty
+run_lookup_failure_case fail
+run_lookup_failure_case value-fail
+
+# Make must execute the same absolute Ginkgo path that the installer manages.
+grep -Fq 'GINKGO := $(shell ./hack/go-tool-path.sh ginkgo)' "$MAKEFILE" || fail "Makefile must ignore ambient GINKGO values"
+[[ "$(grep -Fc $'\t"$(GINKGO)"' "$MAKEFILE")" == 2 ]] || fail "Makefile must invoke the quoted \$(GINKGO) path exactly twice"
+managed_ginkgo=$("$GO_TOOL_PATH_SCRIPT" ginkgo)
+GINKGO=ginkgo make -s -C "$REPO_ROOT" --dry-run test | grep -Fq "\"$managed_ginkgo\" -vv" || fail "ambient GINKGO shadows the managed path"
+make -s -C "$REPO_ROOT" GINKGO=/tmp/explicit-ginkgo --dry-run test | grep -Fq '"/tmp/explicit-ginkgo" -vv' || fail "explicit Make override no longer works"
+if grep -Eq $'^\t+ginkgo([[:space:]]|$)' "$MAKEFILE"; then
+    fail "Makefile still invokes a PATH-selected ginkgo binary"
+fi
+
+# Validate the composite action structurally, including producer-before-consumer ordering.
+yq eval '.' "$ACTION_FILE" >/dev/null
+tool_versions_count=$(yq eval '[.runs.steps[] | select(.id == "tool-versions")] | length' "$ACTION_FILE")
+cache_count=$(yq eval '[.runs.steps[] | select(.id == "cache-toolchain")] | length' "$ACTION_FILE")
+[[ "$tool_versions_count" == 1 && "$cache_count" == 1 ]] || fail "expected one tool-versions and one cache-toolchain step"
+tool_versions_index=$(yq eval '.runs.steps | to_entries | map(select(.value.id == "tool-versions")) | .[0].key' "$ACTION_FILE")
+cache_index=$(yq eval '.runs.steps | to_entries | map(select(.value.id == "cache-toolchain")) | .[0].key' "$ACTION_FILE")
+(( tool_versions_index < cache_index )) || fail "tool-versions must run before cache-toolchain"
+cache_key=$(yq eval '.runs.steps[] | select(.id == "cache-toolchain") | .with.key' "$ACTION_FILE")
+expected_cache_key="\${{ runner.os }}-\${{ runner.environment }}-\${{ inputs.k8sVersion }}-go-\${{ steps.setup-go.outputs.go-version }}-ginkgo-\${{ steps.tool-versions.outputs.ginkgo }}-toolchain-cache-\${{ hashFiles('hack/toolchain.sh', 'hack/go-tool-path.sh') }}"
+[[ "$cache_key" == "$expected_cache_key" ]] || fail "cache key differs from the exact Ginkgo-scoped key"
+cache_paths=$(yq eval '.runs.steps[] | select(.id == "cache-toolchain") | .with.path' "$ACTION_FILE")
+[[ "$cache_paths" == *'${{ steps.tool-versions.outputs.go_bin }}'* ]] || fail "cache does not use the effective Go bin directory"
+producer_script=$(yq eval '.runs.steps[] | select(.id == "tool-versions") | .run' "$ACTION_FILE")
+printf '%s\n' "$producer_script" > "$TEMP_DIR/resolve-action-version.sh"
+
+run_action_lookup() {
+    local mode="$1"
+    local expected_version="$2"
+    local case_dir="$TEMP_DIR/action-$mode-${expected_version//./-}"
+    mkdir -p "$case_dir/bin"
+    cat > "$case_dir/bin/go" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$#" == 7 && "$1" == "-C" && "$2" == "$GITHUB_WORKSPACE" && "$3" == "list" && "$4" == "-m" && "$5" == "-f" && "$6" == "{{ .Version }}" && "$7" == "github.com/onsi/ginkgo/v2" ]]; then
+    [[ "${GOWORK:-}" == "off" ]] || exit 89
+    case "$ACTION_LOOKUP_MODE" in
+        value) printf '%s\n' "$ACTION_EXPECTED_VERSION" ;;
+        value-fail) printf '%s\n' "$ACTION_EXPECTED_VERSION"; exit 42 ;;
+        empty) ;;
+        fail) exit 42 ;;
+        *) exit 90 ;;
+    esac
+elif [[ "$#" == 2 && "$1" == "env" && "$2" == "GOBIN" ]]; then
+    printf '%s\n' "$ACTION_FAKE_GOBIN"
+elif [[ "$#" == 2 && "$1" == "env" && "$2" == "GOPATH" ]]; then
+    printf '%s\n' "$ACTION_FAKE_GOPATH"
+else
+    exit 88
+fi
+EOF
+    chmod +x "$case_dir/bin/go"
+    : > "$case_dir/output"
+
+    if PATH="$case_dir/bin:$PATH" GITHUB_WORKSPACE="$REPO_ROOT" GITHUB_OUTPUT="$case_dir/output" ACTION_LOOKUP_MODE="$mode" \
+        ACTION_EXPECTED_VERSION="$expected_version" ACTION_FAKE_GOBIN="$case_dir/gobin" ACTION_FAKE_GOPATH="$case_dir/gopath-one:$case_dir/gopath-two" \
+        bash -e -o pipefail "$TEMP_DIR/resolve-action-version.sh"; then
+        [[ "$mode" == value ]] || fail "action $mode lookup unexpectedly succeeded"
+        [[ "$(<"$case_dir/output")" == "ginkgo=$expected_version"$'\n'"go_bin=$case_dir/gobin" ]] || fail "action emitted wrong tool outputs"
+    else
+        [[ "$mode" != value ]] || fail "action value lookup unexpectedly failed"
+        [[ ! -s "$case_dir/output" ]] || fail "action $mode lookup emitted a cache-key value"
+    fi
+}
+
+run_action_lookup value v9.8.7
+run_action_lookup value v1.2.3
+run_action_lookup empty v9.8.7
+run_action_lookup fail v9.8.7
+run_action_lookup value-fail v9.8.7


### PR DESCRIPTION
(AI-generated)

**Description**

The developer toolchain installed the Ginkgo CLI from `@latest` even though `go.mod` pins the imported Ginkgo library. A newer CLI could therefore be cached and executed against an older library.

This change resolves the required CLI version from this repository's `go.mod`, repairs missing, broken, or mismatched binaries even when installed tools are otherwise skipped, and makes test targets execute the same absolute binary that `go install` manages. The tool cache is keyed by that resolved Ginkgo version and the scripts that determine its path.

**How was this change tested?**

* Added shell regressions for matching, mismatched, broken, missing, `GOBIN`, multi-entry `GOPATH`, PATH shadowing, workspace overrides, failed/empty lookups, action output propagation, and cache ordering/key construction.
* Reproduced and repaired a real CLI `v2.32.1` versus library `v2.32.0` mismatch.
* Adversarial review killed 26/26 implementation and test mutations.
* `make verify`
* `make test` — 39 suites passed in `11m47.831645903s`.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

**Release Note**

```release-note
NONE
```
