### PR TITLE
chore: osDiskType field for v1alpha2

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.azure.com_aksnodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.azure.com_aksnodeclasses.yaml
@@ -744,8 +744,9 @@ spec:
                 type: integer
               osDiskType:
                 description: |-
-                  osDiskType is retained for server-side apply compatibility with objects whose managed fields reference v1alpha2.
-                  v1alpha2 remains unserved; use v1beta1 to configure the OS disk type.
+                  osDiskType is the type of disk to use for the OS.
+                  If unspecified, an ephemeral OS disk is used when the VM size supports an ephemeral OS disk
+                  of at least osDiskSizeGB, falling back to a managed disk otherwise. Managed always uses a managed disk.
                 enum:
                 - Managed
                 type: string

--- a/charts/karpenter-crd/templates/karpenter.azure.com_aksnodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.azure.com_aksnodeclasses.yaml
@@ -742,6 +742,13 @@ spec:
                 maximum: 2048
                 minimum: 30
                 type: integer
+              osDiskType:
+                description: |-
+                  osDiskType is retained for server-side apply compatibility with objects whose managed fields reference v1alpha2.
+                  v1alpha2 remains unserved; use v1beta1 to configure the OS disk type.
+                enum:
+                - Managed
+                type: string
               security:
                 description: security is a collection of security related karpenter
                   fields

--- a/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
@@ -744,8 +744,9 @@ spec:
                 type: integer
               osDiskType:
                 description: |-
-                  osDiskType is retained for server-side apply compatibility with objects whose managed fields reference v1alpha2.
-                  v1alpha2 remains unserved; use v1beta1 to configure the OS disk type.
+                  osDiskType is the type of disk to use for the OS.
+                  If unspecified, an ephemeral OS disk is used when the VM size supports an ephemeral OS disk
+                  of at least osDiskSizeGB, falling back to a managed disk otherwise. Managed always uses a managed disk.
                 enum:
                 - Managed
                 type: string

--- a/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.azure.com_aksnodeclasses.yaml
@@ -742,6 +742,13 @@ spec:
                 maximum: 2048
                 minimum: 30
                 type: integer
+              osDiskType:
+                description: |-
+                  osDiskType is retained for server-side apply compatibility with objects whose managed fields reference v1alpha2.
+                  v1alpha2 remains unserved; use v1beta1 to configure the OS disk type.
+                enum:
+                - Managed
+                type: string
               security:
                 description: security is a collection of security related karpenter
                   fields

--- a/pkg/apis/v1alpha2/aksnodeclass.go
+++ b/pkg/apis/v1alpha2/aksnodeclass.go
@@ -32,6 +32,13 @@ var (
 	FIPSModeDisabled = FIPSMode("Disabled")
 )
 
+// OSDiskType is retained for compatibility with historical v1alpha2 managed fields.
+type OSDiskType string
+
+var (
+	OSDiskTypeManaged = OSDiskType("Managed")
+)
+
 // +kubebuilder:validation:Enum:={OCIContainer,KataVmIsolation}
 type WorkloadRuntime string
 
@@ -63,6 +70,11 @@ type AKSNodeClassSpec struct {
 	// +kubebuilder:validation:Pattern=`(?i)^\/subscriptions\/[^\/]+\/resourceGroups\/[a-zA-Z0-9_\-().]{0,89}[a-zA-Z0-9_\-()]\/providers\/Microsoft\.Network\/virtualNetworks\/[^\/]+\/subnets\/[^\/]+$`
 	// +optional
 	VNETSubnetID *string `json:"vnetSubnetID,omitempty"`
+	// osDiskType is retained for server-side apply compatibility with objects whose managed fields reference v1alpha2.
+	// v1alpha2 remains unserved; use v1beta1 to configure the OS disk type.
+	// +kubebuilder:validation:Enum:={Managed}
+	// +optional
+	OSDiskType *OSDiskType `json:"osDiskType,omitempty"`
 	// osDiskSizeGB is the size of the OS disk in GB.
 	// +default=128
 	// +kubebuilder:validation:Minimum=30

--- a/pkg/apis/v1alpha2/aksnodeclass.go
+++ b/pkg/apis/v1alpha2/aksnodeclass.go
@@ -32,7 +32,6 @@ var (
 	FIPSModeDisabled = FIPSMode("Disabled")
 )
 
-// OSDiskType is retained for compatibility with historical v1alpha2 managed fields.
 type OSDiskType string
 
 var (
@@ -70,8 +69,9 @@ type AKSNodeClassSpec struct {
 	// +kubebuilder:validation:Pattern=`(?i)^\/subscriptions\/[^\/]+\/resourceGroups\/[a-zA-Z0-9_\-().]{0,89}[a-zA-Z0-9_\-()]\/providers\/Microsoft\.Network\/virtualNetworks\/[^\/]+\/subnets\/[^\/]+$`
 	// +optional
 	VNETSubnetID *string `json:"vnetSubnetID,omitempty"`
-	// osDiskType is retained for server-side apply compatibility with objects whose managed fields reference v1alpha2.
-	// v1alpha2 remains unserved; use v1beta1 to configure the OS disk type.
+	// osDiskType is the type of disk to use for the OS.
+	// If unspecified, an ephemeral OS disk is used when the VM size supports an ephemeral OS disk
+	// of at least osDiskSizeGB, falling back to a managed disk otherwise. Managed always uses a managed disk.
 	// +kubebuilder:validation:Enum:={Managed}
 	// +optional
 	OSDiskType *OSDiskType `json:"osDiskType,omitempty"`

--- a/pkg/apis/v1alpha2/aksnodeclass_hash_test.go
+++ b/pkg/apis/v1alpha2/aksnodeclass_hash_test.go
@@ -70,6 +70,7 @@ var _ = Describe("Hash", func() {
 
 		// Static fields, expect changed hash from base
 		Entry("VNETSubnetID", "13971920214979852468", v1alpha2.AKSNodeClass{Spec: v1alpha2.AKSNodeClassSpec{VNETSubnetID: lo.ToPtr("subnet-id-2")}}),
+		Entry("OSDiskType", "10944184826674581697", v1alpha2.AKSNodeClass{Spec: v1alpha2.AKSNodeClassSpec{OSDiskType: lo.ToPtr(v1alpha2.OSDiskTypeManaged)}}),
 		Entry("OSDiskSizeGB", "7816855636861645563", v1alpha2.AKSNodeClass{Spec: v1alpha2.AKSNodeClassSpec{OSDiskSizeGB: lo.ToPtr(int32(40))}}),
 		Entry("ImageFamily", "15616969746300892810", v1alpha2.AKSNodeClass{Spec: v1alpha2.AKSNodeClassSpec{ImageFamily: lo.ToPtr("AzureLinux")}}),
 		Entry("Kubelet", "33638514539106194", v1alpha2.AKSNodeClass{Spec: v1alpha2.AKSNodeClassSpec{Kubelet: &v1alpha2.KubeletConfiguration{CPUManagerPolicy: lo.ToPtr("none")}}}),
@@ -92,6 +93,7 @@ var _ = Describe("Hash", func() {
 		Expect(hash).ToNot(Equal(updatedHash))
 	},
 		Entry("VNETSubnetID", v1alpha2.AKSNodeClass{Spec: v1alpha2.AKSNodeClassSpec{VNETSubnetID: lo.ToPtr("subnet-id-2")}}),
+		Entry("OSDiskType", v1alpha2.AKSNodeClass{Spec: v1alpha2.AKSNodeClassSpec{OSDiskType: lo.ToPtr(v1alpha2.OSDiskTypeManaged)}}),
 		Entry("OSDiskSizeGB", v1alpha2.AKSNodeClass{Spec: v1alpha2.AKSNodeClassSpec{OSDiskSizeGB: lo.ToPtr(int32(40))}}),
 		Entry("ImageFamily", v1alpha2.AKSNodeClass{Spec: v1alpha2.AKSNodeClassSpec{ImageFamily: lo.ToPtr("AzureLinux")}}),
 		Entry("Kubelet", v1alpha2.AKSNodeClass{Spec: v1alpha2.AKSNodeClassSpec{Kubelet: &v1alpha2.KubeletConfiguration{CPUManagerPolicy: lo.ToPtr("none")}}}),

--- a/pkg/apis/v1alpha2/crd_validation_cel_test.go
+++ b/pkg/apis/v1alpha2/crd_validation_cel_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/test"
@@ -133,6 +133,41 @@ var _ = Describe("CEL/Validation", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
 				Spec: v1alpha2.AKSNodeClassSpec{
 					ImageFamily: &invalidImageFamily,
+				},
+			}
+			Expect(env.Client.Create(ctx, nodeClass)).ToNot(Succeed())
+		})
+	})
+
+	Context("OSDiskType", func() {
+		It("should accept Managed OSDiskType", func() {
+			nodeClass := &v1alpha2.AKSNodeClass{
+				ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+				Spec: v1alpha2.AKSNodeClassSpec{
+					OSDiskType: lo.ToPtr(v1alpha2.OSDiskTypeManaged),
+				},
+			}
+			Expect(env.Client.Create(ctx, nodeClass)).To(Succeed())
+		})
+
+		It("should accept omitted OSDiskType", func() {
+			nodeClass := &v1alpha2.AKSNodeClass{
+				ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+				Spec:       v1alpha2.AKSNodeClassSpec{
+					// OSDiskType is nil - should be accepted
+				},
+			}
+			Expect(env.Client.Create(ctx, nodeClass)).To(Succeed())
+			Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(nodeClass), nodeClass)).To(Succeed())
+			Expect(nodeClass.Spec.OSDiskType).To(BeNil())
+		})
+
+		It("should reject invalid OSDiskType", func() {
+			invalidOSDiskType := v1alpha2.OSDiskType("asdf")
+			nodeClass := &v1alpha2.AKSNodeClass{
+				ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+				Spec: v1alpha2.AKSNodeClassSpec{
+					OSDiskType: &invalidOSDiskType,
 				},
 			}
 			Expect(env.Client.Create(ctx, nodeClass)).ToNot(Succeed())
@@ -1178,42 +1213,5 @@ var _ = Describe("CEL/Validation", func() {
 			}
 			Expect(env.Client.Create(ctx, nodeClass)).To(Succeed())
 		})
-	})
-})
-
-var _ = Describe("Version Compatibility", func() {
-	It("should allow v1beta1 osDiskType apply with v1alpha2 managed fields", func() {
-		name := strings.ToLower(randomdata.SillyName())
-		alphaVersion := v1alpha2.SchemeGroupVersion.String()
-		betaVersion := v1beta1.SchemeGroupVersion.String()
-		alphaResource := azureEnv.DynamicInterface.Resource(v1alpha2.SchemeGroupVersion.WithResource("aksnodeclasses"))
-		betaResource := azureEnv.DynamicInterface.Resource(v1beta1.SchemeGroupVersion.WithResource("aksnodeclasses"))
-
-		alphaNodeClass := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": alphaVersion,
-			"kind":       "AKSNodeClass",
-			"metadata": map[string]any{
-				"name": name,
-			},
-			"spec": map[string]any{
-				"osDiskSizeGB": int64(64),
-			},
-		}}
-		created, err := alphaResource.Apply(ctx, name, alphaNodeClass, metav1.ApplyOptions{FieldManager: "v1alpha2-manager"})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(lo.ContainsBy(created.GetManagedFields(), func(entry metav1.ManagedFieldsEntry) bool {
-			return entry.APIVersion == alphaVersion
-		})).To(BeTrue())
-
-		betaNodeClass := alphaNodeClass.DeepCopy()
-		betaNodeClass.SetAPIVersion(betaVersion)
-		Expect(unstructured.SetNestedField(betaNodeClass.Object, "Managed", "spec", "osDiskType")).To(Succeed())
-		applied, err := betaResource.Apply(ctx, name, betaNodeClass, metav1.ApplyOptions{FieldManager: "v1beta1-manager"})
-		Expect(err).ToNot(HaveOccurred())
-
-		osDiskType, found, err := unstructured.NestedString(applied.Object, "spec", "osDiskType")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(found).To(BeTrue())
-		Expect(osDiskType).To(Equal("Managed"))
 	})
 })

--- a/pkg/apis/v1alpha2/crd_validation_cel_test.go
+++ b/pkg/apis/v1alpha2/crd_validation_cel_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -1177,5 +1178,42 @@ var _ = Describe("CEL/Validation", func() {
 			}
 			Expect(env.Client.Create(ctx, nodeClass)).To(Succeed())
 		})
+	})
+})
+
+var _ = Describe("Version Compatibility", func() {
+	It("should allow v1beta1 osDiskType apply with v1alpha2 managed fields", func() {
+		name := strings.ToLower(randomdata.SillyName())
+		alphaVersion := v1alpha2.SchemeGroupVersion.String()
+		betaVersion := v1beta1.SchemeGroupVersion.String()
+		alphaResource := azureEnv.DynamicInterface.Resource(v1alpha2.SchemeGroupVersion.WithResource("aksnodeclasses"))
+		betaResource := azureEnv.DynamicInterface.Resource(v1beta1.SchemeGroupVersion.WithResource("aksnodeclasses"))
+
+		alphaNodeClass := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": alphaVersion,
+			"kind":       "AKSNodeClass",
+			"metadata": map[string]any{
+				"name": name,
+			},
+			"spec": map[string]any{
+				"osDiskSizeGB": int64(64),
+			},
+		}}
+		created, err := alphaResource.Apply(ctx, name, alphaNodeClass, metav1.ApplyOptions{FieldManager: "v1alpha2-manager"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(lo.ContainsBy(created.GetManagedFields(), func(entry metav1.ManagedFieldsEntry) bool {
+			return entry.APIVersion == alphaVersion
+		})).To(BeTrue())
+
+		betaNodeClass := alphaNodeClass.DeepCopy()
+		betaNodeClass.SetAPIVersion(betaVersion)
+		Expect(unstructured.SetNestedField(betaNodeClass.Object, "Managed", "spec", "osDiskType")).To(Succeed())
+		applied, err := betaResource.Apply(ctx, name, betaNodeClass, metav1.ApplyOptions{FieldManager: "v1beta1-manager"})
+		Expect(err).ToNot(HaveOccurred())
+
+		osDiskType, found, err := unstructured.NestedString(applied.Object, "spec", "osDiskType")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(osDiskType).To(Equal("Managed"))
 	})
 })

--- a/pkg/apis/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/v1alpha2/zz_generated.deepcopy.go
@@ -93,6 +93,11 @@ func (in *AKSNodeClassSpec) DeepCopyInto(out *AKSNodeClassSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.OSDiskType != nil {
+		in, out := &in.OSDiskType, &out.OSDiskType
+		*out = new(OSDiskType)
+		**out = **in
+	}
 	if in.OSDiskSizeGB != nil {
 		in, out := &in.OSDiskSizeGB, &out.OSDiskSizeGB
 		*out = new(int32)


### PR DESCRIPTION
**Description**

`osDiskType` is declared only in the `v1beta1` AKSNodeClass schema. Kubernetes server-side apply still consults the retained `v1alpha2` schema when an existing object has managed fields recorded in that version, causing the apply to fail because `v1alpha2` does not recognize the field.

This change copies the existing `v1beta1` `osDiskType` definition into the retained `v1alpha2` schema for managed-fields compatibility. The type, enum, optional field, generated OpenAPI schema, validation tests, and hash tests remain in strict parity. `v1alpha2` remains deprecated and unserved.

**How was this change tested?**

* `make verify`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened
- [x] No

**Release Note**

```release-note
Fix server-side apply of AKSNodeClass `osDiskType` when objects retain `v1alpha2` managed fields.
```
