### PR TITLE
fix: use Microsoft Go for FIPS-compliant release builds

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -11,7 +11,7 @@ runs:
       id: setup-go
       with:
         go-version-file: go.mod
-        check-latest: true
+        go-download-base-url: "https://aka.ms/golang/release/latest"
         cache-dependency-path: "**/go.sum"
     # Root path permission workaround for caching https://github.com/actions/cache/issues/845#issuecomment-1252594999
     - run: sudo chown "$USER" /usr/local
@@ -23,7 +23,7 @@ runs:
           /usr/local/kubebuilder/bin
           ~/go/bin
         # Include runner.environment in key because ~/go/bin expands differently on github-hosted vs self-hosted runners
-        key: ${{ runner.os }}-${{ runner.environment }}-${{ inputs.k8sVersion }}-go-${{ steps.setup-go.outputs.go-version }}-toolchain-cache-${{ hashFiles('hack/toolchain.sh') }}
+        key: ${{ runner.os }}-${{ runner.environment }}-${{ inputs.k8sVersion }}-go-${{ steps.setup-go.outputs.go-version }}-microsoft-toolchain-cache-${{ hashFiles('hack/toolchain.sh') }}
     - if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
       shell: bash
       env:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -45,6 +45,8 @@ jobs:
           packages.microsoft.com:443
           esm.ubuntu.com:443
           aka.ms:443
+          download.visualstudio.microsoft.com:443
+          download.microsoft.com:443
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - uses: ./.github/actions/install-deps

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -44,6 +44,7 @@ jobs:
           azure.archive.ubuntu.com:80
           packages.microsoft.com:443
           esm.ubuntu.com:443
+          aka.ms:443
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - uses: ./.github/actions/install-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           azure.archive.ubuntu.com:80
           packages.microsoft.com:443
           esm.ubuntu.com:443
+          aka.ms:443
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - uses: ./.github/actions/install-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
           packages.microsoft.com:443
           esm.ubuntu.com:443
           aka.ms:443
+          download.visualstudio.microsoft.com:443
+          download.microsoft.com:443
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - uses: ./.github/actions/install-deps

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,6 +50,8 @@ jobs:
             packages.microsoft.com:443
             esm.ubuntu.com:443
             aka.ms:443
+            download.visualstudio.microsoft.com:443
+            download.microsoft.com:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/install-deps

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,6 +49,7 @@ jobs:
             azure.archive.ubuntu.com:80
             packages.microsoft.com:443
             esm.ubuntu.com:443
+            aka.ms:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/install-deps

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -34,6 +34,7 @@ jobs:
             azure.archive.ubuntu.com:80
             packages.microsoft.com:443
             esm.ubuntu.com:443
+            aka.ms:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/install-deps

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -35,6 +35,8 @@ jobs:
             packages.microsoft.com:443
             esm.ubuntu.com:443
             aka.ms:443
+            download.visualstudio.microsoft.com:443
+            download.microsoft.com:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/install-deps

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -22,6 +22,8 @@ jobs:
             azure.archive.ubuntu.com:80
             esm.ubuntu.com:443
             aka.ms:443
+            download.visualstudio.microsoft.com:443
+            download.microsoft.com:443
             github.com:443
             packages.microsoft.com:443
             proxy.golang.org:443

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -21,6 +21,7 @@ jobs:
             aquasecurity.github.io:443
             azure.archive.ubuntu.com:80
             esm.ubuntu.com:443
+            aka.ms:443
             github.com:443
             packages.microsoft.com:443
             proxy.golang.org:443

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:178f25fadf466549d31e234b3091bf815161159f2f2bc98720bbf39f7368aff4
+defaultBaseImage: mcr.microsoft.com/azurelinux/distroless/base:3.0@sha256:1d06d2f92799daf3da2c81b23ea24057fd05bd11f77cd4dbe9af91e4716c2487
 defaultPlatforms:
   - linux/arm64
   - linux/amd64


### PR DESCRIPTION
**Description**

Configure the shared dependency setup action to download the Go toolchain from the Microsoft Go distribution while continuing to resolve the version from go.mod. This ensures release builds use Microsoft Go systemcrypto/OpenSSL on Linux. Also update the toolchain cache namespace to avoid collisions with caches produced by the standard Go distribution.

The Microsoft shortlink redirects to download.visualstudio.microsoft.com (with download.microsoft.com also allowed), so all blocked HardenRunner workflows using the shared installer permit the redirect targets.

Update the pinned Azure Linux 3 distroless base image digest to the newer 3.0.20260809 release.

**How was this change tested?**

* actionlint on the edited workflows
* git diff --check
* Verified the Microsoft Go redirect chain and Azure Linux base image manifest digest.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
action required. If no release note is required, write NONE. -->

```release-note
NONE
```