### PR TITLE
Raise LocalDNS Preferred Kubernetes threshold to 1.37

### DIFF
--- a/pkg/controllers/nodeclass/status/localdns.go
+++ b/pkg/controllers/nodeclass/status/localdns.go
@@ -45,7 +45,7 @@ var localDNSPreferredVersionThreshold = lo.Must(semver.ParseTolerant(localDNSPre
 const (
 	// localDNSPreferredK8sVersionThreshold is the minimum Kubernetes version
 	// required to auto-enable LocalDNS when Spec.LocalDNS.Mode=Preferred.
-	localDNSPreferredK8sVersionThreshold = "1.99.0"
+	localDNSPreferredK8sVersionThreshold = "1.37.0"
 
 	// konnectivityAgentPolicy{Name,Namespace} identify the AKS-managed
 	// NetworkPolicy that is allow-listed when scanning for conflicting
@@ -74,7 +74,7 @@ const localDNSPreferredRequeueAfter = 5 * time.Minute
 //   - Mode unset/nil  -> Status=Disabled, LocalDNSReady=True.
 //   - Mode=Required   -> Status=Enabled, LocalDNSReady=True.
 //   - Mode=Disabled   -> Status=Disabled, LocalDNSReady=True.
-//   - Mode=Preferred  -> evaluate five gates (k8s>=1.36, !BYO CNI,
+//   - Mode=Preferred  -> evaluate five gates (k8s>=1.37, !BYO CNI,
 //     !ResolvesToUbuntu2004, no conflicting NetworkPolicies, no upstream
 //     node-local-dns DS) and commit Enabled or Disabled. Sticky: once Enabled
 //     under Preferred, stays Enabled while Mode=Preferred (read off

--- a/pkg/controllers/nodeclass/status/localdns_test.go
+++ b/pkg/controllers/nodeclass/status/localdns_test.go
@@ -40,8 +40,8 @@ import (
 )
 
 const (
-	hiK8s = "1.99.0"
-	loK8s = "1.98.0"
+	hiK8s = "1.37.0"
+	loK8s = "1.36.0"
 )
 
 func newDynFake() *dynamicfake.FakeDynamicClient {
@@ -113,6 +113,15 @@ func TestPreferred_K8sBelowThreshold_Disabled(t *testing.T) {
 	r := NewLocalDNSReconciler(fake.NewClientset(), newDynFake(), "", "azure")
 	mustReconcile(t, r, nc)
 	expectState(t, nc, v1beta1.LocalDNSStateDisabled)
+}
+
+func TestPreferred_K8sAtThreshold_Enabled(t *testing.T) {
+	nc := newNC()
+	nc.Spec.LocalDNS = &v1beta1.LocalDNS{Mode: v1beta1.LocalDNSModePreferred}
+	setKVReady(nc, hiK8s)
+	r := NewLocalDNSReconciler(fake.NewClientset(), newDynFake(), "", "azure")
+	mustReconcile(t, r, nc)
+	expectState(t, nc, v1beta1.LocalDNSStateEnabled)
 }
 
 func TestPreferred_BYOCNI_Disabled(t *testing.T) {


### PR DESCRIPTION
## Summary

- Raise the LocalDNS `Preferred` Kubernetes version threshold from `1.99.0` to `1.37.0`.
- Update the status reconciler documentation to reflect the `1.37` gate.
- Update LocalDNS status tests for the `1.36`/`1.37` boundary and add explicit coverage for `1.37.0`.

This aligns the Karpenter provider with the planned AKS Kubernetes 1.37 LocalDNS default re-enablement.

## Test plan

- `git diff --check` passed.
- `go test ./pkg/controllers/nodeclass/status` attempted, but the local environment is missing `/usr/local/kubebuilder/bin/etcd`; envtest failed in `BeforeSuite` before running specs.
