### PR TITLE
feat: honor sku retirement ahead of time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0
 	github.com/Azure/go-autorest/autorest v0.11.30
-	github.com/Azure/skewer v0.0.24
+	github.com/Azure/skewer v0.0.28
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/alecthomas/kong v1.16.0
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/Azure/msi-dataplane v0.4.3 h1:dWPWzY4b54tLIR9T1Q014Xxd/1DxOsMIp6EjRFAJlQY=
 github.com/Azure/msi-dataplane v0.4.3/go.mod h1:yAfxdJyvcnvSDfSyOFV9qm4fReEQDl+nZLGeH2ZWSmw=
-github.com/Azure/skewer v0.0.24 h1:6u+/o+LO6ufDnpk08KruOAeUDWm62Fi1DcbAY8EFdPA=
-github.com/Azure/skewer v0.0.24/go.mod h1:KwKqaVxdP/XSYDvWiIxbvBRDcm+cQ8lRAwKRPNGsxMg=
+github.com/Azure/skewer v0.0.28 h1:tzgIuk6fvNDkl5UqGi2y7Hc86jCf8QrYUnpUxqvrfYs=
+github.com/Azure/skewer v0.0.28/go.mod h1:KwKqaVxdP/XSYDvWiIxbvBRDcm+cQ8lRAwKRPNGsxMg=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.8.0 h1:Nljr4q1GRA/5vCrMONS+g4u4LRHNgOXVSh3O43J2CnI=

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -53,7 +53,8 @@ import (
 )
 
 const (
-	InstanceTypesCacheTTL = 23 * time.Hour
+	InstanceTypesCacheTTL      = 23 * time.Hour
+	skuRetirementHorizonMonths = 6
 )
 
 // instanceTypeParameters contains the resolved set of AKSNodeClass fields that affect
@@ -460,8 +461,13 @@ func (p *DefaultProvider) UpdateInstanceTypes(ctx context.Context) error {
 
 	skus := cache.List(ctx, skewer.ResourceTypeFilter("virtualMachines"))
 	log.FromContext(ctx).V(1).Info("discovered SKUs", "skuCount", len(skus))
+	now := time.Now().UTC()
+	retirementCutoff := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, skuRetirementHorizonMonths, 0)
 	for i := range skus {
 		if IsRestrictedSKU(skus[i].GetName()) {
+			continue
+		}
+		if isRetired(ctx, &skus[i], retirementCutoff) {
 			continue
 		}
 		vmsize, err := skus[i].GetVMSize()
@@ -488,6 +494,17 @@ func (p *DefaultProvider) UpdateInstanceTypes(ctx context.Context) error {
 	}
 	p.instanceTypesInfo = instanceTypes
 	return nil
+}
+
+// isRetired returns true if the specified SKU has a retirement date that is before the retirement cutoff.
+func isRetired(ctx context.Context, sku *skewer.SKU, retirementCutoff time.Time) bool {
+	retirementDate, err := sku.GetRetirementDate()
+	if err != nil {
+		log.FromContext(ctx).Error(err, "parsing SKU retirement date", "vmSize", sku.GetSize())
+		// We don't understand the format of the retirement entry, so assume it is not retied and don't filter it for safety
+		return false
+	}
+	return retirementDate != nil && retirementDate.Before(retirementCutoff)
 }
 
 // logUnknownSKUFamilies logs VM SKU families that were discovered from the Azure API

--- a/pkg/providers/instancetype/instancetypes.go
+++ b/pkg/providers/instancetype/instancetypes.go
@@ -501,7 +501,7 @@ func isRetired(ctx context.Context, sku *skewer.SKU, retirementCutoff time.Time)
 	retirementDate, err := sku.GetRetirementDate()
 	if err != nil {
 		log.FromContext(ctx).Error(err, "parsing SKU retirement date", "vmSize", sku.GetSize())
-		// We don't understand the format of the retirement entry, so assume it is not retied and don't filter it for safety
+		// We don't understand the format of the retirement entry, so assume it is not retired and don't filter it for safety
 		return false
 	}
 	return retirementDate != nil && retirementDate.Before(retirementCutoff)

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -2398,10 +2398,10 @@ var _ = Describe("InstanceType Provider", func() {
 					}
 				},
 				Entry("retains a SKU without a retirement date", nil, true),
-			Entry("retains a SKU retiring in more than six months", lo.ToPtr(time.Now().UTC().AddDate(0, 7, 0).Format("01/02/2006")), true),
-			Entry("retains a SKU retiring in exactly six months", lo.ToPtr(time.Now().UTC().AddDate(0, 6, 0).Format("01/02/2006")), true),
-			Entry("filters a SKU retiring with less than six months", lo.ToPtr(time.Now().UTC().AddDate(0, 5, 0).Format("01/02/2006")), false),
-			Entry("filters an already retired SKU", lo.ToPtr(time.Now().UTC().AddDate(0, -1, 0).Format("01/02/2006")), false),
+				Entry("retains a SKU retiring in more than six months", lo.ToPtr(time.Now().UTC().AddDate(0, 7, 0).Format("01/02/2006")), true),
+				Entry("retains a SKU retiring in exactly six months", lo.ToPtr(time.Now().UTC().AddDate(0, 6, 0).Format("01/02/2006")), true),
+				Entry("filters a SKU retiring with less than six months", lo.ToPtr(time.Now().UTC().AddDate(0, 5, 0).Format("01/02/2006")), false),
+				Entry("filters an already retired SKU", lo.ToPtr(time.Now().UTC().AddDate(0, -1, 0).Format("01/02/2006")), false),
 				Entry("retains a SKU with an invalid retirement date", lo.ToPtr("not-a-date"), true),
 			)
 		})

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -2398,10 +2398,10 @@ var _ = Describe("InstanceType Provider", func() {
 					}
 				},
 				Entry("retains a SKU without a retirement date", nil, true),
-				Entry("retains a SKU retiring in more than six months", lo.ToPtr(time.Now().AddDate(0, 7, 0).Format("01/02/2006")), true),
-				Entry("retains a SKU retiring in exactly six months", lo.ToPtr(time.Now().UTC().AddDate(0, 6, 0).Format("01/02/2006")), true),
-				Entry("filters a SKU retiring with less than six months", lo.ToPtr(time.Now().AddDate(0, 5, 0).Format("01/02/2006")), false),
-				Entry("filters an already retired SKU", lo.ToPtr(time.Now().AddDate(0, -1, 0).Format("01/02/2006")), false),
+			Entry("retains a SKU retiring in more than six months", lo.ToPtr(time.Now().UTC().AddDate(0, 7, 0).Format("01/02/2006")), true),
+			Entry("retains a SKU retiring in exactly six months", lo.ToPtr(time.Now().UTC().AddDate(0, 6, 0).Format("01/02/2006")), true),
+			Entry("filters a SKU retiring with less than six months", lo.ToPtr(time.Now().UTC().AddDate(0, 5, 0).Format("01/02/2006")), false),
+			Entry("filters an already retired SKU", lo.ToPtr(time.Now().UTC().AddDate(0, -1, 0).Format("01/02/2006")), false),
 				Entry("retains a SKU with an invalid retirement date", lo.ToPtr("not-a-date"), true),
 			)
 		})

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -2364,6 +2364,46 @@ var _ = Describe("InstanceType Provider", func() {
 			It("should not include confidential SKUs", func() {
 				Expect(instanceTypes).ShouldNot(ContainElement(WithTransform(getName, Equal("Standard_DC8s_v3"))))
 			})
+
+			DescribeTable("filtering SKUs by retirement date",
+				func(retirementDate *string, expectedToBeAvailable bool) {
+					capabilities := []compute.ResourceSkuCapabilities{
+						{Name: lo.ToPtr("vCPUs"), Value: lo.ToPtr("2")},
+						{Name: lo.ToPtr("MemoryGB"), Value: lo.ToPtr("8")},
+						{Name: lo.ToPtr("CpuArchitectureType"), Value: lo.ToPtr("x64")},
+					}
+					if retirementDate != nil {
+						capabilities = append(
+							capabilities,
+							compute.ResourceSkuCapabilities{
+								Name:  lo.ToPtr(skewer.RetirementDateUTC),
+								Value: retirementDate,
+							})
+					}
+					azureEnv.SKUsAPI.AdditionalSKUs = append(azureEnv.SKUsAPI.AdditionalSKUs, compute.ResourceSku{
+						Name:         lo.ToPtr("Standard_TestRetirement_v1"),
+						Size:         lo.ToPtr("D2s_v3"),
+						Family:       lo.ToPtr("standardTestRetirementFamily"),
+						ResourceType: lo.ToPtr("virtualMachines"),
+						Locations:    &[]string{fake.Region},
+						Capabilities: &capabilities,
+					})
+
+					Expect(azureEnv.InstanceTypesProvider.UpdateInstanceTypes(ctx)).To(Succeed())
+					_, err := azureEnv.InstanceTypesProvider.Get(ctx, "Standard_TestRetirement_v1")
+					if expectedToBeAvailable {
+						Expect(err).NotTo(HaveOccurred())
+					} else {
+						Expect(err).To(HaveOccurred())
+					}
+				},
+				Entry("retains a SKU without a retirement date", nil, true),
+				Entry("retains a SKU retiring in more than six months", lo.ToPtr(time.Now().AddDate(0, 7, 0).Format("01/02/2006")), true),
+				Entry("retains a SKU retiring in exactly six months", lo.ToPtr(time.Now().UTC().AddDate(0, 6, 0).Format("01/02/2006")), true),
+				Entry("filters a SKU retiring with less than six months", lo.ToPtr(time.Now().AddDate(0, 5, 0).Format("01/02/2006")), false),
+				Entry("filters an already retired SKU", lo.ToPtr(time.Now().AddDate(0, -1, 0).Format("01/02/2006")), false),
+				Entry("retains a SKU with an invalid retirement date", lo.ToPtr("not-a-date"), true),
+			)
 		})
 		Context("Filtering GPU SKUs AzureLinux", func() {
 			var instanceTypes corecloudprovider.InstanceTypes


### PR DESCRIPTION
If a SKU is retired, stop provisoning it before the "drop dead" date of actual retirement.

Fixes #1890 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
