### PR TITLE
test: update NVIDIA device plugin to v0.20.0

### DIFF
--- a/examples/workloads/device-plugin.yaml
+++ b/examples/workloads/device-plugin.yaml
@@ -24,7 +24,7 @@ spec:
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       priorityClassName: "system-node-critical"
       containers:
-      - image: nvcr.io/nvidia/k8s-device-plugin:v0.14.1
+      - image: nvcr.io/nvidia/k8s-device-plugin:v0.20.0
         name: nvidia-device-plugin-ctr
         env:
         - name: FAIL_ON_INIT_ERROR

--- a/test/suites/gpu/suite_test.go
+++ b/test/suites/gpu/suite_test.go
@@ -226,7 +226,7 @@ func createNVIDIADevicePluginDaemonSet() *appsv1.DaemonSet {
 					Containers: []corev1.Container{
 						{
 							Name:  "nvidia-device-plugin-ctr",
-							Image: "nvcr.io/nvidia/k8s-device-plugin:v0.14.1",
+							Image: "nvcr.io/nvidia/k8s-device-plugin:v0.20.0",
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: lo.ToPtr(false),
 								Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
## Summary
- update the GPU E2E DaemonSet from NVIDIA device plugin `v0.14.1` to the latest stable release, [`v0.20.0`](https://github.com/NVIDIA/k8s-device-plugin/releases/tag/v0.20.0)
- keep the example device-plugin manifest on the same version

## Why
The GPU E2E still exercises a plugin released in July 2023. Recent A10 failures reach `GetPreferredAllocation` and fail inside that legacy plugin path, so the E2E should run against the current supported implementation instead.

## Validation
- `cd test && go test ./suites/gpu -run '^$'`