### PR TITLE
fix: prevent unsafe setup-envtest asset links

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 K8S_VERSION="${K8S_VERSION:="1.29.x"}"
-KUBEBUILDER_ASSETS="/usr/local/kubebuilder/bin"
+KUBEBUILDER_ASSETS="${KUBEBUILDER_ASSETS:=/usr/local/kubebuilder/bin}"
+SETUP_ENVTEST_BIN="${SETUP_ENVTEST_BIN:=/usr/local/bin/setup-envtest}"
 
 # Default SKIP_INSTALLED to false if not set
 SKIP_INSTALLED="${SKIP_INSTALLED:=false}"
@@ -118,24 +119,118 @@ tools() {
     fi
 }
 
+link-kubebuilder-assets() {
+    local arch="$1"
+    local asset_dir
+    if ! asset_dir=$("$SETUP_ENVTEST_BIN" use -p path "$K8S_VERSION" --arch="$arch" --bin-dir="$KUBEBUILDER_ASSETS"); then
+        echo "setup-envtest failed to resolve Kubernetes $K8S_VERSION assets" >&2
+        return 1
+    fi
+    if [[ -z "$asset_dir" || "$asset_dir" != /* || "$asset_dir" == "/" || ! -d "$asset_dir" ]]; then
+        echo "setup-envtest returned an invalid asset directory: ${asset_dir:-<empty>}" >&2
+        return 1
+    fi
+    if [[ ! -d "$KUBEBUILDER_ASSETS" ]]; then
+        echo "kubebuilder asset destination does not exist: $KUBEBUILDER_ASSETS" >&2
+        return 1
+    fi
+
+    local -a required_binaries=(kube-apiserver kubectl etcd)
+    local -a destinations=()
+    local -a old_targets=()
+    local -a old_exists=()
+    local binary source destination
+    for binary in "${required_binaries[@]}"; do
+        source="$asset_dir/$binary"
+        destination="$KUBEBUILDER_ASSETS/$binary"
+        if [[ ! -f "$source" || ! -x "$source" ]]; then
+            echo "setup-envtest asset is missing regular executable $binary: $source" >&2
+            return 1
+        fi
+        if [[ -e "$destination" && ! -L "$destination" ]]; then
+            echo "refusing to replace non-symlink kubebuilder asset: $destination" >&2
+            return 1
+        fi
+        if [[ -L "$destination" && -d "$destination" ]]; then
+            echo "refusing to replace symlink to directory: $destination" >&2
+            return 1
+        fi
+        destinations+=("$destination")
+        if [[ -L "$destination" ]]; then
+            old_targets+=("$(readlink "$destination")")
+            old_exists+=(1)
+        else
+            old_targets+=("")
+            old_exists+=(0)
+        fi
+    done
+
+    local i j
+    for i in "${!required_binaries[@]}"; do
+        source="$asset_dir/${required_binaries[$i]}"
+        destination="${destinations[$i]}"
+        if ! ln -sfnT -- "$source" "$destination"; then
+            echo "failed to link kubebuilder asset: $destination" >&2
+            for ((j = 0; j <= i; j++)); do
+                if [[ "${old_exists[$j]}" == 1 ]]; then
+                    ln -sfnT -- "${old_targets[$j]}" "${destinations[$j]}" || \
+                        echo "failed to roll back kubebuilder asset: ${destinations[$j]}" >&2
+                else
+                    rm -f -- "${destinations[$j]}"
+                fi
+            done
+            return 1
+        fi
+    done
+}
+
+install-setup-envtest() {
+    local os="$1"
+    local arch="$2"
+    local download
+    download=$(mktemp)
+    if ! sudo curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --retry-all-errors \
+        --retry-max-time 180 --connect-timeout 20 --max-time 120 \
+        "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.22.3/setup-envtest-${os}-${arch}" \
+        --output "$download"; then
+        rm -f -- "$download"
+        return 1
+    fi
+    local install_dir staged
+    install_dir=$(dirname "$SETUP_ENVTEST_BIN")
+    if ! staged=$(sudo mktemp "$install_dir/.setup-envtest.XXXXXX"); then
+        rm -f -- "$download"
+        return 1
+    fi
+    if ! sudo install -m 0755 "$download" "$staged"; then
+        rm -f -- "$download"
+        sudo rm -f -- "$staged"
+        return 1
+    fi
+    if ! sudo mv -fT -- "$staged" "$SETUP_ENVTEST_BIN"; then
+        rm -f -- "$download"
+        sudo rm -f -- "$staged"
+        return 1
+    fi
+    rm -f -- "$download"
+}
+
 kubebuilder() {
     echo "[INF] Setting up kubebuilder binaries for Kubernetes ${K8S_VERSION}"
     sudo mkdir -p "${KUBEBUILDER_ASSETS}"
     sudo chown "${USER}" "${KUBEBUILDER_ASSETS}"
     arch=$(go env GOARCH)
     os=$(go env GOOS)
-    sudo curl -sL "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.22.3/setup-envtest-${os}-${arch}" --output /usr/local/bin/setup-envtest
-    sudo chmod +x /usr/local/bin/setup-envtest
-
-    ln -sf "$(setup-envtest use -p path "${K8S_VERSION}" --arch="${arch}" --bin-dir="${KUBEBUILDER_ASSETS}")"/* "${KUBEBUILDER_ASSETS}"
-    find "$KUBEBUILDER_ASSETS"
+    install-setup-envtest "$os" "$arch"
+    link-kubebuilder-assets "$arch"
+    find "$KUBEBUILDER_ASSETS" -maxdepth 2
 
     # Install latest binaries for 1.25.x (contains CEL fix)
     if [[ "${K8S_VERSION}" = "1.25.x" ]] && [[ "$OSTYPE" == "linux"* ]]; then
         for binary in 'kube-apiserver' 'kubectl'; do
-            rm $KUBEBUILDER_ASSETS/$binary
-            wget -P $KUBEBUILDER_ASSETS https://dl.k8s.io/v1.25.16/bin/linux/"${arch}"/${binary}
-            chmod +x $KUBEBUILDER_ASSETS/$binary
+            rm -- "$KUBEBUILDER_ASSETS/$binary"
+            wget -P "$KUBEBUILDER_ASSETS" "https://dl.k8s.io/v1.25.16/bin/linux/${arch}/${binary}"
+            chmod +x "$KUBEBUILDER_ASSETS/$binary"
         done
     fi
 }

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -189,7 +189,7 @@ install-setup-envtest() {
     local arch="$2"
     local download
     download=$(mktemp)
-    if ! sudo curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --retry-all-errors \
+    if ! curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --retry-all-errors \
         --retry-max-time 180 --connect-timeout 20 --max-time 120 \
         "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.22.3/setup-envtest-${os}-${arch}" \
         --output "$download"; then

--- a/hack/toolchain_test.sh
+++ b/hack/toolchain_test.sh
@@ -259,3 +259,250 @@ run_action_lookup value v1.2.3
 run_action_lookup empty v9.8.7
 run_action_lookup fail v9.8.7
 run_action_lookup value-fail v9.8.7
+
+run_kubebuilder_asset_case() {
+    local mode="$1"
+    local expected_result="$2"
+    local case_dir="$TEMP_DIR/kubebuilder-$mode"
+    local source_dir="$case_dir/source dir"
+    local target_dir="$case_dir/target"
+    local call_record="$case_dir/setup-envtest-call"
+    local error_record="$case_dir/error"
+    mkdir -p "$case_dir/bin" "$source_dir" "$target_dir"
+
+    case "$mode" in
+        valid|missing-binary|directory-binary|destination-directory|destination-symlink-directory|link-failure|output-fail)
+            for binary in kube-apiserver kubectl etcd; do
+                if [[ "$mode" == "missing-binary" && "$binary" == "etcd" ]]; then
+                    continue
+                fi
+                printf '#!/usr/bin/env bash\nexit 0\n' > "$source_dir/$binary"
+                chmod +x "$source_dir/$binary"
+            done
+            ;;
+    esac
+    if [[ "$mode" == "directory-binary" ]]; then
+        rm "$source_dir/etcd"
+        mkdir "$source_dir/etcd"
+    elif [[ "$mode" == "destination-directory" ]]; then
+        mkdir "$target_dir/kubectl"
+    elif [[ "$mode" == "destination-symlink-directory" ]]; then
+        mkdir "$case_dir/collision-dir"
+        ln -s "$case_dir/collision-dir" "$target_dir/kubectl"
+    elif [[ "$mode" == "link-failure" ]]; then
+        mkdir "$case_dir/old-assets"
+        for binary in kube-apiserver kubectl etcd; do
+            printf 'old-%s\n' "$binary" > "$case_dir/old-assets/$binary"
+            ln -s "$case_dir/old-assets/$binary" "$target_dir/$binary"
+        done
+        cat > "$case_dir/bin/ln" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+count=0
+[[ -f "$LN_CALL_COUNT" ]] && count=$(<"$LN_CALL_COUNT")
+count=$((count + 1))
+printf '%s\n' "$count" > "$LN_CALL_COUNT"
+if [[ "$count" == 2 ]]; then
+    exit 73
+fi
+exec /usr/bin/ln "$@"
+EOF
+        chmod +x "$case_dir/bin/ln"
+    fi
+
+    cat > "$case_dir/bin/setup-envtest" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$SETUP_ENVTEST_CALL"
+case "$SETUP_ENVTEST_MODE" in
+    valid|missing-binary|directory-binary|destination-directory|destination-symlink-directory|link-failure) printf '%s\n' "$SETUP_ENVTEST_SOURCE" ;;
+    output-fail) printf '%s\n' "$SETUP_ENVTEST_SOURCE"; exit 42 ;;
+    empty) ;;
+    fail) exit 42 ;;
+    non-directory) printf '%s\n' "$SETUP_ENVTEST_SOURCE/not-a-directory" ;;
+    root) printf '/\n' ;;
+    *) exit 90 ;;
+esac
+EOF
+    chmod +x "$case_dir/bin/setup-envtest"
+    grep -v '^main "\$@"$' "$TOOLCHAIN_SCRIPT" > "$case_dir/toolchain-library.sh"
+    before_links=$(find "$target_dir" -maxdepth 1 -type l -printf '%f -> %l\n' | sort)
+
+    if (
+        export KUBEBUILDER_ASSETS="$target_dir" K8S_VERSION="1.29.x"
+        export SETUP_ENVTEST_BIN="$case_dir/bin/setup-envtest"
+        export SETUP_ENVTEST_CALL="$call_record" SETUP_ENVTEST_MODE="$mode" SETUP_ENVTEST_SOURCE="$source_dir"
+        export LN_CALL_COUNT="$case_dir/ln-count" PATH="$case_dir/bin:$PATH"
+        # shellcheck source=/dev/null
+        source "$case_dir/toolchain-library.sh"
+        link-kubebuilder-assets amd64
+    ) 2>"$error_record"; then
+        [[ "$expected_result" == "success" ]] || fail "$mode setup-envtest unexpectedly succeeded"
+    else
+        [[ "$expected_result" == "failure" ]] || fail "$mode setup-envtest unexpectedly failed"
+    fi
+
+    expected_call=$'use\n-p\npath\n1.29.x\n--arch=amd64\n'"--bin-dir=$target_dir"
+    [[ "$(<"$call_record")" == "$expected_call" ]] || fail "$mode used unexpected setup-envtest argument boundaries"
+    after_links=$(find "$target_dir" -maxdepth 1 -type l -printf '%f -> %l\n' | sort)
+    if [[ "$expected_result" == "success" ]]; then
+        [[ "$(printf '%s\n' "$after_links" | grep -c -- ' -> ')" == 3 ]] || fail "$mode did not create exactly 3 symlinks"
+        for binary in kube-apiserver kubectl etcd; do
+            [[ "$(readlink "$target_dir/$binary")" == "$source_dir/$binary" ]] || fail "$mode linked $binary to the wrong target"
+        done
+    else
+        [[ "$after_links" == "$before_links" ]] || fail "$mode changed destination links after failure"
+    fi
+    if [[ "$mode" == "root" ]]; then
+        grep -Fq 'invalid asset directory: /' "$error_record" || fail "root path was rejected only incidentally"
+    fi
+}
+
+run_kubebuilder_asset_case valid success
+run_kubebuilder_asset_case empty failure
+run_kubebuilder_asset_case fail failure
+run_kubebuilder_asset_case output-fail failure
+run_kubebuilder_asset_case non-directory failure
+run_kubebuilder_asset_case root failure
+run_kubebuilder_asset_case missing-binary failure
+run_kubebuilder_asset_case directory-binary failure
+run_kubebuilder_asset_case destination-directory failure
+run_kubebuilder_asset_case destination-symlink-directory failure
+run_kubebuilder_asset_case link-failure failure
+
+write_fake_curl() {
+    local path="$1"
+    cat > "$path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$CURL_CALLS"
+output=""
+while (( $# )); do
+    if [[ "$1" == "--output" ]]; then
+        output="$2"
+        break
+    fi
+    shift
+done
+[[ -n "$output" ]] || exit 88
+if [[ "$CURL_MODE" == "success" ]]; then
+    cat > "$output" <<'SCRIPT'
+#!/usr/bin/env bash
+if [[ -n "${SETUP_ENVTEST_CALL:-}" ]]; then
+    printf '%s\n' "$@" > "$SETUP_ENVTEST_CALL"
+fi
+printf '%s\n' "$SETUP_ENVTEST_SOURCE"
+SCRIPT
+else
+    printf 'partial' > "$output"
+    exit 18
+fi
+EOF
+    chmod +x "$path"
+}
+
+run_setup_envtest_download_case() {
+    local mode="$1"
+    local case_dir="$TEMP_DIR/setup-download-$mode"
+    local destination="$case_dir/existing-setup-envtest"
+    local calls="$case_dir/curl-calls"
+    mkdir -p "$case_dir/bin"
+    printf 'sentinel' > "$destination"
+    cat > "$case_dir/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+    chmod +x "$case_dir/bin/sudo"
+    if [[ "$mode" == "install-failure" ]]; then
+        cat > "$case_dir/bin/install" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+destination=${!#}
+printf 'partial-install' > "$destination"
+exit 153
+EOF
+        chmod +x "$case_dir/bin/install"
+    fi
+    write_fake_curl "$case_dir/bin/curl"
+    grep -v '^main "\$@"$' "$TOOLCHAIN_SCRIPT" > "$case_dir/toolchain-library.sh"
+
+    if (
+        export SETUP_ENVTEST_BIN="$destination" CURL_CALLS="$calls"
+        [[ "$mode" == "failure" ]] && export CURL_MODE=failure || export CURL_MODE=success
+        export PATH="$case_dir/bin:$PATH"
+        # shellcheck source=/dev/null
+        source "$case_dir/toolchain-library.sh"
+        install-setup-envtest linux amd64
+    ); then
+        [[ "$mode" == "success" ]] || fail "$mode setup-envtest installation unexpectedly succeeded"
+    else
+        [[ "$mode" != "success" ]] || fail "setup-envtest download unexpectedly failed"
+    fi
+
+    mapfile -t curl_args < "$calls"
+    expected_prefix=(
+        --fail --silent --show-error --location --retry 3 --retry-delay 2 --retry-all-errors
+        --retry-max-time 180 --connect-timeout 20 --max-time 120
+        https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.22.3/setup-envtest-linux-amd64
+        --output
+    )
+    [[ "${#curl_args[@]}" == $((${#expected_prefix[@]} + 1)) ]] || fail "curl received an unexpected argument count"
+    for i in "${!expected_prefix[@]}"; do
+        [[ "${curl_args[$i]}" == "${expected_prefix[$i]}" ]] || fail "curl argument $i differs: ${curl_args[$i]}"
+    done
+    temp_download=${curl_args[$((${#curl_args[@]} - 1))]}
+    [[ "$temp_download" != "$destination" && ! -e "$temp_download" ]] || fail "temporary setup-envtest download was not cleaned"
+    if [[ "$mode" == "success" ]]; then
+        [[ -x "$destination" && "$(<"$destination")" != "sentinel" ]] || fail "successful setup-envtest download was not installed"
+    else
+        [[ "$(<"$destination")" == "sentinel" ]] || fail "$mode replaced the existing setup-envtest"
+    fi
+    [[ -z "$(find "$case_dir" -maxdepth 1 -name '.setup-envtest.*' -print -quit)" ]] || fail "$mode left a staged setup-envtest file"
+}
+
+run_setup_envtest_download_case success
+run_setup_envtest_download_case failure
+run_setup_envtest_download_case install-failure
+
+run_kubebuilder_125_path_case() {
+    local case_dir="$TEMP_DIR/kubebuilder-125"
+    local source_dir="$case_dir/source"
+    local target_dir="$case_dir/target dir"
+    mkdir -p "$case_dir/bin" "$source_dir" "$target_dir"
+    for binary in kube-apiserver kubectl etcd; do
+        printf '#!/usr/bin/env bash\nexit 0\n' > "$source_dir/$binary"
+        chmod +x "$source_dir/$binary"
+    done
+    cat > "$case_dir/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+    cat > "$case_dir/bin/wget" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$#" == 3 && "$1" == "-P" ]] || exit 88
+name=${3##*/}
+printf '#!/usr/bin/env bash\nexit 0\n' > "$2/$name"
+EOF
+    chmod +x "$case_dir/bin/sudo" "$case_dir/bin/wget"
+    export SETUP_ENVTEST_SOURCE="$source_dir" SETUP_ENVTEST_CALL="$case_dir/setup-envtest-call"
+    export CURL_CALLS="$case_dir/curl-calls" CURL_MODE=success
+    write_fake_curl "$case_dir/bin/curl"
+    grep -v '^main "\$@"$' "$TOOLCHAIN_SCRIPT" > "$case_dir/toolchain-library.sh"
+    (
+        export KUBEBUILDER_ASSETS="$target_dir" K8S_VERSION="1.25.x"
+        export SETUP_ENVTEST_BIN="$case_dir/installed-setup-envtest"
+        export PATH="$case_dir/bin:$PATH"
+        # shellcheck source=/dev/null
+        source "$case_dir/toolchain-library.sh"
+        kubebuilder
+    ) >/dev/null
+    expected_arch=$(go env GOARCH)
+    expected_call=$'use\n-p\npath\n1.25.x\n'"--arch=$expected_arch"$'\n'"--bin-dir=$target_dir"
+    [[ "$(<"$SETUP_ENVTEST_CALL")" == "$expected_call" ]] || fail "1.25 setup-envtest arguments split the spaced path"
+    [[ -f "$target_dir/kube-apiserver" && -x "$target_dir/kube-apiserver" ]] || fail "1.25 kube-apiserver replacement failed with spaced path"
+    [[ -f "$target_dir/kubectl" && -x "$target_dir/kubectl" ]] || fail "1.25 kubectl replacement failed with spaced path"
+    [[ -L "$target_dir/etcd" ]] || fail "1.25 etcd setup was lost"
+}
+
+run_kubebuilder_125_path_case

--- a/hack/toolchain_test.sh
+++ b/hack/toolchain_test.sh
@@ -463,6 +463,9 @@ EOF
 run_setup_envtest_download_case success
 run_setup_envtest_download_case failure
 run_setup_envtest_download_case install-failure
+if grep -Fq 'sudo curl' "$TOOLCHAIN_SCRIPT"; then
+    fail "setup-envtest download must run as the user that owns the temporary file"
+fi
 
 run_kubebuilder_125_path_case() {
     local case_dir="$TEMP_DIR/kubebuilder-125"


### PR DESCRIPTION
(AI-generated)

**Description**

The toolchain interpolated `setup-envtest use -p path` directly into a glob. If resolution failed or returned an empty path, the glob could expand from `/` and link unrelated host entries into the kubebuilder asset directory.

This change preserves the pinned setup-envtest version while validating the resolved directory and all three required binaries before mutation. Link replacement is preflighted and rolled back on failure. The resolver download now uses bounded retries as the temporary-file owner, stages installation outside the live path, and atomically replaces the installed binary only after a complete download.

This PR is stacked on https://github.com/Azure/karpenter-provider-azure/pull/1872 because both changes share the toolchain regression harness.

**How was this change tested?**

* Added valid, empty, output-then-fail, command-fail, root, non-directory, missing-binary, directory-as-binary, destination-collision, and injected-link-failure cases.
* Added partial-download and partial-install preservation checks, exact pinned curl arguments, rollback of existing links, and a spaced-path Kubernetes 1.25 compatibility case.
* Reproduced the 1ES `curl: (23)` failure caused by privileged curl writing a user-owned temporary file and added a regression forbidding that ownership mismatch.
* `make verify`
* Verified the real asset directory contains only `kube-apiserver`, `kubectl`, and `etcd` links to the versioned Kubernetes 1.29.5 directory.
* The stacked head containing this commit passed 39 presubmit suites in `15m41.305127638s` with 68.8% composite coverage.
* The same head passed CI and all seven Kubernetes-version jobs: https://github.com/Azure/karpenter-provider-azure/actions/runs/32992074192 and https://github.com/Azure/karpenter-provider-azure/actions/runs/32992077215.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

**Release Note**

```release-note
NONE
```
