### PR TITLE
fix: isolate golangci-lint formatter state per worktree

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
   rev: v2.8.0
   hooks:
   - id: golangci-lint
-    entry: golangci-lint-custom run --new-from-rev HEAD --fix
+    entry: ./hack/golangci-lint.sh run --new-from-rev HEAD --fix
 - repo: https://github.com/jumanjihouse/pre-commit-hooks
   rev: 3.0.0
   hooks:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,15 @@ LDFLAGS ?= -ldflags=-X=sigs.k8s.io/karpenter/pkg/operator.Version=$(shell git de
 GOFLAGS ?= $(LDFLAGS)
 GINKGO := $(shell ./hack/go-tool-path.sh ginkgo)
 
+ifeq ($(origin GOLANGCI_LINT_CACHE),command line)
+override GOLANGCI_LINT_CACHE := $(value GOLANGCI_LINT_CACHE)
+export GOLANGCI_LINT_CACHE
+override GOLANGCI_LINT_CACHE_FLAG := --use-env-cache
+else
+unexport GOLANGCI_LINT_CACHE
+override GOLANGCI_LINT_CACHE_FLAG :=
+endif
+
 # # CR for local builds of Karpenter
 KARPENTER_NAMESPACE ?= kube-system
 
@@ -33,6 +42,9 @@ presubmit: verify test ## Run all steps in the developer loop
 ci-test: test coverage ## Runs tests and submits coverage
 
 ci-non-test: verify licenses vulncheck ## Runs checks other than tests
+
+lint: ## Run linters
+	./hack/golangci-lint.sh $(GOLANGCI_LINT_CACHE_FLAG) --all-modules run
 
 test: ## Run tests
 	"$(GINKGO)" -vv \
@@ -104,7 +116,7 @@ verify: tidy download ## Verify code. Includes dependencies, linting, formatting
 	hack/mutation/kubectl_get_ux.sh
 	cp $(addprefix pkg/apis/crds/,$(SUPPORTED_CRDS)) charts/karpenter-crd/templates
 	hack/github/dependabot.sh
-	$(foreach dir,$(MOD_DIRS),cd $(dir) && golangci-lint-custom run $(newline))
+	./hack/golangci-lint.sh $(GOLANGCI_LINT_CACHE_FLAG) --all-modules run
 	@git diff --quiet ||\
 		{ echo "New file modification detected in the Git working tree. Please check in before commit."; git --no-pager diff --name-only | uniq | awk '{print "  - " $$0}'; \
 		if [ "${CI}" = true ]; then\
@@ -157,7 +169,7 @@ tidy: ## Recursively "go mod tidy" on all directories where go.mod exists
 download: ## Recursively "go mod download" on all directories where go.mod exists
 	$(foreach dir,$(MOD_DIRS),cd $(dir) && go mod download $(newline))
 
-.PHONY: help presubmit ci-test ci-non-test test deflake deflake-until-it-fails e2etests upstream-e2etests coverage verify vulncheck licenses codegen codegen-pricing codegen-locations codegen-skugen codegen-allazureskus snapshot release toolchain tidy download
+.PHONY: help presubmit ci-test ci-non-test lint test deflake deflake-until-it-fails e2etests upstream-e2etests coverage verify vulncheck licenses codegen codegen-pricing codegen-locations codegen-skugen codegen-allazureskus snapshot release toolchain tidy download
 
 define newline
 

--- a/hack/golangci-cache-path.sh
+++ b/hack/golangci-cache-path.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 0 )); then
+    echo "usage: $0" >&2
+    exit 2
+fi
+
+git_dir=$(git rev-parse --absolute-git-dir)
+if [[ -z "$git_dir" || ! -d "$git_dir" ]]; then
+    echo "unable to resolve an absolute Git directory" >&2
+    exit 1
+fi
+printf '%s/golangci-lint-cache\n' "$git_dir"

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+REPO_ROOT=$(dirname "$SCRIPT_DIR")
+use_env_cache=false
+all_modules=false
+while (( $# )); do
+    case "$1" in
+        --use-env-cache)
+            use_env_cache=true
+            shift
+            ;;
+        --all-modules)
+            all_modules=true
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [[ "$use_env_cache" == true ]]; then
+    cache="${GOLANGCI_LINT_CACHE:-}"
+else
+    cache=$(cd "$REPO_ROOT" && "$SCRIPT_DIR/golangci-cache-path.sh")
+fi
+if [[ -z "$cache" || "$cache" != /* ]]; then
+    echo "unable to resolve an absolute golangci-lint cache path" >&2
+    exit 1
+fi
+export GOLANGCI_LINT_CACHE="$cache"
+
+if [[ "$all_modules" == false ]]; then
+    cd "$REPO_ROOT"
+    exec golangci-lint-custom "$@"
+fi
+
+mapfile -d '' module_files < <(
+    find "$REPO_ROOT" \
+        -path "$REPO_ROOT/test" -prune -o \
+        -name go.mod -type f -print0 | sort -z
+)
+if (( ${#module_files[@]} == 0 )); then
+    echo "no Go modules found under $REPO_ROOT" >&2
+    exit 1
+fi
+for go_mod in "${module_files[@]}"; do
+    module_dir=$(dirname "$go_mod")
+    if (cd "$module_dir" && golangci-lint-custom "$@"); then
+        continue
+    else
+        exit_code=$?
+        exit "$exit_code"
+    fi
+done

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -189,7 +189,7 @@ install-setup-envtest() {
     local arch="$2"
     local download
     download=$(mktemp)
-    if ! sudo curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --retry-all-errors \
+    if ! curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --retry-all-errors \
         --retry-max-time 180 --connect-timeout 20 --max-time 120 \
         "https://github.com/kubernetes-sigs/controller-runtime/releases/download/v0.22.3/setup-envtest-${os}-${arch}" \
         --output "$download"; then

--- a/hack/toolchain_test.sh
+++ b/hack/toolchain_test.sh
@@ -5,8 +5,11 @@ SCRIPT_DIR=$(dirname "$(realpath "$0")")
 REPO_ROOT=$(dirname "$SCRIPT_DIR")
 TOOLCHAIN_SCRIPT="$SCRIPT_DIR/toolchain.sh"
 GO_TOOL_PATH_SCRIPT="$SCRIPT_DIR/go-tool-path.sh"
+GOLANGCI_CACHE_PATH_SCRIPT="$SCRIPT_DIR/golangci-cache-path.sh"
+GOLANGCI_LINT_SCRIPT="$SCRIPT_DIR/golangci-lint.sh"
 ACTION_FILE="$REPO_ROOT/.github/actions/install-deps/action.yaml"
 MAKEFILE="$REPO_ROOT/Makefile"
+PRECOMMIT_FILE="$REPO_ROOT/.pre-commit-config.yaml"
 EXPECTED_GINKGO_VERSION="v9.8.7"
 TEMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TEMP_DIR"' EXIT
@@ -506,3 +509,107 @@ EOF
 }
 
 run_kubebuilder_125_path_case
+
+[[ -x "$GOLANGCI_CACHE_PATH_SCRIPT" ]] || fail "missing executable $GOLANGCI_CACHE_PATH_SCRIPT"
+[[ -x "$GOLANGCI_LINT_SCRIPT" ]] || fail "missing executable $GOLANGCI_LINT_SCRIPT"
+
+git_test_root="$TEMP_DIR/git-cache-paths"
+main_repo="$git_test_root/repo-\$HOME with space"
+linked_repo="$git_test_root/linked worktree"
+git init -q "$main_repo"
+global_hooks="$git_test_root/global-hooks"
+empty_hooks="$git_test_root/empty-hooks"
+git_config="$git_test_root/global-gitconfig"
+mkdir -p "$global_hooks" "$empty_hooks"
+printf '#!/usr/bin/env bash\nexit 77\n' > "$global_hooks/prepare-commit-msg"
+chmod +x "$global_hooks/prepare-commit-msg"
+git config --file "$git_config" core.hooksPath "$global_hooks"
+mkdir -p "$main_repo/nested module"
+printf 'module example.com/root\n\ngo 1.26.6\n' > "$main_repo/go.mod"
+printf 'module example.com/nested\n\ngo 1.26.6\n' > "$main_repo/nested module/go.mod"
+git -C "$main_repo" add go.mod "nested module/go.mod"
+GIT_CONFIG_GLOBAL="$git_config" git -C "$main_repo" -c core.hooksPath="$empty_hooks" \
+    -c user.name=Test -c user.email=test@example.com -c commit.gpgSign=false \
+    commit -q --no-gpg-sign --no-verify -m initial
+GIT_CONFIG_GLOBAL="$git_config" git -C "$main_repo" -c core.hooksPath="$empty_hooks" \
+    worktree add -q -b linked "$linked_repo"
+for repo in "$main_repo" "$linked_repo"; do
+    mkdir "$repo/hack"
+    cp "$GOLANGCI_CACHE_PATH_SCRIPT" "$GOLANGCI_LINT_SCRIPT" "$repo/hack/"
+done
+mkdir "$git_test_root/bin"
+cat > "$git_test_root/bin/golangci-lint-custom" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+{
+    printf 'cache=%s\n' "$GOLANGCI_LINT_CACHE"
+    printf 'pwd=%s\n' "$PWD"
+    printf 'args='
+    printf '%s ' "$@"
+    printf '\n'
+} >> "$LINT_RECORD"
+exit "${LINT_EXIT:-0}"
+EOF
+chmod +x "$git_test_root/bin/golangci-lint-custom"
+
+run_fake_linter() {
+    local repo="$1"
+    local record="$2"
+    local expected_cache="$3"
+    : > "$record"
+    GOLANGCI_LINT_CACHE=/tmp/ambient-shared-cache LINT_RECORD="$record" \
+        PATH="$git_test_root/bin:$PATH" "$repo/hack/golangci-lint.sh" run --new-from-rev HEAD --fix
+    grep -Fqx "cache=$expected_cache" "$record" || fail "wrapper used the wrong cache for $repo"
+    grep -Fqx "pwd=$repo" "$record" || fail "wrapper did not execute from $repo"
+    grep -Fqx 'args=run --new-from-rev HEAD --fix ' "$record" || fail "wrapper changed linter arguments"
+}
+
+expected_main="$(git -C "$main_repo" rev-parse --absolute-git-dir)/golangci-lint-cache"
+expected_linked="$(git -C "$linked_repo" rev-parse --absolute-git-dir)/golangci-lint-cache"
+[[ "$expected_main" != "$expected_linked" ]] || fail "main and linked worktrees share a linter cache"
+run_fake_linter "$main_repo" "$git_test_root/main-record" "$expected_main"
+run_fake_linter "$linked_repo" "$git_test_root/linked-record" "$expected_linked"
+
+all_modules_record="$git_test_root/all-modules-record"
+: > "$all_modules_record"
+LINT_RECORD="$all_modules_record" PATH="$git_test_root/bin:$PATH" \
+    "$main_repo/hack/golangci-lint.sh" --all-modules run
+[[ "$(grep -Fxc "cache=$expected_main" "$all_modules_record")" == 2 ]] || fail "nested modules did not share the worktree-local cache"
+grep -Fqx "pwd=$main_repo" "$all_modules_record" || fail "root module was not linted from its directory"
+grep -Fqx "pwd=$main_repo/nested module" "$all_modules_record" || fail "nested module was not linted from its directory"
+[[ "$(grep -Fxc 'args=run ' "$all_modules_record")" == 2 ]] || fail "nested module lint arguments changed"
+
+if GOLANGCI_LINT_CACHE=/tmp/ambient-shared-cache LINT_RECORD="$git_test_root/failure-record" LINT_EXIT=73 \
+    PATH="$git_test_root/bin:$PATH" "$main_repo/hack/golangci-lint.sh" run; then
+    fail "wrapper did not propagate linter failure"
+else
+    [[ "$?" == 73 ]] || fail "wrapper changed linter failure code"
+fi
+
+nongit_repo="$git_test_root/not-a-git-repository"
+mkdir -p "$nongit_repo/hack" "$nongit_repo/fallback-cache"
+cp "$GOLANGCI_CACHE_PATH_SCRIPT" "$GOLANGCI_LINT_SCRIPT" "$nongit_repo/hack/"
+rm -f "$git_test_root/nongit-record"
+if GOLANGCI_LINT_CACHE="$nongit_repo/fallback-cache" LINT_RECORD="$git_test_root/nongit-record" \
+    PATH="$git_test_root/bin:$PATH" "$nongit_repo/hack/golangci-lint.sh" run; then
+    fail "wrapper ran outside a Git worktree"
+fi
+[[ ! -e "$git_test_root/nongit-record" ]] || fail "linter executed after cache resolution failed"
+
+grep -Fq './hack/golangci-lint.sh $(GOLANGCI_LINT_CACHE_FLAG) --all-modules run' "$MAKEFILE" || fail "Make lint bypasses the isolated all-module wrapper"
+make -s -C "$REPO_ROOT" --dry-run tidy | grep -Fq 'go mod tidy' || fail "tidy no longer visits non-test Go modules"
+make -s -C "$REPO_ROOT" --dry-run download | grep -Fq 'go mod download' || fail "download no longer visits non-test Go modules"
+actual_repo_cache=$(bash -c 'cd "$1" && ./hack/golangci-cache-path.sh' _ "$REPO_ROOT")
+ambient_record="$git_test_root/make-ambient-record"
+: > "$ambient_record"
+env -u MAKEFLAGS -u MFLAGS -u MAKEOVERRIDES GOLANGCI_LINT_CACHE=/tmp/ambient-shared-cache LINT_RECORD="$ambient_record" \
+    PATH="$git_test_root/bin:$PATH" make -e -s -C "$REPO_ROOT" lint
+[[ "$(<"$ambient_record")" == *"cache=$actual_repo_cache"* ]] || fail "make -e ambient cache bypassed isolation"
+explicit_cache="$git_test_root/explicit-\$HOME cache"
+explicit_record="$git_test_root/make-explicit-record"
+: > "$explicit_record"
+env -u MAKEFLAGS -u MFLAGS -u MAKEOVERRIDES LINT_RECORD="$explicit_record" PATH="$git_test_root/bin:$PATH" \
+    make -s -C "$REPO_ROOT" "GOLANGCI_LINT_CACHE=$explicit_cache" lint
+[[ "$(<"$explicit_record")" == *"cache=$explicit_cache"* ]] || fail "explicit Make cache override was not preserved literally"
+precommit_entry=$(yq eval '.repos[] | select(.repo == "https://github.com/golangci/golangci-lint") | .hooks[] | select(.id == "golangci-lint") | .entry' "$PRECOMMIT_FILE")
+[[ "$precommit_entry" == './hack/golangci-lint.sh run --new-from-rev HEAD --fix' ]] || fail "pre-commit bypasses the isolated linter wrapper"

--- a/hack/toolchain_test.sh
+++ b/hack/toolchain_test.sh
@@ -466,6 +466,9 @@ EOF
 run_setup_envtest_download_case success
 run_setup_envtest_download_case failure
 run_setup_envtest_download_case install-failure
+if grep -Fq 'sudo curl' "$TOOLCHAIN_SCRIPT"; then
+    fail "setup-envtest download must run as the user that owns the temporary file"
+fi
 
 run_kubebuilder_125_path_case() {
     local case_dir="$TEMP_DIR/kubebuilder-125"


### PR DESCRIPTION
(AI-generated)

**Description**

The repository enables golangci-lint formatter fixes, but its default cache is shared across linked Git worktrees. Cached formatter state from one checkout can therefore be replayed while linting another checkout.

This change routes Make and pre-commit linting through one fail-closed wrapper. The wrapper stores cache state under the current worktree's absolute Git directory, preserves explicit Make command-line overrides, ignores ambient and `make -e` cache values, and runs each non-test Go module from its own directory.

This PR is stacked on https://github.com/Azure/karpenter-provider-azure/pull/1873 because it extends the same toolchain regression harness.

**How was this change tested?**

* Added primary/linked worktree, shell-metacharacter path, nested-module, ambient/explicit Make precedence, pre-commit, no-Git failure, linter failure propagation, and hostile Git-hook cases.
* Reproduced sibling worktree source truncation with the shared fix-enabled cache, then verified real linting with the isolated cache preserves sibling hashes.
* `make verify` passed at `eda74aa4` with `0 issues` and a clean worktree.
* `make presubmit` passed 39 suites at `eda74aa4` in `15m41.305127638s` with 68.8% composite coverage.
* CI passed at `eda74aa4`: https://github.com/Azure/karpenter-provider-azure/actions/runs/32992074192.
* All seven Kubernetes-version jobs passed at `eda74aa4`: https://github.com/Azure/karpenter-provider-azure/actions/runs/32992077215.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: #
- [x] No

**Release Note**

```release-note
NONE
```
